### PR TITLE
Remove hmis reference from client search placeholder (DEV-905) (#687)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
@@ -185,7 +185,7 @@ export default function Clients({ Logo }: { Logo: ElementType }) {
           mb="sm"
           icon={<SearchIcon ml="sm" color={Colors.NEUTRAL} />}
           value={search}
-          placeholder="Search by name or HMIS ID"
+          placeholder="Search by name"
           autoCorrect={false}
           onChangeText={onChange}
           onDelete={() => {


### PR DESCRIPTION
### [Clean Up - Clients] Remove "or HMIS ID" from the placeholder text
https://betterangels.atlassian.net/browse/DEV-905

original PR #687 

## Summary by Sourcery

Remove 'or HMIS ID' from the search placeholder text in the Clients screen.