### PR TITLE
Fix hmis profile data migration (DEV-383)

### DIFF
--- a/apps/betterangels-backend/accounts/migrations/0027_hmisprofile_hmisprofile_unique_hmis_id_agency.py
+++ b/apps/betterangels-backend/accounts/migrations/0027_hmisprofile_hmisprofile_unique_hmis_id_agency.py
@@ -10,9 +10,8 @@ def add_hmis_profile(apps, schema_editor):
     ClientProfile = apps.get_model("accounts", "ClientProfile")
     HmisProfile = apps.get_model("accounts", "HmisProfile")
 
-    client_profiles = ClientProfile.objects.all()
-
-    for client_profile in client_profiles:
+    client_profiles_with_hmis_id = ClientProfile.objects.filter(hmis_id__isnull=False)
+    for client_profile in client_profiles_with_hmis_id:
         HmisProfile.objects.create(
             client_profile=client_profile,
             hmis_id=client_profile.hmis_id,

--- a/apps/betterangels-backend/accounts/migrations/0027_hmisprofile_hmisprofile_unique_hmis_id_agency.py
+++ b/apps/betterangels-backend/accounts/migrations/0027_hmisprofile_hmisprofile_unique_hmis_id_agency.py
@@ -10,7 +10,8 @@ def add_hmis_profile(apps, schema_editor):
     ClientProfile = apps.get_model("accounts", "ClientProfile")
     HmisProfile = apps.get_model("accounts", "HmisProfile")
 
-    client_profiles_with_hmis_id = ClientProfile.objects.filter(hmis_id__isnull=False)
+    client_profiles_with_hmis_id = ClientProfile.objects.exclude(hmis_id=None).exclude(hmis_id="")
+
     for client_profile in client_profiles_with_hmis_id:
         HmisProfile.objects.create(
             client_profile=client_profile,

--- a/apps/betterangels-backend/accounts/migrations/0027_hmisprofile_hmisprofile_unique_hmis_id_agency.py
+++ b/apps/betterangels-backend/accounts/migrations/0027_hmisprofile_hmisprofile_unique_hmis_id_agency.py
@@ -4,13 +4,14 @@ import accounts.enums
 import django.db.models.deletion
 import django_choices_field.fields
 from django.db import migrations, models
+from django.db.models.query import Q
 
 
 def add_hmis_profile(apps, schema_editor):
     ClientProfile = apps.get_model("accounts", "ClientProfile")
     HmisProfile = apps.get_model("accounts", "HmisProfile")
 
-    client_profiles_with_hmis_id = ClientProfile.objects.exclude(hmis_id=None).exclude(hmis_id="")
+    client_profiles_with_hmis_id = ClientProfile.objects.exclude(Q(hmis_id=None) | Q(hmis_id=""))
 
     for client_profile in client_profiles_with_hmis_id:
         HmisProfile.objects.create(


### PR DESCRIPTION
`ClientProfile.hmis_id` is optional. `HmisProfile.hmis_id` is required. 

The data migration in #482 didn't account for that and tried to create hmis profiles for all client profiles, including those with no hmis id, resulting in a null constraint integrity error