### PR TITLE
Pin NX VSCode Extension to 18.10.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,7 +41,7 @@
         "ms-python.black-formatter",
         "ms-python.isort",
         "ms-python.python",
-        "nrwl.angular-console",
+        "nrwl.angular-console@18.10.1",
         "tamasfe.even-better-toml",
         "wix.vscode-import-cost",
         "ms-python.flake8",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.fixAll.eslint": true,
-    "source.organizeImports": true
+    "source.fixAll": "explicit",
+    "source.fixAll.eslint": "explicit",
+    "source.organizeImports": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,


### PR DESCRIPTION
> Error "Remote Extension host terminated unexpectedly 3 times within the last 5 minutes"

I spent all of 1/11/24 trying to understand the above error.  This error broke ALL extensions and remote container development.  According to this [comment](
https://github.com/microsoft/vscode-remote-release/issues/8967#issuecomment-1795001253) the culprit was the NX VSCode extension 😢 .  This pins it to a 18.10.1 which does not break VSCode. 

Also updates `settings.json` because VSCode [keeps trying to automatically update it](https://stackoverflow.com/a/77637765).