### PR TITLE
Reexpose by default Django Server port in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       - IS_LOCAL_DEV=True
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - '8000:8000'
   db:
     image: postgis/postgis:15-3.4
     ports:


### PR DESCRIPTION
This port was removed a PR or two ago.  iOS and Android are not able to access the Django development server unless this is set.