### PR TITLE
fixed android bug with date of birth (DEV-919)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/Dob.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/Dob.tsx
@@ -21,6 +21,7 @@ export default function Dob() {
         mode="date"
         format="MM/dd/yyyy"
         placeholder="MM/DD/YYYY"
+        minDate={new Date('1900-01-01')}
         mt="xs"
         value={dateOfBirth || new Date()}
         setValue={(date) => setValue('dateOfBirth', date)}

--- a/libs/expo/betterangels/src/lib/ui-components/DateOfBirthPicker.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/DateOfBirthPicker.tsx
@@ -15,6 +15,7 @@ export default function DateOfBirthPicker(props: IDateOfBirthPickerProps) {
       disabled
       maxDate={new Date()}
       pattern={Regex.date}
+      minDate={new Date('1900-01-01')}
       mode="date"
       format="MM/dd/yyyy"
       placeholder="MM/DD/YYYY"


### PR DESCRIPTION
DEV-919

## Summary by Sourcery

Bug Fixes:
- Fix the Android bug related to the date of birth by setting a minimum date of January 1, 1900, in the date picker components.