### PR TITLE
Fix `assertNumQueries` tests

### DIFF
--- a/apps/betterangels-backend/notes/tests/test_mutations.py
+++ b/apps/betterangels-backend/notes/tests/test_mutations.py
@@ -24,7 +24,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
     @time_machine.travel("03-12-2024 10:11:12", tick=False)
     def test_create_note_mutation(self) -> None:
         expected_query_count = 37
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._create_note_fixture(
                 {
                     "title": "New Note",
@@ -63,7 +63,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         }
 
         expected_query_count = 22
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._update_note_fixture(variables)
 
         updated_note = response["data"]["updateNote"]
@@ -93,7 +93,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         }
 
         expected_query_count = 22
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._update_note_fixture(variables)
 
         updated_note = response["data"]["updateNote"]
@@ -134,7 +134,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         note = Note.objects.get(id=self.note["id"])
         self.assertEqual(0, getattr(note, tasks_to_check).count())
 
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._create_note_task_fixture(variables)
 
         expected_task = {
@@ -176,7 +176,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         note = Note.objects.get(id=self.note["id"])
         self.assertEqual(0, getattr(note, service_requests_to_check).count())
 
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._create_note_service_request_fixture(variables)
 
         expected_service_request = {
@@ -202,8 +202,8 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
     @parametrize(
         "service_request_type,  expected_query_count",  # noqa E501
         [
-            ("REQUESTED", 8),
-            ("PROVIDED", 8),
+            ("REQUESTED", 9),
+            ("PROVIDED", 9),
         ],
     )
     def test_remove_note_service_request_mutation(
@@ -231,7 +231,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
 
         # Remove note service request
         expected_query_count = expected_query_count
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             updated_note = self._remove_note_service_request_fixture(variables)["data"][
                 "removeNoteServiceRequest"
             ]
@@ -257,7 +257,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         self.assertEqual(0, getattr(note, tasks_to_check).count())
 
         expected_query_count = 10
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._add_note_task_fixture(variables)
 
         expected_note = {
@@ -311,7 +311,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         self.assertEqual(1, note.next_steps.count())
 
         expected_query_count = 10
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._remove_note_task_fixture(variables)
 
         expected_note = {
@@ -349,7 +349,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         self.assertEqual(1, note.moods.count())
 
         expected_query_count = 9
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._create_note_mood_fixture(variables)
 
         expected_mood = {
@@ -385,7 +385,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         variables = {"id": moods[0].pk}
 
         expected_query_count = 4
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(mutation, variables)
 
         self.assertIsNotNone(response["data"]["deleteMood"])
@@ -413,7 +413,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         variables = {"id": self.note["id"]}
 
         expected_query_count = 20
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(mutation, variables)
         self.assertIsNotNone(response["data"]["deleteNote"])
 
@@ -468,8 +468,8 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase):
 
         variables = {"id": note_id, "savedAt": saved_at}
 
-        expected_query_count = 23
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 24
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["title"], "Updated Title")
@@ -500,8 +500,8 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase):
 
         variables = {"id": note_id, "savedAt": saved_at}
 
-        expected_query_count = 21
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 22
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["moods"]), 1)
@@ -545,8 +545,8 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase):
 
         variables = {"id": note_id, "savedAt": saved_at}
 
-        expected_query_count = 28
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 29
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["moods"]), 2)
@@ -603,8 +603,8 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase):
         # Revert to saved_at state
         variables = {"id": note_id, "savedAt": saved_at}
 
-        expected_query_count = 24
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 25
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["purposes"]), 1)
@@ -666,8 +666,8 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase):
         # Revert to saved_at state
         variables = {"id": note_id, "savedAt": saved_at}
 
-        expected_query_count = 24
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 25
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["providedServices"]), 1)
@@ -743,8 +743,8 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase):
 
         variables = {"id": note_id, "savedAt": saved_at}
 
-        expected_query_count = 24
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 25
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["purposes"]), 2)
@@ -823,8 +823,8 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase):
 
         variables = {"id": note_id, "savedAt": saved_at}
 
-        expected_query_count = 24
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 25
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["providedServices"]), 2)
@@ -867,7 +867,7 @@ class NoteAttachmentMutationTestCase(NoteGraphQLBaseTestCase):
         file_name = "test_attachment.txt"
 
         expected_query_count = 23
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             create_response = self._create_note_attachment_fixture(
                 self.note["id"],
                 NoteNamespaceEnum.MOOD_ASSESSMENT.name,
@@ -901,8 +901,8 @@ class NoteAttachmentMutationTestCase(NoteGraphQLBaseTestCase):
         attachment_id = create_response["data"]["createNoteAttachment"]["id"]
         self.assertTrue(Attachment.objects.filter(id=attachment_id).exists())
 
-        expected_query_count = 13
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 14
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             self._delete_note_attachment_fixture(attachment_id)
 
         self.assertFalse(
@@ -919,8 +919,8 @@ class ServiceRequestMutationTestCase(ServiceRequestGraphQLBaseTestCase):
         self._handle_user_login("org_1_case_manager_1")
 
     def test_create_service_request_mutation(self) -> None:
-        expected_query_count = 28
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 29
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._create_service_request_fixture(
                 {
                     "service": "BLANKET",
@@ -950,8 +950,8 @@ class ServiceRequestMutationTestCase(ServiceRequestGraphQLBaseTestCase):
             "client": self.client_1.pk,
         }
 
-        expected_query_count = 15
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 16
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._update_service_request_fixture(variables)
 
         updated_service_request = response["data"]["updateServiceRequest"]
@@ -975,8 +975,8 @@ class ServiceRequestMutationTestCase(ServiceRequestGraphQLBaseTestCase):
             "client": self.client_1.pk,
         }
 
-        expected_query_count = 15
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 16
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._update_service_request_fixture(variables)
 
         updated_service_request = response["data"]["updateServiceRequest"]
@@ -1012,8 +1012,8 @@ class ServiceRequestMutationTestCase(ServiceRequestGraphQLBaseTestCase):
         """
         variables = {"id": self.service_request["id"]}
 
-        expected_query_count = 15
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 16
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(mutation, variables)
 
         self.assertIsNotNone(response["data"]["deleteServiceRequest"])
@@ -1030,8 +1030,8 @@ class TaskMutationTestCase(TaskGraphQLBaseTestCase):
         self._handle_user_login("org_1_case_manager_1")
 
     def test_create_task_mutation(self) -> None:
-        expected_query_count = 28
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 29
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._create_task_fixture(
                 {
                     "title": "New Task",
@@ -1058,8 +1058,8 @@ class TaskMutationTestCase(TaskGraphQLBaseTestCase):
             "client": self.client_1.pk,
         }
 
-        expected_query_count = 15
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 16
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._update_task_fixture(variables)
         updated_task = response["data"]["updateTask"]
         expected_task = {
@@ -1079,8 +1079,8 @@ class TaskMutationTestCase(TaskGraphQLBaseTestCase):
             "title": "Updated task title",
         }
 
-        expected_query_count = 13
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 14
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._update_task_fixture(variables)
         updated_task = response["data"]["updateTask"]
         expected_task = {
@@ -1113,8 +1113,8 @@ class TaskMutationTestCase(TaskGraphQLBaseTestCase):
         """
         variables = {"id": self.task["id"]}
 
-        expected_query_count = 15
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 16
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(mutation, variables)
 
         self.assertIsNotNone(response["data"]["deleteTask"])

--- a/apps/betterangels-backend/notes/tests/test_queries.py
+++ b/apps/betterangels-backend/notes/tests/test_queries.py
@@ -87,9 +87,9 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
         """
 
         variables = {"id": note_id}
-        expected_query_count = 7
+        expected_query_count = 8
 
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables)
 
         note = response["data"]["note"]
@@ -179,7 +179,7 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
             }
         """
         expected_query_count = 8
-        with self.assertNumQueries(expected_query_count):
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query)
 
         notes = response["data"]["notes"]
@@ -247,8 +247,8 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
         if is_submitted is not None:
             filters["isSubmitted"] = is_submitted
 
-        expected_query_count = 2
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 3
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables={"filters": filters})
 
         notes = response["data"]["notes"]
@@ -364,8 +364,8 @@ class ServiceRequestQueryTestCase(ServiceRequestGraphQLBaseTestCase):
         """
         variables = {"id": service_request_id}
 
-        expected_query_count = 2
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 3
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables)
 
         service_request = response["data"]["serviceRequest"]
@@ -403,8 +403,8 @@ class ServiceRequestQueryTestCase(ServiceRequestGraphQLBaseTestCase):
                 }
             }
         """
-        expected_query_count = 2
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 3
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query)
 
         service_requests = response["data"]["serviceRequests"]
@@ -450,8 +450,8 @@ class TaskQueryTestCase(TaskGraphQLBaseTestCase):
         """
         variables = {"id": task_id}
 
-        expected_query_count = 2
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 3
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables)
 
         task = response["data"]["task"]
@@ -475,8 +475,8 @@ class TaskQueryTestCase(TaskGraphQLBaseTestCase):
                 }
             }
         """
-        expected_query_count = 2
-        with self.assertNumQueries(expected_query_count):
+        expected_query_count = 3
+        with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query)
 
         tasks = response["data"]["tasks"]

--- a/apps/betterangels-backend/notes/tests/utils.py
+++ b/apps/betterangels-backend/notes/tests/utils.py
@@ -58,17 +58,7 @@ class GraphQLBaseTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase):
         else:
             self.graphql_client.logout()
 
-
-class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self._setup_note()
-        self._setup_note_tasks()
-        self.provided_services = baker.make(ServiceRequest, _quantity=2)
-        self.requested_services = baker.make(ServiceRequest, _quantity=2)
-        self._clear_query_caches()
-
-    def _clear_query_caches(self) -> None:
+    def assertNumQueriesWithoutCache(self, query_count: int) -> Any:
         """
         Resets all caches that may prevent query execution.
         Needed to ensure deterministic behavior of ``assertNumQueries`` (or
@@ -78,6 +68,16 @@ class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
         """
         ContentType.objects.clear_cache()
         Site.objects.clear_cache()
+        return self.assertNumQueries(query_count)
+
+
+class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._setup_note()
+        self._setup_note_tasks()
+        self.provided_services = baker.make(ServiceRequest, _quantity=2)
+        self.requested_services = baker.make(ServiceRequest, _quantity=2)
 
     def _setup_note(self) -> None:
         # Force login the case manager to create a note


### PR DESCRIPTION
We were running into cases where the number of queries were occasionally being +/1 1 queries due to Django Query caching.  This should resolve this issue by clearing the query cache before the run.

DEV-194