### PR TITLE
Styling on Important notes Textarea now aligned vertically flex-start

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/ImportantNotes/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/ImportantNotes/index.tsx
@@ -40,6 +40,7 @@ export default function ImportantNotes(props: IImportantNotesProps) {
           }}
         >
           <Textarea
+            textAlignVertical='top'
             placeholder="Enter important notes"
             name="importantNotes"
             control={control}

--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/ImportantNotes/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/ImportantNotes/index.tsx
@@ -40,7 +40,6 @@ export default function ImportantNotes(props: IImportantNotesProps) {
           }}
         >
           <Textarea
-            textAlignVertical='top'
             placeholder="Enter important notes"
             name="importantNotes"
             control={control}

--- a/libs/expo/shared/ui-components/src/lib/Textarea/Textarea.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Textarea/Textarea.tsx
@@ -52,6 +52,7 @@ interface ITextareaProps extends TextInputProps {
   ml?: TSpacing;
   mr?: TSpacing;
   height?: number | 'auto';
+  textAlignVertical?: 'top' | 'center' | 'bottom';
   onFocus?: () => void;
 }
 
@@ -73,6 +74,7 @@ export function Textarea(props: ITextareaProps) {
     mr,
     height,
     onFocus,
+    textAlignVertical = 'top',
     ...rest
   } = props;
 
@@ -121,6 +123,7 @@ export function Textarea(props: ITextareaProps) {
                 fontFamily: 'Poppins-Regular',
                 fontSize: FontSizes.md.fontSize,
                 lineHeight: FontSizes.md.lineHeight,
+                textAlignVertical: textAlignVertical,
                 minHeight: 40,
                 height,
                 overflow: 'scroll',

--- a/libs/expo/shared/ui-components/src/lib/Textarea/Textarea.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Textarea/Textarea.tsx
@@ -52,7 +52,6 @@ interface ITextareaProps extends TextInputProps {
   ml?: TSpacing;
   mr?: TSpacing;
   height?: number | 'auto';
-  textAlignVertical?: 'top' | 'center' | 'bottom';
   onFocus?: () => void;
 }
 
@@ -112,6 +111,7 @@ export function Textarea(props: ITextareaProps) {
             ]}
           >
             <TextInput
+              textAlignVertical={textAlignVertical}
               style={{
                 color: disabled
                   ? Colors.NEUTRAL_LIGHT
@@ -123,7 +123,6 @@ export function Textarea(props: ITextareaProps) {
                 fontFamily: 'Poppins-Regular',
                 fontSize: FontSizes.md.fontSize,
                 lineHeight: FontSizes.md.lineHeight,
-                textAlignVertical: textAlignVertical,
                 minHeight: 40,
                 height,
                 overflow: 'scroll',


### PR DESCRIPTION
- On Android the text area text and placeholder appeared centred in the Textarea component (not on iOS)
- Added the textAlignVertical='top' attribute to textArea, resolved issue on Android. No change on iOS.

## Summary by Sourcery

Bug Fixes:
- Fix vertical alignment of text and placeholder in the Textarea component on Android by setting textAlignVertical to 'top'.