### PR TITLE
Set Concurrency Group to deploy-main

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -157,5 +157,5 @@ jobs:
           DOCKER_TAG: ${{ needs.build.outputs.docker_tag }}
 
     concurrency:
-      group: deploy-main-${{ github.ref }}
+      group: deploy-main
       cancel-in-progress: false


### PR DESCRIPTION
The previous group wouldn't prevent parallel deploys.