### PR TITLE
Set purpose to undefined on field clear (DEV-948)

### DIFF
--- a/apps/betterangels/src/app/(private-screens)/add-note/Purpose/index.tsx
+++ b/apps/betterangels/src/app/(private-screens)/add-note/Purpose/index.tsx
@@ -113,8 +113,7 @@ export default function Purpose(props: IPurposeProps) {
           }}
           error={!!errors.purpose}
           errorMessage={errors.purpose ? 'Purpose is required' : ''}
-          // TODO: remove default value after backend cleanup (DEV-804)
-          value={value || 'Session with client'}
+          value={value || undefined}
           onChangeText={(e) => onChange(e)}
         />
       </View>


### PR DESCRIPTION
DEV-948

was supposed to be done in #642 but the fix was reverted between approval and merge 🤦

## Summary by Sourcery

Bug Fixes:
- Set the 'purpose' field value to undefined when cleared, instead of defaulting to 'Session with client'.