### PR TITLE
Add searchClient to ClientProfiles query to support finding clients with identical names (DEV-912)

### DIFF
--- a/apps/betterangels-backend/clients/tests/test_queries.py
+++ b/apps/betterangels-backend/clients/tests/test_queries.py
@@ -209,8 +209,9 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
     @parametrize(
         ("first_name, last_name, middle_name, expected_client_profile_count"),
         [
-            ("", "", None, 0),  # no filters
-            ("Todd", "", None, 0),  # missing last name
+            ("", "", "", 3),  # no filters
+            ("Todd", None, None, 1),  # exact match on first name only
+            (None, "Chavez", None, 2),  # exact match on last name only
             ("Tod", "Chavez", None, 0),  # inexact match on first name
             ("Todd", "Chave", None, 0),  # inexact match on last name
             ("Todd", "Chavez", "Eleanor", 0),  # inexact match on middle name
@@ -223,9 +224,6 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
     def test_client_profiles_query_search_client(
         self, first_name: str, last_name: str, middle_name: str | None, expected_client_profile_count: int
     ) -> None:
-        """
-        Assert that when using the full name client search, only exact first & last name matches are returned.
-        """
         self.graphql_client.force_login(self.org_1_case_manager_1)
 
         # create a new client with similar name to client 1, with space in first name
@@ -248,10 +246,13 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
             }
         """
 
-        response = self.execute_graphql(
-            query,
-            variables={"searchClient": {"firstName": first_name, "lastName": last_name, "middleName": middle_name}},
-        )
+        search_fields = {
+            **({"firstName": first_name} if first_name else {}),
+            **({"lastName": last_name} if last_name else {}),
+            **({"middleName": middle_name} if middle_name else {}),
+        }
+
+        response = self.execute_graphql(query, variables={"searchClient": search_fields})
 
         client_profiles = response["data"]["clientProfiles"]
         self.assertEqual(len(client_profiles), expected_client_profile_count)

--- a/apps/betterangels-backend/clients/tests/test_queries.py
+++ b/apps/betterangels-backend/clients/tests/test_queries.py
@@ -220,7 +220,7 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
             ("Todd Gustav", "Chavez", None, 1),  # exact match on first & last name
         ],
     )
-    def test_client_profiles_query_full_name_search(
+    def test_client_profiles_query_search_client(
         self, first_name: str, last_name: str, middle_name: str | None, expected_client_profile_count: int
     ) -> None:
         """
@@ -241,8 +241,8 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
         )
 
         query = """
-            query ClientProfiles($fullNameSearch: UserSearchInput) {
-                clientProfiles(filters: {fullNameSearch: $fullNameSearch}) {
+            query ClientProfiles($searchClient: ClientSearchInput) {
+                clientProfiles(filters: {searchClient: $searchClient}) {
                     id
                 }
             }
@@ -250,7 +250,7 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
 
         response = self.execute_graphql(
             query,
-            variables={"fullNameSearch": {"firstName": first_name, "lastName": last_name, "middleName": middle_name}},
+            variables={"searchClient": {"firstName": first_name, "lastName": last_name, "middleName": middle_name}},
         )
 
         client_profiles = response["data"]["clientProfiles"]

--- a/apps/betterangels-backend/clients/tests/test_queries.py
+++ b/apps/betterangels-backend/clients/tests/test_queries.py
@@ -209,7 +209,7 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
     @parametrize(
         ("first_name, last_name, middle_name, expected_client_profile_count"),
         [
-            ("", "", "", 3),  # no filters
+            (" ", " ", " ", 0),  # no filters
             ("Todd", None, None, 1),  # exact match on first name only
             (None, "Chavez", None, 2),  # exact match on last name only
             ("Tod", "Chavez", None, 0),  # inexact match on first name

--- a/apps/betterangels-backend/clients/types.py
+++ b/apps/betterangels-backend/clients/types.py
@@ -130,8 +130,11 @@ class ClientProfileFilter:
         user_fields = ["first_name", "middle_name", "last_name"]
 
         for field in user_fields:
-            if field_value := getattr(value, field):
-                filters[f"user__{field}__iexact"] = field_value.strip()
+            if field_value := (getattr(value, field) or "").strip():
+                filters[f"user__{field}__iexact"] = field_value
+
+        if not filters:
+            return (queryset.none(), Q())
 
         queryset = queryset.filter(**filters)
 

--- a/apps/betterangels-backend/clients/types.py
+++ b/apps/betterangels-backend/clients/types.py
@@ -57,7 +57,7 @@ class ClientProfileOrder:
 
 
 @strawberry.input
-class UserSearchInput:
+class ClientSearchInput:
     first_name: str
     last_name: str
     middle_name: str | None = None
@@ -114,11 +114,11 @@ class ClientProfileFilter:
         return (queryset, Q())
 
     @strawberry_django.filter_field
-    def full_name_search(
+    def search_client(
         self,
         queryset: QuerySet,
         info: Info,
-        value: UserSearchInput,
+        value: ClientSearchInput,
         prefix: str,
     ) -> Tuple[QuerySet[ClientProfile], Q]:
         """

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -152,7 +152,7 @@ input ClientProfileFilter {
   DISTINCT: Boolean
   isActive: Boolean
   search: String
-  fullNameSearch: UserSearchInput
+  searchClient: ClientSearchInput
 }
 
 input ClientProfileOrder {
@@ -208,6 +208,12 @@ type ClientProfileType {
   otherDocuments(pagination: OffsetPaginationInput): [ClientDocumentType!]
   user: UserType!
   displayCaseManager: String!
+}
+
+input ClientSearchInput {
+  firstName: String!
+  lastName: String!
+  middleName: String = null
 }
 
 input CreateClientDocumentInput {
@@ -1045,12 +1051,6 @@ input UpdateUserInput {
 }
 
 scalar Upload
-
-input UserSearchInput {
-  firstName: String!
-  lastName: String!
-  middleName: String = null
-}
 
 type UserType {
   firstName: String

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -152,6 +152,7 @@ input ClientProfileFilter {
   DISTINCT: Boolean
   isActive: Boolean
   search: String
+  fullNameSearch: String
 }
 
 input ClientProfileOrder {

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -152,7 +152,7 @@ input ClientProfileFilter {
   DISTINCT: Boolean
   isActive: Boolean
   search: String
-  fullNameSearch: String
+  fullNameSearch: UserSearchInput
 }
 
 input ClientProfileOrder {
@@ -1045,6 +1045,12 @@ input UpdateUserInput {
 }
 
 scalar Upload
+
+input UserSearchInput {
+  firstName: String!
+  lastName: String!
+  middleName: String = null
+}
 
 type UserType {
   firstName: String

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -211,8 +211,8 @@ type ClientProfileType {
 }
 
 input ClientSearchInput {
-  firstName: String!
-  lastName: String!
+  firstName: String = null
+  lastName: String = null
   middleName: String = null
 }
 

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -178,6 +178,7 @@ export type ClientProfileType = {
   adaAccommodation?: Maybe<Array<AdaAccommodationEnum>>;
   address?: Maybe<Scalars['String']['output']>;
   age?: Maybe<Scalars['Int']['output']>;
+  californiaId?: Maybe<Scalars['String']['output']>;
   consentFormDocuments?: Maybe<Array<ClientDocumentType>>;
   contacts?: Maybe<Array<ClientContactType>>;
   dateOfBirth?: Maybe<Scalars['Date']['output']>;
@@ -233,8 +234,8 @@ export type ClientProfileTypeOtherDocumentsArgs = {
 };
 
 export type ClientSearchInput = {
-  firstName: Scalars['String']['input'];
-  lastName: Scalars['String']['input'];
+  firstName?: InputMaybe<Scalars['String']['input']>;
+  lastName?: InputMaybe<Scalars['String']['input']>;
   middleName?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -250,6 +251,7 @@ export type CreateClientProfileInput = {
   adaAccommodation?: InputMaybe<Array<AdaAccommodationEnum>>;
   address?: InputMaybe<Scalars['String']['input']>;
   age?: InputMaybe<Scalars['Int']['input']>;
+  californiaId?: InputMaybe<Scalars['String']['input']>;
   contacts?: InputMaybe<Array<ClientContactInput>>;
   dateOfBirth?: InputMaybe<Scalars['Date']['input']>;
   eyeColor?: InputMaybe<EyeColorEnum>;
@@ -1235,6 +1237,7 @@ export type UpdateClientProfileInput = {
   adaAccommodation?: InputMaybe<Array<AdaAccommodationEnum>>;
   address?: InputMaybe<Scalars['String']['input']>;
   age?: InputMaybe<Scalars['Int']['input']>;
+  californiaId?: InputMaybe<Scalars['String']['input']>;
   contacts?: InputMaybe<Array<ClientContactInput>>;
   dateOfBirth?: InputMaybe<Scalars['Date']['input']>;
   eyeColor?: InputMaybe<EyeColorEnum>;

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -157,7 +157,7 @@ export type ClientProfileFilter = {
   DISTINCT?: InputMaybe<Scalars['Boolean']['input']>;
   NOT?: InputMaybe<ClientProfileFilter>;
   OR?: InputMaybe<ClientProfileFilter>;
-  fullNameSearch?: InputMaybe<Scalars['String']['input']>;
+  fullNameSearch?: InputMaybe<UserSearchInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1325,6 +1325,12 @@ export type UpdateUserInput = {
   hasAcceptedTos?: InputMaybe<Scalars['Boolean']['input']>;
   id: Scalars['ID']['input'];
   lastName?: InputMaybe<Scalars['String']['input']>;
+  middleName?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UserSearchInput = {
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
   middleName?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -157,9 +157,9 @@ export type ClientProfileFilter = {
   DISTINCT?: InputMaybe<Scalars['Boolean']['input']>;
   NOT?: InputMaybe<ClientProfileFilter>;
   OR?: InputMaybe<ClientProfileFilter>;
-  fullNameSearch?: InputMaybe<UserSearchInput>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
+  searchClient?: InputMaybe<ClientSearchInput>;
 };
 
 export type ClientProfileOrder = {
@@ -230,6 +230,12 @@ export type ClientProfileTypeDocReadyDocumentsArgs = {
 
 export type ClientProfileTypeOtherDocumentsArgs = {
   pagination?: InputMaybe<OffsetPaginationInput>;
+};
+
+export type ClientSearchInput = {
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  middleName?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateClientDocumentInput = {
@@ -1325,12 +1331,6 @@ export type UpdateUserInput = {
   hasAcceptedTos?: InputMaybe<Scalars['Boolean']['input']>;
   id: Scalars['ID']['input'];
   lastName?: InputMaybe<Scalars['String']['input']>;
-  middleName?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type UserSearchInput = {
-  firstName: Scalars['String']['input'];
-  lastName: Scalars['String']['input'];
   middleName?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -157,6 +157,7 @@ export type ClientProfileFilter = {
   DISTINCT?: InputMaybe<Scalars['Boolean']['input']>;
   NOT?: InputMaybe<ClientProfileFilter>;
   OR?: InputMaybe<ClientProfileFilter>;
+  fullNameSearch?: InputMaybe<Scalars['String']['input']>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   search?: InputMaybe<Scalars['String']['input']>;
 };
@@ -850,7 +851,7 @@ export type NoteTypeRequestedServicesArgs = {
 };
 
 export type OffsetPaginationInput = {
-  limit?: Scalars['Int']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: Scalars['Int']['input'];
 };
 


### PR DESCRIPTION
https://betterangels.atlassian.net/browse/DEV-912

Adds a new search filter: `searchClient` to `ClientProfiles` query. 


Example usage: 
```
        query = """
            query ClientProfiles($searchClient: ClientSearchInput) {
                clientProfiles(filters: {searchClient: $searchClient}) {
                    id
                }
            }
        """

        response = self.execute_graphql(
            query,
            variables={"searchClient": {"firstName":"Marc Anthony", "lastName": "Ramirez"},
        )
```


## Summary by Sourcery

Add a full name search feature to the ClientProfiles query to enable deduplication of clients with identical names, and implement corresponding tests to validate the functionality.

New Features:
- Introduce a full name search feature in the ClientProfiles query to allow deduplication of clients with identical names.

Tests:
- Add tests for the new full name search feature in the ClientProfiles query to ensure it returns only exact matches on first and last names.
