### PR TITLE
Fix home and client page infinite rerender

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
@@ -96,7 +96,7 @@ export default function Clients({ Logo }: { Logo: ElementType }) {
   );
 
   useEffect(() => {
-    if (!data || !('clients' in data)) return;
+    if (!data || !('clientProfiles' in data)) return;
 
     const clientsToShow = data.clientProfiles
       .slice(0, paginationLimit)

--- a/libs/expo/betterangels/src/lib/screens/Home/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Home/index.tsx
@@ -69,7 +69,7 @@ export default function Home({ Logo }: { Logo: ElementType }) {
   };
 
   useEffect(() => {
-    if (!data || !('clients' in data)) return;
+    if (!data || !('clientProfiles' in data)) return;
 
     const clientsToShow = data.clientProfiles.slice(0, paginationLimit);
     const isMoreAvailable = data.clientProfiles.length > clientsToShow.length;
@@ -83,7 +83,7 @@ export default function Home({ Logo }: { Logo: ElementType }) {
     setHasMore(isMoreAvailable);
   }, [data, offset]);
 
-  if (!data) return null;
+  if (!data?.clientProfiles) return null;
   return (
     <View style={{ flex: 1 }}>
       <Header title="Home" Logo={Logo} />


### PR DESCRIPTION
In #295 we swapped `Client` with `ClientProfile`. In #288 we missed these references to `'clients'` that should have been updated to `'clientProfiles'`. This caused an infinite rerender on the Home and Clients pages