### PR TITLE
Use single doc flow for license upload (DEV-946)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
@@ -239,46 +239,6 @@ export default function UploadModal(props: IUploadModalProps) {
             </TextRegular>
             <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
               <TextBold>Doc-Ready</TextBold>
-              {/* <View
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                }}
-              >
-                <View
-                  style={{
-                    height: 20,
-                    width: 20,
-                    borderRadius: Radiuses.xxxl,
-                    backgroundColor:
-                      !!docs.DriversLicenseFront && !!docs.DriversLicenseBack
-                        ? Colors.SUCCESS
-                        : Colors.NEUTRAL_LIGHT,
-                    marginRight: Spacings.xs,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}
-                >
-                  {!!docs.DriversLicenseFront && !!docs.DriversLicenseBack && (
-                    <CheckIcon size="sm" color={Colors.WHITE} />
-                  )}
-                </View>
-
-                <Button
-                  disabled={
-                    !!docs.DriversLicenseFront && !!docs.DriversLicenseBack
-                  }
-                  containerStyle={{ flex: 1 }}
-                  weight="regular"
-                  onPress={() => setTab('DriversLicense')}
-                  height="md"
-                  align="flex-start"
-                  size="full"
-                  variant="secondary"
-                  title="CA ID or CA Driver's License"
-                  accessibilityHint="opens CA Photo ID upload screen"
-                />
-              </View> */}
               <View
                 style={{
                   flexDirection: 'row',

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
@@ -49,7 +49,7 @@ export default function UploadModal(props: IUploadModalProps) {
       <SingleDocUploads
         thumbnailSize={thumbnailSizes.PhotoId}
         docType="DriversLicenseFront"
-        title="Upload CA ID or CA Driver’s License (front)"
+        title="Upload CA ID or CA Driver’s License - Front"
         {...docProps}
       />
     ),
@@ -57,7 +57,7 @@ export default function UploadModal(props: IUploadModalProps) {
       <SingleDocUploads
         thumbnailSize={thumbnailSizes.PhotoId}
         docType="DriversLicenseBack"
-        title="Upload CA ID or CA Driver’s License (back)"
+        title="Upload CA ID or CA Driver’s License - Back"
         {...docProps}
       />
     ),
@@ -272,8 +272,8 @@ export default function UploadModal(props: IUploadModalProps) {
                   weight="regular"
                   size="full"
                   variant="secondary"
-                  title="CA ID or CA Driver's License (front)"
-                  accessibilityHint="opens CA Photo ID (front) upload screen"
+                  title="CA ID or CA Driver's License - Front"
+                  accessibilityHint="opens CA Photo ID front upload screen"
                 />
               </View>
               <View
@@ -309,8 +309,8 @@ export default function UploadModal(props: IUploadModalProps) {
                   weight="regular"
                   size="full"
                   variant="secondary"
-                  title="CA ID or CA Driver's License (back)"
-                  accessibilityHint="opens CA Photo ID (back) upload screen"
+                  title="CA ID or CA Driver's License - Back"
+                  accessibilityHint="opens CA Photo ID back upload screen"
                 />
               </View>
               <View

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
@@ -327,6 +327,43 @@ export default function UploadModal(props: IUploadModalProps) {
                     height: 20,
                     width: 20,
                     borderRadius: Radiuses.xxxl,
+                    backgroundColor: docs.DriversLicenseBack
+                      ? Colors.SUCCESS
+                      : Colors.NEUTRAL_LIGHT,
+                    marginRight: Spacings.xs,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {!!docs.DriversLicenseBack && (
+                    <CheckIcon size="sm" color={Colors.WHITE} />
+                  )}
+                </View>
+
+                <Button
+                  disabled={!!docs.DriversLicenseBack}
+                  containerStyle={{ flex: 1 }}
+                  onPress={() => setTab('DriversLicenseBack')}
+                  height="md"
+                  align="flex-start"
+                  weight="regular"
+                  size="full"
+                  variant="secondary"
+                  title="CA ID or CA Driver's License (back)"
+                  accessibilityHint="opens CA Photo ID (back) upload screen"
+                />
+              </View>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                }}
+              >
+                <View
+                  style={{
+                    height: 20,
+                    width: 20,
+                    borderRadius: Radiuses.xxxl,
                     backgroundColor: docs.PhotoId
                       ? Colors.SUCCESS
                       : Colors.NEUTRAL_LIGHT,

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
@@ -17,7 +17,7 @@ import { Pressable, ScrollView, View } from 'react-native';
 import Modal from 'react-native-modal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ClientDocumentNamespaceEnum } from '../../../../apollo';
-import DriversLicense from './DriverLicense';
+// import DriversLicense from './DriverLicense';
 import MultipleDocUploads from './MultipleDocUploads';
 import SingleDocUploads from './SingleDocUploads';
 import { Docs, ITab, IUploadModalProps } from './types';
@@ -45,7 +45,22 @@ export default function UploadModal(props: IUploadModalProps) {
   };
 
   const TABS = {
-    DriversLicense: <DriversLicense {...docProps} />,
+    DriversLicenseFront: (
+      <SingleDocUploads
+        thumbnailSize={thumbnailSizes.PhotoId}
+        docType="DriversLicenseFront"
+        title="Upload CA ID or CA Driver’s License (front)"
+        {...docProps}
+      />
+    ),
+    DriversLicenseBack: (
+      <SingleDocUploads
+        thumbnailSize={thumbnailSizes.PhotoId}
+        docType="DriversLicenseBack"
+        title="Upload CA ID or CA Driver’s License (back)"
+        {...docProps}
+      />
+    ),
     BirthCertificate: (
       <SingleDocUploads
         thumbnailSize={thumbnailSizes.BirthCertificate}
@@ -224,7 +239,7 @@ export default function UploadModal(props: IUploadModalProps) {
             </TextRegular>
             <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
               <TextBold>Doc-Ready</TextBold>
-              <View
+              {/* <View
                 style={{
                   flexDirection: 'row',
                   alignItems: 'center',
@@ -262,6 +277,43 @@ export default function UploadModal(props: IUploadModalProps) {
                   variant="secondary"
                   title="CA ID or CA Driver's License"
                   accessibilityHint="opens CA Photo ID upload screen"
+                />
+              </View> */}
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                }}
+              >
+                <View
+                  style={{
+                    height: 20,
+                    width: 20,
+                    borderRadius: Radiuses.xxxl,
+                    backgroundColor: docs.DriversLicenseFront
+                      ? Colors.SUCCESS
+                      : Colors.NEUTRAL_LIGHT,
+                    marginRight: Spacings.xs,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {!!docs.DriversLicenseFront && (
+                    <CheckIcon size="sm" color={Colors.WHITE} />
+                  )}
+                </View>
+
+                <Button
+                  disabled={!!docs.DriversLicenseFront}
+                  containerStyle={{ flex: 1 }}
+                  onPress={() => setTab('DriversLicenseFront')}
+                  height="md"
+                  align="flex-start"
+                  weight="regular"
+                  size="full"
+                  variant="secondary"
+                  title="CA ID or CA Driver's License (front)"
+                  accessibilityHint="opens CA Photo ID (front) upload screen"
                 />
               </View>
               <View

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/types.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/types.ts
@@ -26,7 +26,11 @@ export interface IIdDocUploadsProps {
   docs: Docs;
   setDocs: Dispatch<SetStateAction<Docs>>;
   title: string;
-  docType: 'SocialSecurityCard' | 'PhotoId';
+  docType:
+    | 'DriversLicenseFront'
+    | 'DriversLicenseBack'
+    | 'SocialSecurityCard'
+    | 'PhotoId';
 }
 
 export interface IMultipleDocUploadsProps {
@@ -44,7 +48,12 @@ export interface ISingleDocUploadsProps {
   docs: Docs;
   setDocs: Dispatch<SetStateAction<Docs>>;
   title: string;
-  docType: 'BirthCertificate' | 'SocialSecurityCard' | 'PhotoId';
+  docType:
+    | 'DriversLicenseFront'
+    | 'DriversLicenseBack'
+    | 'BirthCertificate'
+    | 'SocialSecurityCard'
+    | 'PhotoId';
   thumbnailSize: TThumbnailSize;
 }
 
@@ -66,7 +75,8 @@ export type Docs = {
 };
 
 export type ITab =
-  | 'DriversLicense'
+  | 'DriversLicenseFront'
+  | 'DriversLicenseBack'
   | 'BirthCertificate'
   | 'PhotoId'
   | 'SocialSecurityCard'


### PR DESCRIPTION
DEV-946

<img width="270" alt="image" src="https://github.com/user-attachments/assets/4abed40d-c101-43c6-9be6-902c5d22199c">

## Summary by Sourcery

Enhancements:
- Separate the driver's license upload process into two distinct tabs for front and back uploads.