### PR TITLE
Remove terraform

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,16 +16,7 @@
   "workspaceFolder": "/workspace",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
-  "features": {
-    "ghcr.io/devcontainers/features/terraform:1": {
-      "installSentinel": true,
-      "installTFsec": true,
-      "installTerraformDocs": true,
-      "version": "1.5.4",
-      "tflint": "0.47.0",
-      "terragrunt": "0.48.6"
-    }
-  },
+  "features": {},
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],


### PR DESCRIPTION
Given that this repo may become public, we're moving all infrastructure work into it's own repo.  This removes all terraform plugins and extensions.