### PR TITLE
Limit phone digits to 10 (DEV-502)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/AddClient/ContactInfo.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddClient/ContactInfo.tsx
@@ -61,6 +61,7 @@ export default function ContactInfo(props: IContactInfoProps) {
           placeholder="Enter Phone Number"
           value={client.phoneNumber || ''}
           onChangeText={(e) => setClient({ ...client, phoneNumber: e })}
+          maxLength={10}
         />
         <BasicInput
           keyboardType="email-address"

--- a/libs/expo/shared/ui-components/src/lib/BasicInput/BasicInput.tsx
+++ b/libs/expo/shared/ui-components/src/lib/BasicInput/BasicInput.tsx
@@ -40,6 +40,7 @@ export function BasicInput(props: IBasicInputProps) {
     disabled,
     componentStyle,
     height = 56,
+    maxLength,
     mb,
     mt,
     my,
@@ -98,6 +99,7 @@ export function BasicInput(props: IBasicInputProps) {
             }),
           }}
           editable={!disabled}
+          maxLength={maxLength}
           {...rest}
           value={value}
         />


### PR DESCRIPTION
[DEV-502](https://betterangels.atlassian.net/browse/DEV-502?atlOrigin=eyJpIjoiMzVmMDZjODc4YTAxNDAxYjgzZDczZTE3NDMyNTc1MGQiLCJwIjoiaiJ9)

![limit-phone-digits](https://github.com/BetterAngelsLA/monorepo/assets/63478848/bc9bb6f8-d01d-4ac9-a609-782026324b87)


Keyboard in gif is to help show keystrokes into the app. 

The console log assures the digits are the same as inputted onto the phone upon creating a client, and ultimately to the backend.

NOTE: 
- Tried to format the phone number to appear as "(123) 456-7890". Although I got it working, it didn't work as seamless as I'd like it to be. If someone requests this feature, then I'd like to pair program would someone to go over what I did and how to improve it. Otherwise, I could find a dependency that already takes care of this, but I would imagine the styling would be different to the other existing text inputs.

[DEV-502]: https://betterangels.atlassian.net/browse/DEV-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ