### PR TITLE
Try adding async upload using `django-formset`

### DIFF
--- a/apps/betterangels-backend/betterangels_backend/settings.py
+++ b/apps/betterangels-backend/betterangels_backend/settings.py
@@ -85,6 +85,7 @@ DEBUG = env("DEBUG")
 
 # Application definition
 INSTALLED_APPS = [
+    "formset",
     "jazzmin",
     "django.contrib.admin",
     "django.contrib.auth",

--- a/apps/betterangels-backend/betterangels_backend/urls.py
+++ b/apps/betterangels-backend/betterangels_backend/urls.py
@@ -17,12 +17,14 @@ Including another URLconf
 
 from betterangels_backend import settings
 from common.graphql.views import ProtectedGraphQLView
+from common.models import Attachment, AttachmentModelForm
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic.base import TemplateView
 
 from .schema import schema
+from .views import FormsetModelFormView
 
 urlpatterns = [
     path("", TemplateView.as_view(template_name="home.html"), name="home"),
@@ -33,6 +35,7 @@ urlpatterns = [
     path("graphql", ProtectedGraphQLView.as_view(schema=schema)),
     path("legal/", include("legal.urls")),
     path("proxy/", include("proxy.urls"), name="proxy"),
+    path("attachment_upload/", FormsetModelFormView.as_view(form_class=AttachmentModelForm, model=Attachment)),
 ]
 
 

--- a/apps/betterangels-backend/betterangels_backend/views.py
+++ b/apps/betterangels-backend/betterangels_backend/views.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import formset.renderers.default  # ignore : type
+from django.views.generic.edit import CreateView, FormMixin  # ignore : type
+from formset.views import (  # ignore : type
+    FileUploadMixin,
+    FormCollectionViewMixin,
+    FormViewMixin,
+)
+
+
+class FormsetModelFormView(FileUploadMixin, FormViewMixin, CreateView):
+    template_name = "formset_modelform.html"
+    extra_context = {"click_actions": "disable -> submit -> reload !~ scrollToError"}
+
+    @property
+    def framework(self) -> Any:
+        return self.request.resolver_match.app_name
+
+    @property
+    def mode(self) -> Any:
+        if self.request.resolver_match.url_name:
+            return self.request.resolver_match.url_name.split(".")[-1]
+        return ""
+
+    def get_context_data(self, **kwargs) -> Any:
+        context_data = super().get_context_data(**kwargs)
+        if self.framework != "default":
+            context_data.update(framework=self.framework)
+        if isinstance(self, FormCollectionViewMixin):
+            holder_class = self.collection_class
+        else:
+            holder_class = self.form_class
+        context_data.update(
+            leaf_name=holder_class.__name__,
+            valid_formset_data=self.request.session.get("valid_formset_data"),
+        )
+        self.request.session.pop("valid_formset_data", None)
+        return context_data
+
+    def get_form_class(self) -> Any:
+        form_class = super().get_form_class()
+        if issubclass(form_class, FormMixin):
+            return form_class
+        # attrs = self.get_css_classes()
+        # attrs.pop("button_css_classes", None)
+        renderer_class = formset.renderers.default.FormRenderer
+        if self.mode != "native":
+            renderer = renderer_class()
+            form_class = type(form_class.__name__, (FormMixin, form_class), {"default_renderer": renderer})
+        return form_class

--- a/apps/betterangels-backend/common/models.py
+++ b/apps/betterangels-backend/common/models.py
@@ -8,7 +8,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.db.models import PointField
 from django.db import models
 from django.db.models import ForeignKey
+from django.forms import ModelForm
 from django_choices_field import TextChoicesField
+from formset.widgets import UploadedFileInput  # ignore : type
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from phonenumber_field.modelfields import PhoneNumberField
 
@@ -101,6 +103,15 @@ class Attachment(BaseModel):
                 self.attachment_type = AttachmentType.DOCUMENT
             self.file.seek(0)
         super().save(*args, **kwargs)
+
+
+class AttachmentModelForm(ModelForm):
+    class Meta:
+        model = Attachment
+        fields = "__all__"
+        widgets = {
+            "file": UploadedFileInput,
+        }
 
 
 class Address(BaseModel):

--- a/apps/betterangels-backend/poetry.lock
+++ b/apps/betterangels-backend/poetry.lock
@@ -648,6 +648,20 @@ files = [
 Django = ">=3.2"
 
 [[package]]
+name = "django-formset"
+version = "1.5.3"
+description = "The missing widgets and form manipulation library for Django"
+optional = false
+python-versions = "*"
+files = [
+    {file = "django_formset-1.5.3-py3-none-any.whl", hash = "sha256:694e0adab1500383996d592f88319de0ba48dce1507469ddaf0ebc6bae459375"},
+    {file = "django_formset-1.5.3.tar.gz", hash = "sha256:a1623e845966eaab2c67280378602d25667de72c39cabf2977b10f8b9615f3a1"},
+]
+
+[package.dependencies]
+django = ">=4.0"
+
+[[package]]
 name = "django-guardian"
 version = "2.4.0"
 description = "Implementation of per object permissions for Django."
@@ -1867,4 +1881,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.12.2"
-content-hash = "68a79454108bc1f42a203c022a047e31a9ea55d4aae5066e8622b890958935e7"
+content-hash = "a8b8054e23c86e55f021107fd723c7daa8ce48937c551b5aa5181f7a1928bbd9"

--- a/apps/betterangels-backend/pyproject.toml
+++ b/apps/betterangels-backend/pyproject.toml
@@ -44,6 +44,7 @@ django-structlog = "^8.1.0"
 deepdiff = "^7.0.1"
 django-phonenumber-field = { extras = ["phonenumbers"], version = "^8.0.0" }
 django-ckeditor-5 = "^0.2.13"
+django-formset = "^1.5.3"
 
 [build-system]
 requires = ["poetry-core"]

--- a/apps/betterangels-backend/templates/formset_admin_change_form.html
+++ b/apps/betterangels-backend/templates/formset_admin_change_form.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_form.html" %}
+{% load static %}
+{% block extrahead %}
+    {{ block.super }}
+    <!-- N.B. this was copied from django-formset's `change_admin.html`, but it seems they have not updated it to point to the correct location for this file -->
+    <script type="module"
+            src="{% if use_monolithic_build %}{% static 'formset/js/django-formset.monolith.js' %}{% else %}{% static 'formset/js/django-formset.js' %}{% endif %}"></script>
+{% endblock %}
+{% block content %}
+    <django-formset endpoint="{{ request.path }}" csrf-token="{{ csrf_token }}">
+    {{ block.super }}
+    </django-formset>
+{% endblock %}

--- a/apps/betterangels-backend/templates/formset_buttons.html
+++ b/apps/betterangels-backend/templates/formset_buttons.html
@@ -1,0 +1,15 @@
+<p>
+    <button type="button"
+            df-click="{{ click_actions }}"
+            {% if auto_disable %}auto-disable{% endif %}
+            class="button">
+        Submit&ensp;<span class="dj-button-decorator"><i class="dj-icon">
+        {% include "formset/icons/send.svg" %}
+    </i></span>
+</button>
+<button type="button" df-click="reset">
+    Reset to initial&ensp;<span class="dj-button-decorator"><i class="dj-icon">
+    {% include "formset/icons/reset.svg" %}
+</i></span>
+</button>
+</p>

--- a/apps/betterangels-backend/templates/formset_modelform.html
+++ b/apps/betterangels-backend/templates/formset_modelform.html
@@ -1,0 +1,25 @@
+{% load static %}
+<!DOCTYPE html>
+<html dir="ltr" lang="{{ LANGUAGE_CODE|default:'en' }}">
+    <head>
+        <meta charset="utf-8" />
+        <script type="module"
+                src="{% if use_monolithic_build %}{% static 'formset/js/django-formset.monolith.js' %}{% else %}{% static 'formset/js/django-formset.js' %}{% endif %}"></script>
+        {% load render_form from formsetify %}
+    </head>
+    <body>
+        <django-formset endpoint="{{ request.path }}"
+        {% if force_submission %}force-submission{% endif %}
+        {% if withhold_feedback %}withhold-feedback="{{ withhold_feedback }}"{% endif %}
+        csrf-token="{{ csrf_token }}">
+        {% include "formset/non_field_errors.html" %}
+        {% render_form form framework form_classes=form_css_classes field_classes=field_css_classes fieldset_classes=fieldset_css_classes label_classes=label_css_classes|default:None control_classes=control_css_classes %}
+        {% include "formset_buttons.html" %}
+        </django-formset>
+        {% if valid_formset_data %}
+            <hr>
+            <h3>Submitted Formset Data:</h3>
+            <pre>{{ valid_formset_data }}</pre>
+        {% endif %}
+    </body>
+</html>


### PR DESCRIPTION
I've included two attempts to make this work:
* At the view `attachment_upload/`, there is a regular ModelForm that uses the async upload mechanism. It doesn't use any admin permissions or styling, but should work to upload the data itself.
* I've also included what I _believe_ is the correct way to integrate it into the admin, however it appears that has not been tested in some time, as I had to patch in a change to the change form's HTML. It also appears to have an error involving the CSS import (I haven't investigated further what this error is or how to fix it).