### PR TITLE
Added description to HMIS ID section (DEV-862)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/HmisProfiles.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/HmisProfiles.tsx
@@ -39,6 +39,9 @@ export default function HmisProfiles() {
     <CardWrapper
       {...(hmisProfiles.length !== 0 && { onReset })}
       title="HMIS IDs"
+      subtitle={
+        hmisProfiles.length !== 0 ? 'Fill in both HMIS ID Type and ID #' : ''
+      }
     >
       {fields.map((_, index) => (
         <View style={{ gap: Spacings.sm }} key={index}>


### PR DESCRIPTION
[DEV-862](https://betterangels.atlassian.net/browse/DEV-862)

## Summary by Sourcery

Enhancements:
- Add a subtitle to the HMIS IDs section to guide users to fill in both HMIS ID Type and ID # when profiles are present.

[DEV-862]: https://betterangels.atlassian.net/browse/DEV-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ