### PR TITLE
Separate Note Attachments from Shelter Attachents

### DIFF
--- a/apps/betterangels-backend/notes/admin.py
+++ b/apps/betterangels-backend/notes/admin.py
@@ -5,6 +5,22 @@ from notes.enums import ServiceEnum
 from .models import Mood, Note, ServiceRequest, Task
 
 
+class AttachmentAdminMixin:
+    def attachments(self, obj: Model) -> SafeString:
+        attachments = Attachment.objects.filter(
+            content_type=ContentType.objects.get_for_model(obj),
+            object_id=obj.pk,
+        )
+        attachment_links = [
+            '<a href="{}">{}</a>'.format(
+                reverse("admin:common_attachment_change", args=(attachment.id,)),
+                f"Attachment {attachment.id}: {attachment}",
+            )
+            for attachment in attachments
+        ]
+        return format_html("<br>".join(attachment_links))
+
+
 class MoodAdmin(admin.ModelAdmin):
     list_display = (
         "descriptor",

--- a/apps/betterangels-backend/notes/models.py
+++ b/apps/betterangels-backend/notes/models.py
@@ -3,11 +3,11 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import pghistory
 from accounts.models import User
-from common.models import Attachment, BaseModel, Location
+from common.models import BaseAttachment, BaseModel, Location
 from common.permissions.utils import permission_enums_to_django_meta_permissions
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
-from django.db.models import Q
+from django.db.models import ForeignKey, Q
 from django.utils import timezone
 from django_choices_field import TextChoicesField
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
@@ -25,6 +25,36 @@ from .enums import (
 
 if TYPE_CHECKING:
     from pghistory.models import Events
+
+
+class Attachment(BaseAttachment):
+    """
+    Represents an attachment any model instance within the app.
+
+    Attributes:
+        associated_with: The User with whom the attachment is associated, if any.
+    """
+
+    associated_with = models.ForeignKey(
+        User, on_delete=models.CASCADE, related_name="associated_note_attachments", blank=True, null=True
+    )
+
+    attachmentuserobjectpermission_set: models.QuerySet["AttachmentUserObjectPermission"]
+    attachmentgroupobjectpermission_set: models.QuerySet["AttachmentGroupObjectPermission"]
+
+
+class AttachmentUserObjectPermission(UserObjectPermissionBase):
+    content_object: ForeignKey = models.ForeignKey(
+        Attachment,
+        on_delete=models.CASCADE,
+    )
+
+
+class AttachmentGroupObjectPermission(GroupObjectPermissionBase):
+    content_object: ForeignKey = models.ForeignKey(
+        Attachment,
+        on_delete=models.CASCADE,
+    )
 
 
 @pghistory.track(


### PR DESCRIPTION
### Plan for Migrating Attachments

- [ ] **Create Note-Specific Attachments**  
  Implement a new model for note-specific attachments to replace the current generic attachment model.

- [ ] **Database Migration - Migrate Generic Attachment Entries to Note-Specific Entries**  
  Write a migration to move all existing generic attachment data to the new note-specific attachment model.

- [ ] **Database Migration - Migrate Generic Attachment Permissions to Note-Specific Permissions**  
  Migrate permissions associated with the generic attachments to be associated with the new note-specific attachments.

- [ ] **Migrate Generic GraphQL Permissions to DB Permissions**  
  Update the GraphQL permissions to align with the new database structure for note-specific attachments.

- [ ] **Drop Shelter Attachments for Now**  
  Temporarily remove the shelter attachment model and its related database tables and permissions.

### Execution Strategy

- **Step 1:** Migrate note attachments and associated permissions to the new model.
- **Step 2:** Temporarily drop shelter attachments in the next PR.
- **Step 3:** Once note attachments are fully functional and stable, reintroduce shelter attachments in a subsequent PR.

### Goal

The primary goal is to maintain the functionality of note attachments while refactoring and migrating the attachment models to be more specific and manageable.

DEV-628
