### PR TITLE
Bump BetterAngels to 1.0.25

### DIFF
--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -72,13 +72,17 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     if: needs.prepare.outputs.is_matrix_empty == 'false'
-    concurrency: continuous-deploy-fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     strategy:
       matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
     permissions:
       pull-requests: write # REQUIRED: Allow comments on PRs
       actions: write # REQUIRED: Allow updating fingerprint in action caches
     steps:
+      - name: 🚦 Turnstyle
+        uses: softprops/turnstyle@master
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏗 Check out repo
         uses: actions/checkout@v4
         with:
@@ -227,13 +231,17 @@ jobs:
     needs: prepare
     environment: production
     runs-on: ubuntu-latest
-    concurrency: continuous-deploy-fingerprint-main
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     permissions:
       pull-requests: write # REQUIRED: Allow comments on PRs
       actions: write # REQUIRED: Allow updating fingerprint in action caches
     steps:
+      - name: 🚦 Turnstyle
+        uses: softprops/turnstyle@master
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🏗 Check out repo
         uses: actions/checkout@v4
         with:

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.24',
+    version: '1.0.25',
     orientation: 'portrait',
     icon: './src/app/assets/images/icon.png',
     splash: {
@@ -37,7 +37,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.23', // Does this number reset when you bump the version number?
+      buildNumber: '1.0.24', // Does this number reset when you bump the version number?
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -74,7 +74,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 23, // Does this number reset when you bump the version number?
+      versionCode: 24, // Does this number reset when you bump the version number?
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/apps/betterangels/package.json
+++ b/apps/betterangels/package.json
@@ -80,7 +80,8 @@
     "expo-sharing": "*",
     "@teovilla/react-native-web-maps": "*",
     "react-native-paper": "*",
-    "dotenv": "*"
+    "dotenv": "*",
+    "@react-native-picker/picker": "*"
   },
   "scripts": {
     "eas-build-pre-install": "cd ../../ && node tools/scripts/eas-build-pre-install.mjs . apps/betterangels && cp yarn.lock apps/betterangels && corepack enable",

--- a/apps/betterangels/package.json
+++ b/apps/betterangels/package.json
@@ -79,7 +79,8 @@
     "expo-file-system": "*",
     "expo-sharing": "*",
     "@teovilla/react-native-web-maps": "*",
-    "react-native-paper": "*"
+    "react-native-paper": "*",
+    "dotenv": "*"
   },
   "scripts": {
     "eas-build-pre-install": "cd ../../ && node tools/scripts/eas-build-pre-install.mjs . apps/betterangels && cp yarn.lock apps/betterangels && corepack enable",

--- a/apps/shelter/package.json
+++ b/apps/shelter/package.json
@@ -54,7 +54,8 @@
     "@react-native-async-storage/async-storage": "*",
     "react-native-reanimated": "*",
     "react-native-modal": "*",
-    "react-native-select-dropdown": "*"
+    "react-native-select-dropdown": "*",
+    "react-native-paper": "*"
   },
   "scripts": {
     "eas-build-pre-install": "cd ../../ && node tools/scripts/eas-build-pre-install.mjs . apps/shelter && cp yarn.lock apps/shelter",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@expo/metro-config": "~0.18.11",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.0.1",
+    "@react-native-picker/picker": "2.7.5",
     "@teovilla/react-native-web-maps": "^0.9.5",
     "apollo-link-rest": "^0.9.0",
     "apollo-upload-client": "^18.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4434,6 +4434,7 @@ __metadata:
     "@nxlv/python": "npm:17.0.0"
     "@react-native-async-storage/async-storage": "npm:1.23.1"
     "@react-native-community/datetimepicker": "npm:8.0.1"
+    "@react-native-picker/picker": "npm:2.7.5"
     "@storybook/addon-essentials": "npm:^7.6.20"
     "@storybook/addon-react-native-web": "npm:^0.0.24"
     "@storybook/core-server": "npm:^7.6.20"
@@ -6377,6 +6378,16 @@ __metadata:
     react-native-windows:
       optional: true
   checksum: 10/d6ec07197ad12ca49188c17b5dc5c62626f55381b20f474a36314ce4b8a3705e366244f8a565f38525730834c48dfe59c5b3b5ae17dafc82618ec2a8c05d1b32
+  languageName: node
+  linkType: hard
+
+"@react-native-picker/picker@npm:2.7.5":
+  version: 2.7.5
+  resolution: "@react-native-picker/picker@npm:2.7.5"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10/fb2111753ef46365799e5a7ef0f4a542244788054de4145cb982bd2b15a86daf4e0794503fb69918d7cbcb67e2f9719f984143764ae79d858f6bee9bd6cad473
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary by Sourcery

Bump the BetterAngels app version to 1.0.25 and update package dependencies across multiple package.json files, including adding new dependencies 'dotenv' and '@react-native-picker/picker' to BetterAngels, and 'react-native-paper' to Shelter.

Enhancements:
- Update BetterAngels app version to 1.0.25 in app configuration.
- Add new dependencies 'dotenv' and '@react-native-picker/picker' to BetterAngels package.json.
- Add 'react-native-paper' dependency to Shelter package.json.
- Add '@react-native-picker/picker' dependency to the root package.json.