### PR TITLE
Replace postgis/postgis image with cross platform capable nickblah/postgis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - '8000:8000'
   db:
-    image: postgis/postgis:15-3.4
+    image: nickblah/postgis:15-bullseye-postgis-3.4
     ports:
       - '5432:5432'
     environment:


### PR DESCRIPTION
The [postgis/postgis](https://registry.hub.docker.com/r/postgis/postgis/) docker image does not support ARM processors (Apple Silicon Macs) and will run the AMD64 image in emulation mode (which is slow).  This moves our postgres image to [nickblah/postgis](https://hub.docker.com/r/nickblah/postgis) which supports x86 & arm.

![image](https://github.com/BetterAngelsLA/monorepo/assets/407393/501d7975-23f4-479c-adab-70e5550d81d6)
