### PR TITLE
Update UserType for frontend 'client' type compatibility (DEV-435)

### DIFF
--- a/apps/betterangels-backend/accounts/types.py
+++ b/apps/betterangels-backend/accounts/types.py
@@ -87,8 +87,9 @@ class UserType:
     first_name: auto
     last_name: auto
     email: auto
-    is_outreach_authorized: auto
-    organizations_organization: List[OrganizationType]
+    # TODO: Optional because clients are users. We may want to consider breaking out a "CaseManagerProfile"
+    organizations_organization: Optional[List[OrganizationType]]
+    is_outreach_authorized: Optional[bool]
 
 
 @strawberry_django.input(User)

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -696,8 +696,8 @@ type UserType {
   firstName: String
   lastName: String
   email: String!
-  isOutreachAuthorized: Boolean!
-  organizationsOrganization: [OrganizationType!]!
+  organizationsOrganization: [OrganizationType!]
+  isOutreachAuthorized: Boolean
 }
 
 enum YesNoPreferNotToSayEnum {


### PR DESCRIPTION
This needs to go out before #369 

DEV-435

`note.client` is a `UserType`, so I made the cm-specific fields optional.