### PR TITLE
Fix QR Code Generation

### DIFF
--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -42,12 +42,12 @@ jobs:
           affected_projects=$(yarn nx show projects --affected --withTarget eas-update)
           # Convert the list to a JSON matrix
           MATRIX_JSON=$(echo $affected_projects | jq -Rcs '
-            split("\n") | 
-            map(select(. != "")) | 
-            if length == 0 then 
-                {} 
-            else 
-                {include: map({project: .})} 
+            split("\n") |
+            map(select(. != "")) |
+            if length == 0 then
+                {}
+            else
+                {include: map({project: .})}
             end'
           )
           IS_MATRIX_EMPTY=$(echo $MATRIX_JSON | jq 'if type == "object" and length == 0 then true else false end')
@@ -114,3 +114,4 @@ jobs:
           command: eas update --auto
           comment: true
           working-directory: apps/${{ matrix.project }}
+          qr-target: expo-go


### PR DESCRIPTION
https://github.com/expo/expo-github-action/pull/247 this seems to have changed the default behavior of the expo preview QR code generation.  In another PR it seems to be required to have the `expo-dev-client` installed so we have to manually lock the QR code generation to expo go.

Jira Ticket:
DEV-25
