### PR TITLE
Fix login (OUT-85)

### DIFF
--- a/apps/betterangels-backend/accounts/models.py
+++ b/apps/betterangels-backend/accounts/models.py
@@ -106,11 +106,9 @@ class User(AbstractBaseUser, PermissionsMixin):
         # Once this list grows, we'll need to create an actual list of authorized groups.
         authorized_permission_groups = [template.value for template in GroupTemplateNames]
 
-        user_in_authorized_org = PermissionGroup.objects.filter(
+        return PermissionGroup.objects.filter(
             organization__in=user_organizations, template__name__in=authorized_permission_groups
         ).exists()
-
-        return user_in_authorized_org and self.has_accepted_tos and self.has_accepted_privacy_policy
 
 
 class HmisProfile(models.Model):

--- a/apps/betterangels-backend/accounts/tests/test_models.py
+++ b/apps/betterangels-backend/accounts/tests/test_models.py
@@ -25,21 +25,17 @@ class UserModelTestCase(ParametrizedTestCase, TestCase):
         self.assertEqual(user_2.full_name, "Dale Bartholomew Cooper")
 
     @parametrize(
-        "user_is_in_authorized_org, user_is_in_unauthorized_org, user_has_accepted_tos, user_has_accepted_privacy_policy, should_succeed",
+        "user_is_in_authorized_org, user_is_in_unauthorized_org, should_succeed",
         [
-            (True, True, True, True, True),
-            (True, False, True, True, True),
-            (False, True, True, True, False),
-            (True, True, False, True, False),
-            (True, True, True, False, False),
+            (True, True, True),
+            (True, False, True),
+            (False, True, False),
         ],
     )
     def test_is_outreach_authorized(
         self,
         user_is_in_authorized_org: bool,
         user_is_in_unauthorized_org: bool,
-        user_has_accepted_tos: bool,
-        user_has_accepted_privacy_policy: bool,
         should_succeed: bool,
     ) -> None:
         authorized_org = organization_recipe.make(name="authorized org")
@@ -47,8 +43,6 @@ class UserModelTestCase(ParametrizedTestCase, TestCase):
 
         user = baker.make(
             User,
-            has_accepted_tos=user_has_accepted_tos,
-            has_accepted_privacy_policy=user_has_accepted_privacy_policy,
         )
 
         if user_is_in_authorized_org:

--- a/apps/betterangels-backend/accounts/tests/test_mutations.py
+++ b/apps/betterangels-backend/accounts/tests/test_mutations.py
@@ -56,7 +56,7 @@ class CurrentUserGraphQLTests(CurrentUserGraphQLBaseTestCase, TestCase):
         user = response["data"]["updateCurrentUser"]
         expected_user = {
             **variables,
-            "isOutreachAuthorized": False,
+            "isOutreachAuthorized": True,
             "organizations": [
                 {"id": str(self.user_organization.pk), "name": self.user_organization.name},
             ],

--- a/apps/betterangels-backend/accounts/tests/test_queries.py
+++ b/apps/betterangels-backend/accounts/tests/test_queries.py
@@ -130,6 +130,14 @@ class CurrentUserGraphQLTests(GraphQLBaseTestCase, ParametrizedTestCase):
             is_outreach_authorized,
         )
         self.assertEqual(
+            response["data"]["currentUser"]["hasAcceptedTos"],
+            user.has_accepted_tos,
+        )
+        self.assertEqual(
+            response["data"]["currentUser"]["hasAcceptedPrivacyPolicy"],
+            user.has_accepted_privacy_policy,
+        )
+        self.assertEqual(
             len(response["data"]["currentUser"]["organizations"]),
             organization_count,
         )


### PR DESCRIPTION
OUT-85

#514 introduced breaking change. Basically, I expanded `is_outreach_authorized` to check against tos and privacy policy acceptance, which was the wrong thing to do, as this conflated what should have been two discrete checks.

Follow up tickets:
DEV-682: add login smoke test
DEV-683: add backend terms acceptance check