### PR TITLE
expose clientprofile on usertype (DEV-831)

### DIFF
--- a/apps/betterangels-backend/accounts/types.py
+++ b/apps/betterangels-backend/accounts/types.py
@@ -46,6 +46,7 @@ class UserType(UserBaseType):
     # TODO: has_accepted_tos, has_accepted_privacy_policy, is_outreach_authorized shouldn't be optional.
     # Temporary fix while we figure out type generation
     id: ID
+    client_profile: auto
     has_accepted_tos: Optional[bool]
     has_accepted_privacy_policy: Optional[bool]
     is_outreach_authorized: Optional[bool]

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1048,6 +1048,7 @@ type UserType {
   middleName: String
   email: String
   id: ID!
+  clientProfile: DjangoModelType
   hasAcceptedTos: Boolean
   hasAcceptedPrivacyPolicy: Boolean
   isOutreachAuthorized: Boolean


### PR DESCRIPTION
DEV-831

this is the backend change necessary for https://github.com/BetterAngelsLA/monorepo/pull/627

## Summary by Sourcery

New Features:
- Expose the 'clientProfile' field on the 'UserType' in the GraphQL schema.