### PR TITLE
Fix Connection Issue in Debug Mode for betterangels-backend

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "type": "python",
       "request": "launch",
       "program": "${workspaceFolder}/apps/betterangels-backend/manage.py",
-      "args": ["runserver"],
+      "args": ["runserver", "0.0.0.0:8000"],
       "django": true,
       "justMyCode": false,
       "gevent": true


### PR DESCRIPTION
We encountered a problem where the backend webserver for betterangels-backend, when run under Debug Mode within VSCode, was not accepting connections. This issue was traced back to the default Django runserver configuration, which listens on 127.0.0.1:8000 and only accepts connections from localhost.

The root cause of the problem is that when Django is running within the development container (devcontainer), the host machine is not recognized as localhost. As a result, attempts to connect to the server from the host machine fail.

This PR addresses the issue by adjusting the server's listening address to enable connections from the host machine while running within the devcontainer.

How to test:
![image](https://github.com/BetterAngelsLA/monorepo/assets/407393/dd5066ca-0984-410f-a819-6efdf9dd537e)

* Before change go to the debug menu and select run
* Try to go to http://localhost:8000 in your browser.  You will see Django is inaccessible
* Swap to this branch and restart the debug web server
* You will see that you can access the django web severer now.