### PR TITLE
Fix Branch Names Creating Noncomforming Docker Tags

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -36,14 +36,20 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          BRANCH_NAME=${{ github.head_ref || github.ref_name }}
+          RAW_BRANCH_NAME=${{ github.head_ref || github.ref_name }}
           SHORT_SHA=$(echo $GITHUB_SHA | cut -c 1-7)
+
+          # Sanitize branch name by replacing '/' with '-' and removing any other invalid characters
+          BRANCH_NAME=$(echo $RAW_BRANCH_NAME | sed 's|/|-|g' | sed 's|[^a-zA-Z0-9_.-]||g')
+
           if [ "$BRANCH_NAME" == "main" ]; then
             IMAGE_TAG_PREFIX="main"
           else
             IMAGE_TAG_PREFIX="dev-$BRANCH_NAME"
           fi
+
           DOCKER_TAG="$IMAGE_TAG_PREFIX-$SHORT_SHA"
+
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           echo "IMAGE_TAG_PREFIX=$IMAGE_TAG_PREFIX" >> $GITHUB_ENV


### PR DESCRIPTION
We had a bug in CI where if a branch was named `feat/blah` this would result in a docker tag which is non conforming.  This add a step to strip out nonconforming characters.