### PR TITLE
Remove whitespace at the end POST_OFFICE_EMAIL_BACKEND

### DIFF
--- a/apps/betterangels-backend/.env
+++ b/apps/betterangels-backend/.env
@@ -16,7 +16,7 @@ AWS_SES_REGION_NAME=us-west-2
 AWS_SES_REGION_ENDPOINT=email.us-west-2.amazonaws.com
 DEFAULT_FROM_EMAIL="no-reply@localhost"
 # Specify file or SES backend depending on your needs
-POST_OFFICE_EMAIL_BACKEND=django.core.mail.backends.filebased.EmailBackend 
+POST_OFFICE_EMAIL_BACKEND=django.core.mail.backends.filebased.EmailBackend
 # POST_OFFICE_EMAIL_BACKEND=django_ses.SESBackend
 
 # Social Account


### PR DESCRIPTION
Having a whitespace at the end causes exceptions to be thrown

Pulled out of #153 
