### PR TITLE
Fix create Note model permissions

### DIFF
--- a/apps/betterangels-backend/notes/migrations/0003_add_casemanager_note_permissions.py
+++ b/apps/betterangels-backend/notes/migrations/0003_add_casemanager_note_permissions.py
@@ -26,15 +26,11 @@ def create_permissions_if_not_exist(apps, schema_editor):
     NoteContentType = ContentType.objects.get_for_model(Note)
     db_alias = schema_editor.connection.alias
 
-    perms = [
-        Permission(
+    for codename, name in PERM_MAP.items():
+        Permission.objects.using(db_alias).get_or_create(
             codename=codename,
-            name=name,
-            content_type=NoteContentType,
+            defaults={"name": name, "content_type": NoteContentType},
         )
-        for codename, name in PERM_MAP.items()
-    ]
-    Permission.objects.using(db_alias).bulk_create(perms)
 
 
 def add_permissions_to_caseworker(apps, schema_editor):


### PR DESCRIPTION
When applying migrations in AWS Dev

> django.db.utils.IntegrityError: duplicate key value violates unique constraint "auth_permission_content_type_id_codename_01ab375a_uniq"
> DETAIL: Key (content_type_id, codename)=(23, view_note) already exists.


Given that we already have applied migrations to the Django Dev server we need to check if it has already created the perms and create if they don't exist.