### PR TITLE
Fix 500 error caused by missing gis template

### DIFF
--- a/apps/betterangels-backend/betterangels_backend/settings.py
+++ b/apps/betterangels-backend/betterangels_backend/settings.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.gis",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",


### PR DESCRIPTION
![Screenshot 2024-04-02 at 9 26 45 AM](https://github.com/BetterAngelsLA/monorepo/assets/407393/cbfe05b5-89a7-4ce0-a721-29d95e02ec58)
![Screenshot 2024-04-02 at 9 27 08 AM](https://github.com/BetterAngelsLA/monorepo/assets/407393/9ee28011-27ea-418f-b4a4-73bb65ce361b)

https://stackoverflow.com/questions/25220540/django-templatedoesnotexist-gis-admin-openlayers-html