### PR TITLE
Fix GraphQL type generation check in CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -129,10 +129,11 @@ jobs:
           fi
 
           yarn nx affected -t generate-graphql-types
+          TYPE_GEN_STATUS=$?
           git diff --exit-code '**/gql-types/*';
-          STATUS=$?
-          if [ $STATUS -ne 0 ]; then
-            echo "Error: The GraphQL types do not match! Make sure you have run 'yarn nx affected -t generate-graphql-types' locally and committed the changes."
+          DIFF_STATUS=$?
+          if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
+            echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx affected -t generate-graphql-types' locally and committed the changes."
             exit 1
           else
             echo "Success: The GraphQL types match!"


### PR DESCRIPTION
Fix CI not failing if validate-graphql-schema does not fail but generate-graphql-types passes.  Pulled out from https://github.com/BetterAngelsLA/monorepo/pull/153. 

See https://github.com/BetterAngelsLA/monorepo/actions/runs/7702551975/job/20991080457 for changes being exercised.
