### PR TITLE
Remove saved_at (DEV-419)

### DIFF
--- a/apps/betterangels-backend/notes/schema.py
+++ b/apps/betterangels-backend/notes/schema.py
@@ -176,10 +176,8 @@ class Mutation:
         note = Note.objects.get(id=data.id)
 
         try:
-            # TODO: update this after the swap
-            revert_to = data.saved_at or data.revert_before_timestamp
             NoteReverter(note_id=data.id).revert_to_revert_before_timestamp(
-                revert_before_timestamp=revert_to.isoformat()
+                revert_before_timestamp=data.revert_before_timestamp.isoformat()
             )
             note.refresh_from_db()
 

--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -264,5 +264,4 @@ class UpdateTaskLocationInput:
 @strawberry_django.input(models.Note)
 class RevertNoteInput:
     id: auto
-    saved_at: Optional[datetime]
     revert_before_timestamp: datetime

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -506,7 +506,6 @@ union RemoveNoteTaskPayload = NoteType | OperationInfo
 
 input RevertNoteInput {
   id: ID
-  savedAt: DateTime
   revertBeforeTimestamp: DateTime!
 }
 

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -741,7 +741,6 @@ export type RemoveNoteTaskPayload = NoteType | OperationInfo;
 export type RevertNoteInput = {
   id?: InputMaybe<Scalars['ID']['input']>;
   revertBeforeTimestamp: Scalars['DateTime']['input'];
-  savedAt?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
 export type RevertNotePayload = NoteType | OperationInfo;


### PR DESCRIPTION
**Do not merge before #384 and #385** 

DEV-419

This PR is step 3 of 3 in renaming `saved_at/savedAt` -> `revert_before_timestamp/revertBeforeTimestamp`:
1. #384:
    1. Replace test and `NoteReverter` use of `saved_at` to `revert_before_timestamp`
    2. Add optional `revert_before_timestamp` to `RevertNoteInput`
    3. Update `NoteReverter` to accept either `saved_at` or `revert_before_timestamp`
 
2. #385: 
    1. Update frontend usage of `savedAt` to `revertBeforeTimestamp`
    2. Make `RevertNoteInput`'s `revert_before_timestamp` required and `saved_at` optional 
    3. Update remaining test usage of `savedAt`

4. **This PR**:
    1. Remove `saved_at`