### PR TITLE
Pin EAS CLI version on EAS Update cleanup job to 5.0.0

### DIFF
--- a/.github/workflows/eas-branch-cleanup.yml
+++ b/.github/workflows/eas-branch-cleanup.yml
@@ -71,7 +71,7 @@ jobs:
       - name: 🔧 Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          eas-version: latest
+          eas-version: 5.0.0
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies


### PR DESCRIPTION
Forgot to pin the eas cli version in the cleanup script.