### PR TITLE
DEV-982 check date exists before formatting

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Profile/PersonalInfo.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Profile/PersonalInfo.tsx
@@ -38,9 +38,19 @@ export default function PersonalInfo(props: IProfileSectionProps) {
     client?.clientProfile.user.lastName ?? ''
   }`.trim();
 
-  const formattedDob = client?.clientProfile.dateOfBirth
-    ? format(client?.clientProfile.dateOfBirth, 'MM/dd/yyyy')
-    : null;
+  const clientDateOfBirth = client?.clientProfile.dateOfBirth;
+  let formattedDob: string | null = '';
+
+  try {
+    if (clientDateOfBirth) {
+      formattedDob = format(clientDateOfBirth, 'MM/dd/yyyy');
+    }
+  } catch (e) {
+    console.warn(
+      `invalid dateOfBirth [${clientDateOfBirth}] for clientProfile ${client?.clientProfile.id}`
+    );
+  }
+
   const clientAge = client?.clientProfile.age;
   const displayDob =
     formattedDob && clientAge ? `${formattedDob} (${clientAge})` : null;

--- a/libs/expo/betterangels/src/lib/screens/Client/Profile/PersonalInfo.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Profile/PersonalInfo.tsx
@@ -39,7 +39,7 @@ export default function PersonalInfo(props: IProfileSectionProps) {
   }`.trim();
 
   const clientDateOfBirth = client?.clientProfile.dateOfBirth;
-  let formattedDob: string | null = '';
+  let formattedDob: string | null = null;
 
   try {
     if (clientDateOfBirth) {

--- a/libs/expo/betterangels/src/lib/screens/Note/NoteTitle.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Note/NoteTitle.tsx
@@ -15,7 +15,8 @@ export default function NoteTitle({
         {note?.purpose}
       </TextBold>
       <TextRegular size="sm" mb="sm">
-        {format(new Date(note?.interactedAt), 'MM/dd/yyyy')}
+        {!!note?.interactedAt &&
+          format(new Date(note?.interactedAt), 'MM/dd/yyyy')}
       </TextRegular>
       {!!note?.team && (
         <>


### PR DESCRIPTION
### Missing client dateOfBirth breaks ui
https://betterangels.atlassian.net/browse/DEV-982

I looked thru code for other implementations of `format` and seemed mostly safe, though may be a good idea to wrap all of them in try/catch cause it can throw for many reasons - https://date-fns.org/v4.1.0/docs/format


## Summary by Sourcery

Add checks for the existence of date fields before formatting to prevent UI issues and potential errors.

Bug Fixes:
- Ensure dateOfBirth is checked for existence before formatting to prevent UI breakage when missing.
- Add a check for the existence of interactedAt date before formatting to avoid potential errors.