### PR TITLE
Add Turnstyle to serialize builds

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Turnstyle
         uses: softprops/turnstyle@v1
-        # if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -127,6 +127,3 @@ jobs:
         run: |
           docker-compose down
           sudo chown -R 1001:1001 .git
-
-    outputs:
-      docker_tag: ${{ env.DOCKER_TAG }}


### PR DESCRIPTION
GitHub Actions is an event-oriented system. Your workflows run in response to events and are triggered independently and without coordination. In a shared repository, if two or more people merge pull requests, each will trigger workflows without regard to one another.

This can be problematic for workflows used as part of a continuous deployment process. You might want to let an in-flight deployment complete before progressing further with the next workflow. This is the usecase turnstyle action targets.