### PR TITLE
DEV-246 - Hide confidental shelters from public GraphQL Query

### DIFF
--- a/apps/betterangels-backend/shelters/types.py
+++ b/apps/betterangels-backend/shelters/types.py
@@ -55,7 +55,7 @@ class ShelterType:
 
     funders: List[str]
 
-    # TODO: Update the Shelter App to use permissions.  Until then we only expose nonsensitive locations
+    # TODO: Update the Shelter App to use permissions.  Until then we only expose nonconfidential locations
     @classmethod
     def get_queryset(cls, queryset: QuerySet[models.Shelter], info: Info, **kwargs: Any) -> QuerySet[models.Shelter]:
         return queryset.filter(Q(confidential=False) | Q(confidential__isnull=True))


### PR DESCRIPTION
We do not want to share confidential shelters on the graphql api until we have permissions enabled.

DEV-246

![image](https://github.com/BetterAngelsLA/monorepo/assets/407393/007a99bd-d6a2-4ec2-8139-113a439259ce)

![image](https://github.com/BetterAngelsLA/monorepo/assets/407393/93007685-c84f-4b1b-b0f7-adb97dda48db)

![image](https://github.com/BetterAngelsLA/monorepo/assets/407393/60525c5c-ccf2-4e6f-bd3d-adfcbe433415)

![image](https://github.com/BetterAngelsLA/monorepo/assets/407393/76efe95b-cee7-4399-b232-b45c206d3378)

