### PR TITLE
Move betterangels-backend image to shared services

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ nx test betterangels
 - Production - x.y.z
 - Development - x.y.z-beta.t
 
-
 ## Backend Development
 
 The betterangels_backend is built on Django, a high-level Python web framework. It also utilizes Celery for distributed task processing, enabling the scheduling and execution of tasks.
@@ -87,7 +86,7 @@ Note: While workers can run independently of the scheduler, the scheduler requir
 
 Django provides a flexible way to handle email backends. By default, our configuration uses the file-based email backend to capture sent emails as files. This is helpful for local development and testing without actually sending real emails.
 
-### Using the File-based Email Backend
+#### Using the File-based Email Backend
 
 Configure the .env File: Set the email backend in your .env file to use the file-based backend:
 

--- a/apps/betterangels-backend/project.json
+++ b/apps/betterangels-backend/project.json
@@ -30,7 +30,7 @@
         "platforms": ["linux/amd64"],
         "metadata": {
           "images": [
-            "784154756963.dkr.ecr.us-west-2.amazonaws.com/betterangels-backend"
+            "174477281453.dkr.ecr.us-west-2.amazonaws.com/betterangels-backend"
           ],
           "tags": ["type=sha"]
         }


### PR DESCRIPTION
This is a required step as I am setting up CodePipeline/CodeDeploy.  We want to centralize all our images into a single account and have the Pipelines reside in that account.  This allows us to push a single image and then promote it between environments.

This PR also quickly updates a type in our readme

Monday Ticket
[5402382458](https://betterangels-team.monday.com/boards/4952608126/pulses/5402382458)