### PR TITLE
Skip GraphQL Inspector on Forked Pull Requests (DEV-669)

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: 🕵🏻‍♂️ GraphQL Inspector
         uses: kamilkisiela/graphql-inspector@master
-        # Warning this now skips schema changes for forks.
+        # Warning: This now skips schema breaking checks in forked repositories.
         # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
         if: ${{ github.event.pull_request.head.repo.fork == false }}
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -149,7 +149,7 @@ jobs:
       - name: 🕵🏻‍♂️ GraphQL Inspector
         uses: kamilkisiela/graphql-inspector@master
         # Warning this now skips schema changes for forks.
-        # Find a better flow:
+        # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
         if: ${{ github.event.pull_request.head.repo.fork == false }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -81,26 +81,26 @@ jobs:
         if: ${{ env.BRANCH_NAME == 'main' }}
 
       # Build and Push Monorepo Image for each commit using GitHub Actions cache
-      - name: 🏗️ Build Monorepo Docker image
-        uses: docker/build-push-action@v6
-        with:
-          file: Dockerfile
-          load: true
-          push: ${{ env.BRANCH_NAME == 'main' }}
-          tags: |
-            ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # - name: 🏗️ Build Monorepo Docker image
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     file: Dockerfile
+      #     load: true
+      #     push: ${{ env.BRANCH_NAME == 'main' }}
+      #     tags: |
+      #       ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
 
-      - name: 🔑 Prep Container Permissions
-        run: |
-          sudo chown -R 1000:1000 .git
-          sudo setfacl --modify user:1000:rw /var/run/docker.sock
-          sudo setfacl -Rm u:1000:rwX,d:u:1000:rwX $HOME/.docker
+      # - name: 🔑 Prep Container Permissions
+      #   run: |
+      #     sudo chown -R 1000:1000 .git
+      #     sudo setfacl --modify user:1000:rw /var/run/docker.sock
+      #     sudo setfacl -Rm u:1000:rwX,d:u:1000:rwX $HOME/.docker
 
-      - name: 🔄 Spin up monorepo environment
-        run: |
-          docker compose up -d
+      # - name: 🔄 Spin up monorepo environment
+      #   run: |
+      #     docker compose up -d
 
       # - name: 🧹 Lint
       #   run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -102,49 +102,49 @@ jobs:
         run: |
           docker compose up -d
 
-      - name: 🧹 Lint
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          yarn nx affected -t lint
-          EOF
+      # - name: 🧹 Lint
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     yarn nx affected -t lint
+      #     EOF
 
-      - name: 🕵️ Check for missing Django migrations
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          yarn nx affected -t check-migrations
-          STATUS=$?
-          if [ $STATUS -ne 0 ]; then
-            echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
-            exit 1
-          else
-            echo "Success: No missing Django migrations!"
-          fi
-          EOF
+      # - name: 🕵️ Check for missing Django migrations
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     yarn nx affected -t check-migrations
+      #     STATUS=$?
+      #     if [ $STATUS -ne 0 ]; then
+      #       echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
+      #       exit 1
+      #     else
+      #       echo "Success: No missing Django migrations!"
+      #     fi
+      #     EOF
 
-      - name: 📝 Make sure GraphQL Schema is up to date
-        # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          yarn nx affected -t validate-graphql-schema
-          STATUS=$?
-          if [ $STATUS -ne 0 ]; then
-            echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx affected -t generate-graphql-schema' locally and committed the changes."
-            exit 1
-          else
-            echo "Success: The GraphQL schemas match!"
-          fi
+      # - name: 📝 Make sure GraphQL Schema is up to date
+      #   # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     yarn nx affected -t validate-graphql-schema
+      #     STATUS=$?
+      #     if [ $STATUS -ne 0 ]; then
+      #       echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx affected -t generate-graphql-schema' locally and committed the changes."
+      #       exit 1
+      #     else
+      #       echo "Success: The GraphQL schemas match!"
+      #     fi
 
-          yarn nx affected -t generate-graphql-types
-          TYPE_GEN_STATUS=$?
-          git diff --exit-code '**/gql-types/*';
-          DIFF_STATUS=$?
-          if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
-            echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx affected -t generate-graphql-types' locally and committed the changes."
-            exit 1
-          else
-            echo "Success: The GraphQL types match!"
-          fi
-          EOF
+      #     yarn nx affected -t generate-graphql-types
+      #     TYPE_GEN_STATUS=$?
+      #     git diff --exit-code '**/gql-types/*';
+      #     DIFF_STATUS=$?
+      #     if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
+      #       echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx affected -t generate-graphql-types' locally and committed the changes."
+      #       exit 1
+      #     else
+      #       echo "Success: The GraphQL types match!"
+      #     fi
+      #     EOF
 
       - name: 🕵🏻‍♂️ GraphQL Inspector
         uses: kamilkisiela/graphql-inspector@master

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,7 +20,7 @@ jobs:
       actions: read # Required to find the last successful workflow run
       contents: read # Required for actions/checkout
       id-token: write # Required for requesting the JWT
-      pull-requests: read
+      pull-requests: write # Required for graphql inspect out of org PRs
       checks: write # Required for graphql inspector
 
     steps:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read # Required to find the last successful workflow run
-      contents: read # Required for actions/checkout
+      contents: write # Required for actions/checkout
       id-token: write # Required for requesting the JWT
       pull-requests: write # Required for graphql inspect out of org PRs
       checks: write # Required for graphql inspector

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read # Required to find the last successful workflow run
-      contents: write # Required for actions/checkout
+      contents: read # Required for actions/checkout
       id-token: write # Required for requesting the JWT
-      pull-requests: write # Required for graphql inspect out of org PRs
+      pull-requests: read
       checks: write # Required for graphql inspector
 
     steps:
@@ -80,74 +80,77 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         if: ${{ env.BRANCH_NAME == 'main' }}
 
-      # Build and Push Monorepo Image for each commit using GitHub Actions cache
-      # - name: 🏗️ Build Monorepo Docker image
-      #   uses: docker/build-push-action@v6
-      #   with:
-      #     file: Dockerfile
-      #     load: true
-      #     push: ${{ env.BRANCH_NAME == 'main' }}
-      #     tags: |
-      #       ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
+      Build and Push Monorepo Image for each commit using GitHub Actions cache
+      - name: 🏗️ Build Monorepo Docker image
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile
+          load: true
+          push: ${{ env.BRANCH_NAME == 'main' }}
+          tags: |
+            ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      # - name: 🔑 Prep Container Permissions
-      #   run: |
-      #     sudo chown -R 1000:1000 .git
-      #     sudo setfacl --modify user:1000:rw /var/run/docker.sock
-      #     sudo setfacl -Rm u:1000:rwX,d:u:1000:rwX $HOME/.docker
+      - name: 🔑 Prep Container Permissions
+        run: |
+          sudo chown -R 1000:1000 .git
+          sudo setfacl --modify user:1000:rw /var/run/docker.sock
+          sudo setfacl -Rm u:1000:rwX,d:u:1000:rwX $HOME/.docker
 
-      # - name: 🔄 Spin up monorepo environment
-      #   run: |
-      #     docker compose up -d
+      - name: 🔄 Spin up monorepo environment
+        run: |
+          docker compose up -d
 
-      # - name: 🧹 Lint
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     yarn nx affected -t lint
-      #     EOF
+      - name: 🧹 Lint
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          yarn nx affected -t lint
+          EOF
 
-      # - name: 🕵️ Check for missing Django migrations
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     yarn nx affected -t check-migrations
-      #     STATUS=$?
-      #     if [ $STATUS -ne 0 ]; then
-      #       echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
-      #       exit 1
-      #     else
-      #       echo "Success: No missing Django migrations!"
-      #     fi
-      #     EOF
+      - name: 🕵️ Check for missing Django migrations
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          yarn nx affected -t check-migrations
+          STATUS=$?
+          if [ $STATUS -ne 0 ]; then
+            echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
+            exit 1
+          else
+            echo "Success: No missing Django migrations!"
+          fi
+          EOF
 
-      # - name: 📝 Make sure GraphQL Schema is up to date
-      #   # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     yarn nx affected -t validate-graphql-schema
-      #     STATUS=$?
-      #     if [ $STATUS -ne 0 ]; then
-      #       echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx affected -t generate-graphql-schema' locally and committed the changes."
-      #       exit 1
-      #     else
-      #       echo "Success: The GraphQL schemas match!"
-      #     fi
+      - name: 📝 Make sure GraphQL Schema is up to date
+        # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          yarn nx affected -t validate-graphql-schema
+          STATUS=$?
+          if [ $STATUS -ne 0 ]; then
+            echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx affected -t generate-graphql-schema' locally and committed the changes."
+            exit 1
+          else
+            echo "Success: The GraphQL schemas match!"
+          fi
 
-      #     yarn nx affected -t generate-graphql-types
-      #     TYPE_GEN_STATUS=$?
-      #     git diff --exit-code '**/gql-types/*';
-      #     DIFF_STATUS=$?
-      #     if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
-      #       echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx affected -t generate-graphql-types' locally and committed the changes."
-      #       exit 1
-      #     else
-      #       echo "Success: The GraphQL types match!"
-      #     fi
-      #     EOF
+          yarn nx affected -t generate-graphql-types
+          TYPE_GEN_STATUS=$?
+          git diff --exit-code '**/gql-types/*';
+          DIFF_STATUS=$?
+          if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
+            echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx affected -t generate-graphql-types' locally and committed the changes."
+            exit 1
+          else
+            echo "Success: The GraphQL types match!"
+          fi
+          EOF
 
       - name: 🕵🏻‍♂️ GraphQL Inspector
         uses: kamilkisiela/graphql-inspector@master
+        # Warning this now skips schema changes for forks.
+        # Find a better flow:
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           schema: main:apps/betterangels-backend/schema.graphql

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -80,7 +80,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         if: ${{ env.BRANCH_NAME == 'main' }}
 
-      Build and Push Monorepo Image for each commit using GitHub Actions cache
+      # Build and Push Monorepo Image for each commit using GitHub Actions cache
       - name: 🏗️ Build Monorepo Docker image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
We can not run GraphQL inspector in forks, which is kind of sad.  We need to find a work around for this in the future which is covered in DEV-690.

DEV-669