### PR TITLE
add bottomOffset to KeyboardAwareScrollView

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/MainScrollContainer.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainScrollContainer.tsx
@@ -3,6 +3,12 @@ import { ReactNode, forwardRef } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
+// used to offset view scroll on keyboard show, accounting for toolbar height
+const iOSToolbarHeightApprox = 44;
+const androidToolbarHeightApprox = 50;
+
+const keyboardToolbarHeight =
+  Platform.OS === 'ios' ? iOSToolbarHeightApprox : androidToolbarHeightApprox;
 interface IMainScrollContainerProps {
   children: ReactNode;
   bg?: string;
@@ -25,6 +31,12 @@ const MainScrollContainer = forwardRef<ScrollView, IMainScrollContainerProps>(
 
     const ViewContainer = keyboardAware ? KeyboardAwareScrollView : ScrollView;
 
+    const viewContainerProps = keyboardAware
+      ? {
+          bottomOffset: keyboardToolbarHeight,
+        }
+      : {};
+
     return (
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -40,6 +52,7 @@ const MainScrollContainer = forwardRef<ScrollView, IMainScrollContainerProps>(
             paddingTop: pt && Spacings[pt],
             flexGrow: 1,
           }}
+          {...viewContainerProps}
         >
           {children}
         </ViewContainer>


### PR DESCRIPTION
### Scroll input fields to be fully visible on keyboard show.
https://betterangels.atlassian.net/browse/DEV-958

Notes:
* getting the toolbar height dynamically is actually really tricky, or at least I wasn't able to find a good way to do it, so just use hard coded defaults for iOS and android
* the `iOSToolbarHeightApprox` and `androidToolbarHeightApprox` are approximate and may differ by device, but we can adjust them up if needbe.

## Summary by Sourcery

New Features:
- Introduce a bottomOffset property to the KeyboardAwareScrollView to ensure input fields are fully visible when the keyboard is shown.