### PR TITLE
add .env.local to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+# env files (we currently track the standard .env file)
+.env.local
+
 # compiled output
 dist
 tmp

--- a/apps/betterangels/.env.local.sample
+++ b/apps/betterangels/.env.local.sample
@@ -1,0 +1,2 @@
+EXPO_PUBLIC_API_URL=http://localhost:8000
+EXPO_PUBLIC_DEMO_API_URL=http://localhost:8000

--- a/docs/frontend_readme.md
+++ b/docs/frontend_readme.md
@@ -91,6 +91,9 @@ Run the following on the host machine (not in the container):
 
 1. Optional: add a `.env.local` file:
    - See `.env.local.sample` file for refernce
+   - .env.local file should override the .env values on your local machine
+     - usage example: seting ` EXPO_PUBLIC_API_URL`` and  `EXPO_PUBLIC_DEMO_API_URL` to same domain to avoid CORS issues
+   - NX docs on [Environment Variables](https://nx.dev/recipes/tips-n-tricks/define-environment-variables)
 
 ### Running the Frontend: Nx Workspace with Expo Application
 

--- a/docs/frontend_readme.md
+++ b/docs/frontend_readme.md
@@ -52,6 +52,7 @@ Run the following on the host machine (not in the container):
    > ```
 
 1. Reload your shell profile or restart your terminal for the changes to take effect
+
    ```bash
    source ~/.zshrc
    ```
@@ -64,10 +65,13 @@ Run the following on the host machine (not in the container):
 
 1. Clone the monorepo
    a. [Setup SSH (optional)](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
-      ```bash
-      git clone git@github.com:BetterAngelsLA/monorepo.git
-      ```
+
+   ```bash
+   git clone git@github.com:BetterAngelsLA/monorepo.git
+   ```
+
    b. Alternatively use https
+
    ```bash
    git clone https://github.com/BetterAngelsLA/monorepo.git
    ```
@@ -85,12 +89,15 @@ Run the following on the host machine (not in the container):
    nvm install node && nvm alias default node
    ```
 
+1. Optional: add a `.env.local` file:
+   - See `.env.local.sample` file for refernce
+
 ### Running the Frontend: Nx Workspace with Expo Application
 
 #### Starting Expo
 
 1. Open a new integrated terminal (local) and run the following to start Expo in your local environment
-   *Note: You should have development builds (linked above) installed on your device*
+   _Note: You should have development builds (linked above) installed on your device_
 
    Start the Outreach app
 


### PR DESCRIPTION
https://betterangels.atlassian.net/browse/DEV-860

* Allows using a `.env.local` file in local repos.
  * this file takes precendence over `.env` file values
* To bypass CORS issues, on web at least, you can:
  *  add a `.env.local` file
  * set `EXPO_PUBLIC_API_URL=http://localhost:8000`

