### PR TITLE
Update caseworker template and delete old permission (DEV-423)

### DIFF
--- a/apps/betterangels-backend/notes/migrations/0006_fix_caseworker_template_servicerequest_permissions.py
+++ b/apps/betterangels-backend/notes/migrations/0006_fix_caseworker_template_servicerequest_permissions.py
@@ -8,8 +8,10 @@ def update_caseworker_permission_template(apps, schema_editor):
     Permission = apps.get_model("auth", "Permission")
     caseworker_template = PermissionGroupTemplate.objects.get(name="Caseworker")
 
-    permission_to_add = Permission.objects.filter(codename="add_servicerequest")
-    permission_to_remove = Permission.objects.filter(codename="add_service_request")
+    permission_to_add = Permission.objects.get(codename="add_servicerequest")
+    # This migration is fixing a typo left in by a bad squash. Using .filter() here
+    # because this permission only exists in the live db, not in local dev
+    permission_to_remove = Permission.objects.filter(codename="add_service_request").first()
 
     caseworker_template.permissions.add(permission_to_add)
     caseworker_template.permissions.remove(permission_to_remove)


### PR DESCRIPTION
Should resolve DEV-423, DEV-422, DEV-412

In #296 we [updated service request permission codenames](https://github.com/BetterAngelsLA/monorepo/pull/296/files#diff-8ad106dcaae53392e7b865546519f3686a9aeb6fd157bf85ddb916640b9372d0R17-R20) from `add_service_request` to `add_servicerequest`. The new permission was created but not applied to the caseworker template. As a result, all caseworker users lost the ability to create service requests.

This migration:
1. adds the correct `add_servicerequest` permission to the caseworker permission group template
2. removes the incorrect `add_service_request` permission from the caseworker permission group template
3. deletes the incorrect `add_service_request` permission

From ecs exec:
```
In [1]: wrong_permission = Permission.objects.get(codename="add_service_request")

In [2]: right_permission = Permission.objects.get(codename="add_servicerequest")

In [3]: wrong_permission.__dict__
Out[3]:
{'_state': <django.db.models.base.ModelState at 0x7f8a7748f440>,
 'id': 181,
 'name': 'Can add service request',
 'content_type_id': 44,
 'codename': 'add_service_request'}

In [4]: right_permission.__dict__
Out[4]:
{'_state': <django.db.models.base.ModelState at 0x7f8a7740d520>,
 'id': 194,
 'name': 'Can add service request',
 'content_type_id': 44,
 'codename': 'add_servicerequest'}

In [5]: caseworker_template = PermissionGroupTemplate.objects.get(name="Caseworker")

In [6]: caseworker_template.permissions.filter(codename__icontains="service")
Out[6]: <QuerySet [<Permission: Notes | service request | Can add service request>]>

In [7]: _.first().codename
Out[7]: 'add_service_request'
```