### PR TITLE
Fix Caseworker `PermissionGroupTemplate` having wrong Attachment Permission

### DIFF
--- a/apps/betterangels-backend/common/migrations/0005_fix_attachment_permission.py
+++ b/apps/betterangels-backend/common/migrations/0005_fix_attachment_permission.py
@@ -37,6 +37,7 @@ def update_caseworker_permission_template(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
+        ("post_office", "0011_models_help_text"),
         ("common", "0004_attachment_attachmentgroupobjectpermission_and_more"),
     ]
 


### PR DESCRIPTION
An earlier PR for attachments accidentally added `post_office`'s `Attachment` permissions to the permission group template.  This was not caught locally since the order of the returned permissions is different than production.  This PR fixes the permission template such that the proper `common` `Attachments` permissions are applied.

![image](https://github.com/BetterAngelsLA/monorepo/assets/407393/b105eda9-f0c4-4959-886c-666f9ff8bd33)

Resolves:
DEV-184