### PR TITLE
Cut over from saved_at to revert_before_timestamp (DEV-419)

### DIFF
--- a/apps/betterangels-backend/notes/schema.py
+++ b/apps/betterangels-backend/notes/schema.py
@@ -177,7 +177,7 @@ class Mutation:
 
         try:
             # TODO: update this after the swap
-            revert_to = data.revert_before_timestamp or data.saved_at
+            revert_to = data.saved_at or data.revert_before_timestamp
             NoteReverter(note_id=data.id).revert_to_revert_before_timestamp(
                 revert_before_timestamp=revert_to.isoformat()
             )

--- a/apps/betterangels-backend/notes/tests/test_mutations.py
+++ b/apps/betterangels-backend/notes/tests/test_mutations.py
@@ -539,8 +539,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
             }
         )
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 32
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -553,8 +552,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Select a moment to revert to
         revert_before_timestamp = timezone.now()
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
         expected_query_count = 17
         with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
@@ -603,8 +601,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
             }
         )
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
         expected_query_count = 34
         with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
@@ -616,8 +613,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Select a moment to revert to
         revert_before_timestamp = timezone.now()
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
         expected_query_count = 29
         with self.assertNumQueriesWithoutCache(expected_query_count):
             reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
@@ -671,8 +667,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
 
         # Update - should be discarded
         note_location_to_discard = self._update_note_location_fixture(variables)["data"]["updateNoteLocation"]
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         # Confirm the note location was updated
         self.assertEqual("104 West 1st Street", note_location_to_discard["location"]["address"]["street"])
@@ -708,8 +703,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Update - should be discarded
         self._create_note_mood_fixture({"descriptor": "EUTHYMIC", "noteId": note_id})
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 24
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -741,8 +735,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
 
         self._delete_mood_fixture(mood_id=mood_to_delete_id)
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 31
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -810,8 +803,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.next_steps.count(), 2)
 
         # Revert to revert_before_timestamp state
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 41
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -880,8 +872,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.next_steps.count(), 2)
 
         # Revert to revert_before_timestamp state
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 27
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -958,8 +949,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.requested_services.count(), 2)
 
         # Revert to revert_before_timestamp state
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 41
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1036,8 +1026,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.requested_services.count(), 2)
 
         # Revert to revert_before_timestamp state
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 41
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1105,8 +1094,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.next_steps.count(), 1)
 
         # Revert to revert_before_timestamp state
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 53
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1192,8 +1180,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.purposes.count(), 1)
         self.assertEqual(note.next_steps.count(), 1)
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 27
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1271,8 +1258,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.provided_services.count(), 1)
         self.assertEqual(note.requested_services.count(), 1)
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 53
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1350,8 +1336,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(note.provided_services.count(), 1)
         self.assertEqual(note.requested_services.count(), 1)
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 53
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1404,8 +1389,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self._update_task_fixture({"id": next_step["id"], "title": "Discarded Next Step Title"})
 
         # Revert to revert_before_timestamp state
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 27
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1459,8 +1443,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self._update_task_location_fixture({"id": task["id"], "location": discarded_location})
 
         # Revert to revert_before_timestamp state
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 24
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1517,8 +1500,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
             }
         )
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         expected_query_count = 27
         with self.assertNumQueriesWithoutCache(expected_query_count):
@@ -1542,8 +1524,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self._update_note_fixture({"id": note_id, "title": "Discarded Title"})
         self._create_note_mood_fixture({"descriptor": "ANXIOUS", "noteId": note_id})
 
-        # TODO: update to revertBeforeTimestamp in next PR
-        variables = {"id": note_id, "savedAt": revert_before_timestamp}
+        variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
         with patch("notes.models.Mood.revert_action", side_effect=Exception("oops")):
             not_reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]

--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -264,5 +264,5 @@ class UpdateTaskLocationInput:
 @strawberry_django.input(models.Note)
 class RevertNoteInput:
     id: auto
-    saved_at: datetime
-    revert_before_timestamp: Optional[datetime]
+    saved_at: Optional[datetime]
+    revert_before_timestamp: datetime

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -506,8 +506,8 @@ union RemoveNoteTaskPayload = NoteType | OperationInfo
 
 input RevertNoteInput {
   id: ID
-  savedAt: DateTime!
-  revertBeforeTimestamp: DateTime
+  savedAt: DateTime
+  revertBeforeTimestamp: DateTime!
 }
 
 union RevertNotePayload = NoteType | OperationInfo

--- a/apps/betterangels/src/app/(private-screens)/add-note/[noteId].tsx
+++ b/apps/betterangels/src/app/(private-screens)/add-note/[noteId].tsx
@@ -26,9 +26,9 @@ import RequestedServices from './RequestedServices';
 import Title from './Title';
 export default function AddNote() {
   const router = useRouter();
-  const { noteId, savedAt } = useLocalSearchParams<{
+  const { noteId, revertBeforeTimestamp } = useLocalSearchParams<{
     noteId: string;
-    savedAt: string;
+    revertBeforeTimestamp: string;
   }>();
 
   if (!noteId) {
@@ -65,7 +65,7 @@ export default function AddNote() {
         variables: {
           data: {
             id: noteId,
-            savedAt: savedAt || '',
+            revertBeforeTimestamp: revertBeforeTimestamp || '',
           },
         },
       });
@@ -169,7 +169,7 @@ export default function AddNote() {
       </MainScrollContainer>
       <BottomActions
         cancel={
-          savedAt ? (
+          revertBeforeTimestamp ? (
             <RevertModal
               body="All changes you made since the last save will be discarded"
               title="Discard changes?"

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -740,7 +740,8 @@ export type RemoveNoteTaskPayload = NoteType | OperationInfo;
 
 export type RevertNoteInput = {
   id?: InputMaybe<Scalars['ID']['input']>;
-  savedAt: Scalars['DateTime']['input'];
+  revertBeforeTimestamp: Scalars['DateTime']['input'];
+  savedAt?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
 export type RevertNotePayload = NoteType | OperationInfo;

--- a/libs/expo/betterangels/src/lib/screens/Note/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Note/index.tsx
@@ -41,7 +41,7 @@ export default function Note({ id }: { id: string }) {
             router.navigate({
               pathname: `/add-note/${id}`,
               params: {
-                savedAt: new Date().toISOString(),
+                revertBeforeTimestamp: new Date().toISOString(),
               },
             })
           }


### PR DESCRIPTION
**Do not merge before #384** 

DEV-419

This PR is step 2 of 3 in renaming `saved_at/savedAt` -> `revert_before_timestamp/revertBeforeTimestamp`:
1. #384:
    1. Replace test and `NoteReverter` use of `saved_at` to `revert_before_timestamp`
    2. Add optional `revert_before_timestamp` to `RevertNoteInput`
    3. Update `NoteReverter` to accept either `saved_at` or `revert_before_timestamp`
 
2. **This PR**: 
    1. Update frontend usage of `savedAt` to `revertBeforeTimestamp`
    2. Make `RevertNoteInput`'s `revert_before_timestamp` required and `saved_at` optional 
    3. Update remaining test usage of `savedAt`

4. #386:
    1. Remove `saved_at`