### PR TITLE
Add paginated version of notes, clientProfiles, clientDocuments queries (DEV-988)

### DIFF
--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, cast
+from strawberry_django.pagination import OffsetPaginated
 
 import strawberry
 import strawberry_django
@@ -135,6 +136,10 @@ class Query:
         return cast(ClientProfileType, client_profile)
 
     client_profiles: List[ClientProfileType] = strawberry_django.field(
+        extensions=[HasRetvalPerm(perms=[ClientProfilePermissions.VIEW])],
+    )
+
+    client_profiles_paginated: OffsetPaginated[ClientProfileType] = strawberry_django.offset_paginated(
         extensions=[HasRetvalPerm(perms=[ClientProfilePermissions.VIEW])],
     )
 

--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, List, cast
-from strawberry_django.pagination import OffsetPaginated
 
 import strawberry
 import strawberry_django
@@ -20,6 +19,7 @@ from strawberry.types import Info
 from strawberry_django import mutations
 from strawberry_django.auth.utils import get_current_user
 from strawberry_django.mutations import resolvers
+from strawberry_django.pagination import OffsetPaginated
 from strawberry_django.permissions import HasPerm, HasRetvalPerm
 from strawberry_django.utils.query import filter_for_user
 

--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -151,6 +151,10 @@ class Query:
         extensions=[HasRetvalPerm(AttachmentPermissions.VIEW)],
     )
 
+    client_documents_paginated: OffsetPaginated[ClientDocumentType] = strawberry_django.offset_paginated(
+        extensions=[HasRetvalPerm(AttachmentPermissions.VIEW)],
+    )
+
 
 @strawberry.type
 class Mutation:

--- a/apps/betterangels-backend/clients/tests/test_queries.py
+++ b/apps/betterangels-backend/clients/tests/test_queries.py
@@ -360,6 +360,10 @@ class ClientDocumentQueryTestCase(ClientProfileGraphQLBaseTestCase):
         )
 
     def test_client_documents_query(self) -> None:
+        """
+        NOTE: This query is deprecated in favor of clientDocumentsPaginated
+        """
+
         self.graphql_client.force_login(self.org_1_case_manager_1)
         query = """
             query ViewClientDocuments {
@@ -378,6 +382,37 @@ class ClientDocumentQueryTestCase(ClientProfileGraphQLBaseTestCase):
 
         self.assertEqual(
             response["data"]["clientDocuments"],
+            [
+                self.client_profile_1_document_1,
+                self.client_profile_1_document_2,
+                self.client_profile_1_document_3,
+                self.client_profile_1_document_4,
+            ],
+        )
+
+    def test_client_documents_paginated_query(self) -> None:
+        self.graphql_client.force_login(self.org_1_case_manager_1)
+        query = """
+            query ViewClientDocuments {
+                clientDocuments: clientDocumentsPaginated {
+                    totalCount
+                    results {
+                        id
+                        file {
+                            name
+                        }
+                        attachmentType
+                        originalFilename
+                        namespace
+                    }
+                }
+            }
+        """
+        response = self.execute_graphql(query)
+
+        self.assertEqual(response["data"]["clientDocuments"]["totalCount"], 4)
+        self.assertEqual(
+            response["data"]["clientDocuments"]["results"],
             [
                 self.client_profile_1_document_1,
                 self.client_profile_1_document_2,

--- a/apps/betterangels-backend/clients/tests/test_queries.py
+++ b/apps/betterangels-backend/clients/tests/test_queries.py
@@ -146,10 +146,10 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables={"offset": 0, "limit": 10})
 
-        client_profiles = response["data"]["clientProfiles"]
+        client_profiles_data = response["data"]["clientProfiles"]
         client_profile_count = ClientProfile.objects.count()
-        self.assertEqual(client_profiles["totalCount"], client_profile_count)
-        self.assertEqual(client_profiles["pageInfo"], {"limit": 10, "offset": 0})
+        self.assertEqual(client_profiles_data["totalCount"], client_profile_count)
+        self.assertEqual(client_profiles_data["pageInfo"], {"limit": 10, "offset": 0})
 
     @parametrize(
         ("sort_order, expected_first_name"),
@@ -173,9 +173,10 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables={"order": {"user_FirstName": sort_order}})
 
+        self.assertEqual(response["data"]["clientProfiles"]["totalCount"], ClientProfile.objects.count())
+
         client_profiles = response["data"]["clientProfiles"]["results"]
         self.assertEqual(client_profiles[0]["user"]["firstName"], expected_first_name)
-        self.assertEqual(response["data"]["clientProfiles"]["totalCount"], ClientProfile.objects.count())
 
     @parametrize(
         ("search_value, is_active, expected_client_profile_count"),

--- a/apps/betterangels-backend/notes/schema.py
+++ b/apps/betterangels-backend/notes/schema.py
@@ -1,6 +1,5 @@
 from typing import Dict, List, cast
 
-from strawberry_django.pagination import OffsetPaginated
 import pghistory
 import strawberry
 import strawberry_django
@@ -29,6 +28,7 @@ from strawberry.types import Info
 from strawberry_django import mutations
 from strawberry_django.auth.utils import get_current_user
 from strawberry_django.mutations import resolvers
+from strawberry_django.pagination import OffsetPaginated
 from strawberry_django.permissions import HasPerm, HasRetvalPerm
 from strawberry_django.utils.query import filter_for_user
 

--- a/apps/betterangels-backend/notes/schema.py
+++ b/apps/betterangels-backend/notes/schema.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, cast
 
+from strawberry_django.pagination import OffsetPaginated
 import pghistory
 import strawberry
 import strawberry_django
@@ -62,6 +63,10 @@ class Query:
     note: NoteType = strawberry_django.field(extensions=[HasRetvalPerm(NotePermissions.VIEW)], filters=NoteFilter)
 
     notes: List[NoteType] = strawberry_django.field(
+        extensions=[HasRetvalPerm(NotePermissions.VIEW)],
+    )
+
+    notes_paginated: OffsetPaginated[NoteType] = strawberry_django.offset_paginated(
         extensions=[HasRetvalPerm(NotePermissions.VIEW)],
     )
 

--- a/apps/betterangels-backend/notes/tests/test_mutations.py
+++ b/apps/betterangels-backend/notes/tests/test_mutations.py
@@ -523,6 +523,24 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
     def setUp(self) -> None:
         super().setUp()
         self._handle_user_login("org_1_case_manager_1")
+        self.task_note_fields = """
+            purposes {
+                id
+                title
+            }
+            nextSteps {
+                id
+                title
+            }
+        """
+        self.service_note_fields = """
+            providedServices {
+                id
+            }
+            requestedServices {
+                id
+            }
+        """
 
     def test_revert_note_mutation_restores_note_details_to_creation(self) -> None:
         """
@@ -555,10 +573,18 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         )
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
+        note_fields = """
+            purpose
+            title
+            publicDetails
+            location {
+                id
+            }
+        """
 
-        expected_query_count = 34
+        expected_query_count = 29
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["purpose"], "Session with Dale Cooper")
         self.assertEqual(reverted_note["title"], "Session with Dale Cooper")
@@ -569,9 +595,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         revert_before_timestamp = timezone.now()
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
-        expected_query_count = 19
+        expected_query_count = 14
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["purpose"], "Session with Dale Cooper")
         self.assertEqual(reverted_note["title"], "Session with Dale Cooper")
@@ -621,9 +647,19 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         )
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
-        expected_query_count = 36
+        note_fields = """
+            purpose
+            title
+            publicDetails
+            location {
+                address {
+                    street
+                }
+            }
+        """
+        expected_query_count = 31
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["purpose"], "Updated purpose")
         self.assertEqual(reverted_note["title"], "Updated Title")
@@ -634,9 +670,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         revert_before_timestamp = timezone.now()
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
-        expected_query_count = 31
+        expected_query_count = 26
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["purpose"], "Updated purpose")
         self.assertEqual(reverted_note["title"], "Updated Title")
@@ -685,6 +721,15 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
             "id": note_id,
             "location": location,
         }
+        note_fields = """
+            location {
+                address {
+                    street
+                }
+                point
+                pointOfInterest
+            }
+        """
 
         # Update - should be discarded
         note_location_to_discard = self._update_note_location_fixture(variables)["data"]["updateNoteLocation"]
@@ -695,9 +740,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self.assertEqual(discarded_point, note_location_to_discard["location"]["point"])
         self.assertEqual(discarded_point_of_interest, note_location_to_discard["location"]["pointOfInterest"])
 
-        expected_query_count = 26
+        expected_query_count = 21
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["location"]["address"]["street"], self.street)
         self.assertEqual(reverted_note["location"]["point"], self.point)
@@ -725,10 +770,15 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self._create_note_mood_fixture({"descriptor": "EUTHYMIC", "noteId": note_id})
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
+        note_fields = """
+            moods {
+                descriptor
+            }
+        """
 
-        expected_query_count = 24
+        expected_query_count = 20
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["moods"]), 1)
 
@@ -757,10 +807,15 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self._delete_mood_fixture(mood_id=mood_to_delete_id)
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
+        note_fields = """
+            moods {
+                descriptor
+            }
+        """
 
-        expected_query_count = 31
+        expected_query_count = 27
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["moods"]), 2)
 
@@ -826,9 +881,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Revert to revert_before_timestamp state
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
-        expected_query_count = 41
+        expected_query_count = 38
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.task_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["purposes"]), 1)
         self.assertEqual(len(reverted_note["nextSteps"]), 1)
@@ -897,7 +952,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
 
         expected_query_count = 27
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.task_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["purposes"]), 1)
         self.assertEqual(len(reverted_note["nextSteps"]), 1)
@@ -976,9 +1031,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Revert to revert_before_timestamp state
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
-        expected_query_count = 41
+        expected_query_count = 38
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.service_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["providedServices"]), 1)
         self.assertEqual(len(reverted_note["requestedServices"]), 1)
@@ -1057,9 +1112,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Revert to revert_before_timestamp state
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
-        expected_query_count = 41
+        expected_query_count = 38
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.service_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["providedServices"]), 1)
         self.assertEqual(len(reverted_note["requestedServices"]), 1)
@@ -1125,9 +1180,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Revert to revert_before_timestamp state
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
-        expected_query_count = 53
+        expected_query_count = 50
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.task_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["purposes"]), 2)
         self.assertEqual(len(reverted_note["nextSteps"]), 2)
@@ -1213,7 +1268,7 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
 
         expected_query_count = 27
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.task_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["purposes"]), 2)
         self.assertEqual(len(reverted_note["nextSteps"]), 2)
@@ -1293,9 +1348,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
-        expected_query_count = 53
+        expected_query_count = 50
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.service_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["providedServices"]), 2)
         self.assertEqual(len(reverted_note["requestedServices"]), 2)
@@ -1375,9 +1430,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
-        expected_query_count = 53
+        expected_query_count = 50
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.service_note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(reverted_note["providedServices"]), 2)
         self.assertEqual(len(reverted_note["requestedServices"]), 2)
@@ -1428,9 +1483,9 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         # Revert to revert_before_timestamp state
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
 
-        expected_query_count = 27
+        expected_query_count = 24
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, self.task_note_fields)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["purposes"][0]["title"], "Purpose Title")
         self.assertEqual(reverted_note["nextSteps"][0]["title"], "Next Step Title")
@@ -1481,10 +1536,26 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
 
         # Revert to revert_before_timestamp state
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
+        note_fields = """
+            nextSteps {
+                id
+                title
+                location {
+                    address {
+                        street
+                        city
+                        state
+                        zipCode
+                    }
+                    point
+                    pointOfInterest
+                }
+            }
+        """
 
-        expected_query_count = 24
+        expected_query_count = 20
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         next_step = reverted_note["nextSteps"][0]
         self.assertEqual(next_step["location"]["address"]["street"], self.street)
@@ -1544,10 +1615,22 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         )
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
+        note_fields = """
+            providedServices {
+                id
+                serviceOther
+                customService
+            }
+            requestedServices {
+                id
+                status
+                dueBy
+            }
+        """
 
-        expected_query_count = 27
+        expected_query_count = 24
         with self.assertNumQueriesWithoutCache(expected_query_count):
-            reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(reverted_note["providedServices"][0]["serviceOther"], "Other Provided Service")
         self.assertEqual(reverted_note["providedServices"][0]["customService"], "Other Provided Service")
@@ -1569,9 +1652,15 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin,
         self._create_note_mood_fixture({"descriptor": "ANXIOUS", "noteId": note_id})
 
         variables = {"id": note_id, "revertBeforeTimestamp": revert_before_timestamp}
+        note_fields = """
+            title
+            moods {
+                descriptor
+            }
+        """
 
         with patch("notes.models.Mood.revert_action", side_effect=Exception("oops")):
-            not_reverted_note = self._revert_note_fixture(variables)["data"]["revertNote"]
+            not_reverted_note = self._revert_note_fixture(variables, note_fields)["data"]["revertNote"]
 
         self.assertEqual(len(not_reverted_note["moods"]), 1)
         self.assertEqual(not_reverted_note["title"], "Discarded Title")

--- a/apps/betterangels-backend/notes/tests/test_queries.py
+++ b/apps/betterangels-backend/notes/tests/test_queries.py
@@ -4,7 +4,13 @@ import time_machine
 from deepdiff import DeepDiff
 from django.test import ignore_warnings, override_settings
 from django.utils import timezone
-from notes.enums import DueByGroupEnum, NoteNamespaceEnum, SelahTeamEnum, ServiceEnum, ServiceRequestStatusEnum
+from notes.enums import (
+    DueByGroupEnum,
+    NoteNamespaceEnum,
+    SelahTeamEnum,
+    ServiceEnum,
+    ServiceRequestStatusEnum,
+)
 from notes.models import Note
 from notes.tests.utils import (
     NoteGraphQLBaseTestCase,
@@ -54,12 +60,6 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
         query = f"""
             query ViewNote($id: ID!) {{
                 note(pk: $id) {{
-                    client {{
-                        id
-                    }}
-                    createdBy {{
-                        id
-                    }}
                     {self.note_fields}
                 }}
             }}
@@ -144,6 +144,10 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
         self.assertFalse(note_differences)
 
     def test_notes_query(self) -> None:
+        """
+        NOTE: This query is deprecated in favor of notesPaginated
+        """
+
         query = f"""
             query ViewNotes {{
                 notes {{
@@ -157,6 +161,32 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
 
         notes = response["data"]["notes"]
         self.assertEqual(len(notes), 1)
+        note_differences = DeepDiff(self.note, notes[0], ignore_order=True)
+        self.assertFalse(note_differences)
+
+    def test_notes_paginated_query(self) -> None:
+        query = f"""
+            query ViewNotes($offset: Int, $limit: Int) {{
+                notes: notesPaginated(pagination: {{offset: $offset, limit: $limit}}) {{
+                    totalCount
+                    pageInfo {{
+                        limit
+                        offset
+                    }}
+                    results {{
+                        {self.note_fields}
+                    }}
+                }}
+            }}
+        """
+        expected_query_count = 9
+        with self.assertNumQueriesWithoutCache(expected_query_count):
+            response = self.execute_graphql(query, variables={"offset": 0, "limit": 10})
+
+        self.assertEqual(response["data"]["notes"]["totalCount"], 1)
+        self.assertEqual(response["data"]["notes"]["pageInfo"], {"limit": 10, "offset": 0})
+
+        notes = response["data"]["notes"]["results"]
         # TODO: Add more validations once sort is implemented
         note_differences = DeepDiff(self.note, notes[0], ignore_order=True)
         self.assertFalse(note_differences)
@@ -216,8 +246,11 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
 
         query = """
             query Notes($filters: NoteFilter) {
-                notes(filters: $filters) {
-                    id
+                notes: notesPaginated(filters: $filters) {
+                    totalCount
+                    results{
+                        id
+                    }
                 }
             }
         """
@@ -236,12 +269,12 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
         if is_submitted is not None:
             filters["isSubmitted"] = is_submitted
 
-        expected_query_count = 3
+        expected_query_count = 4
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables={"filters": filters})
 
-        notes = response["data"]["notes"]
-        self.assertEqual(len(notes), expected_results_count)
+        self.assertEqual(response["data"]["notes"]["totalCount"], expected_results_count)
+        notes = response["data"]["notes"]["results"]
 
         if returned_note_label_1:
             self.assertEqual(notes[0]["id"], getattr(self, returned_note_label_1)["id"])
@@ -275,8 +308,10 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
 
         query = """
             query Notes($order: NoteOrder) {
-                notes(order: $order) {
-                    id
+                notes: notesPaginated(order: $order) {
+                    results{
+                        id
+                    }
                 }
             }
         """
@@ -287,7 +322,8 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
             response = self.execute_graphql(query, variables={"order": {"interactedAt": "DESC"}})
 
         self.assertEqual(
-            [n["id"] for n in response["data"]["notes"]], [self.note["id"], older_note["id"], oldest_note["id"]]
+            [n["id"] for n in response["data"]["notes"]["results"]],
+            [self.note["id"], older_note["id"], oldest_note["id"]],
         )
 
         # Test ascending order
@@ -295,7 +331,8 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
             response = self.execute_graphql(query, variables={"order": {"interactedAt": "ASC"}})
 
         self.assertEqual(
-            [n["id"] for n in response["data"]["notes"]], [oldest_note["id"], older_note["id"], self.note["id"]]
+            [n["id"] for n in response["data"]["notes"]["results"]],
+            [oldest_note["id"], older_note["id"], self.note["id"]],
         )
 
 

--- a/apps/betterangels-backend/notes/tests/utils.py
+++ b/apps/betterangels-backend/notes/tests/utils.py
@@ -189,12 +189,12 @@ class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
         """
         return self.execute_graphql(mutation, {"data": variables})
 
-    def _revert_note_fixture(self, variables: Dict[str, Any]) -> Dict[str, Any]:
+    def _revert_note_fixture(self, variables: Dict[str, Any], note_fields: str) -> Dict[str, Any]:
         mutation = f"""
             mutation RevertNote($data: RevertNoteInput!) {{
                 revertNote(data: $data) {{
                     ... on NoteType {{
-                        {self.note_fields}
+                        {note_fields}
                     }}
                 }}
             }}

--- a/apps/betterangels-backend/notes/tests/utils.py
+++ b/apps/betterangels-backend/notes/tests/utils.py
@@ -14,6 +14,12 @@ class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
         super().setUp()
         self.note_fields = """
             id
+            client {
+                id
+            }
+            createdBy {
+                id
+            }
             interactedAt
             isSubmitted
             privateDetails
@@ -161,54 +167,6 @@ class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
                 }}
             }}
         """
-        # id
-        # interactedAt
-        # isSubmitted
-        # privateDetails
-        # publicDetails
-        # purpose
-        # team
-        # title
-        # client {{
-        #     id
-        # }}
-        # createdBy {{
-        #     id
-        # }}
-        # location {{
-        #     id
-        #     address {{
-        #         street
-        #         city
-        #         state
-        #         zipCode
-        #     }}
-        #     point
-        #     pointOfInterest
-        # }}
-        # moods {{
-        #     descriptor
-        # }}
-        # purposes {{
-        #     id
-        #     title
-        # }}
-        # nextSteps {{
-        #     id
-        #     title
-        # }}
-        # providedServices {{
-        #     id
-        #     service
-        #     serviceOther
-        #     customService
-        # }}
-        # requestedServices {{
-        #     id
-        #     service
-        #     serviceOther
-        #     customService
-        # }}
         return self.execute_graphql(mutation, {"data": variables})
 
     def _create_task_for_note_fixture(self, variables: Dict[str, Any]) -> Dict[str, Any]:

--- a/apps/betterangels-backend/notes/tests/utils.py
+++ b/apps/betterangels-backend/notes/tests/utils.py
@@ -12,6 +12,64 @@ from test_utils.mixins import HasGraphQLProtocol
 class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.note_fields = """
+            id
+            interactedAt
+            isSubmitted
+            privateDetails
+            publicDetails
+            purpose
+            team
+            title
+            location {
+                id
+                address {
+                    street
+                    city
+                    state
+                    zipCode
+                }
+                point
+                pointOfInterest
+            }
+            moods {
+                descriptor
+            }
+            purposes {
+                id
+                title
+            }
+            nextSteps {
+                id
+                title
+                location {
+                    address {
+                        street
+                        city
+                        state
+                        zipCode
+                    }
+                    point
+                    pointOfInterest
+                }
+            }
+            providedServices {
+                id
+                service
+                serviceOther
+                customService
+                dueBy
+                status
+            }
+            requestedServices {
+                id
+                service
+                serviceOther
+                customService
+                dueBy
+                status
+            }
+        """
         self._setup_note()
         self._setup_note_tasks()
         self._setup_location()
@@ -98,58 +156,59 @@ class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
                         }}
                     }}
                     ... on NoteType {{
-                        id
-                        interactedAt
-                        isSubmitted
-                        privateDetails
-                        publicDetails
-                        purpose
-                        team
-                        title
-                        client {{
-                            id
-                        }}
-                        createdBy {{
-                            id
-                        }}
-                        location {{
-                            id
-                            address {{
-                                street
-                                city
-                                state
-                                zipCode
-                            }}
-                            point
-                            pointOfInterest
-                        }}
-                        moods {{
-                            descriptor
-                        }}
-                        purposes {{
-                            id
-                            title
-                        }}
-                        nextSteps {{
-                            id
-                            title
-                        }}
-                        providedServices {{
-                            id
-                            service
-                            serviceOther
-                            customService
-                        }}
-                        requestedServices {{
-                            id
-                            service
-                            serviceOther
-                            customService
-                        }}
+                        {self.note_fields}
                     }}
                 }}
             }}
         """
+        # id
+        # interactedAt
+        # isSubmitted
+        # privateDetails
+        # publicDetails
+        # purpose
+        # team
+        # title
+        # client {{
+        #     id
+        # }}
+        # createdBy {{
+        #     id
+        # }}
+        # location {{
+        #     id
+        #     address {{
+        #         street
+        #         city
+        #         state
+        #         zipCode
+        #     }}
+        #     point
+        #     pointOfInterest
+        # }}
+        # moods {{
+        #     descriptor
+        # }}
+        # purposes {{
+        #     id
+        #     title
+        # }}
+        # nextSteps {{
+        #     id
+        #     title
+        # }}
+        # providedServices {{
+        #     id
+        #     service
+        #     serviceOther
+        #     customService
+        # }}
+        # requestedServices {{
+        #     id
+        #     service
+        #     serviceOther
+        #     customService
+        # }}
         return self.execute_graphql(mutation, {"data": variables})
 
     def _create_task_for_note_fixture(self, variables: Dict[str, Any]) -> Dict[str, Any]:
@@ -173,68 +232,14 @@ class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
         return self.execute_graphql(mutation, {"data": variables})
 
     def _revert_note_fixture(self, variables: Dict[str, Any]) -> Dict[str, Any]:
-        mutation = """
-            mutation RevertNote($data: RevertNoteInput!) {
-                revertNote(data: $data) {
-                    ... on NoteType {
-                        id
-                        interactedAt
-                        isSubmitted
-                        privateDetails
-                        publicDetails
-                        purpose
-                        team
-                        title
-                        location {
-                            address {
-                                street
-                                city
-                                state
-                                zipCode
-                            }
-                            point
-                            pointOfInterest
-                        }
-                        moods {
-                            descriptor
-                        }
-                        purposes {
-                            id
-                            title
-                        }
-                        nextSteps {
-                            id
-                            title
-                            location {
-                                address {
-                                    street
-                                    city
-                                    state
-                                    zipCode
-                                }
-                                point
-                                pointOfInterest
-                            }
-                        }
-                        providedServices {
-                            id
-                            service
-                            serviceOther
-                            customService
-                            dueBy
-                            status
-                        }
-                        requestedServices {
-                            id
-                            service
-                            serviceOther
-                            customService
-                            dueBy
-                            status
-                        }
-                    }
-                }
-            }
+        mutation = f"""
+            mutation RevertNote($data: RevertNoteInput!) {{
+                revertNote(data: $data) {{
+                    ... on NoteType {{
+                        {self.note_fields}
+                    }}
+                }}
+            }}
         """
         return self.execute_graphql(mutation, {"data": variables})
 

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -210,6 +210,16 @@ type ClientProfileType {
   displayCaseManager: String!
 }
 
+type ClientProfileTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [ClientProfileType!]!
+}
+
 input ClientSearchInput {
   excludedClientProfileId: String = null
   californiaId: String = null
@@ -647,6 +657,11 @@ type NoteType {
   privateDetails: String
 }
 
+type OffsetPaginationInfo {
+  offset: Int!
+  limit: Int
+}
+
 input OffsetPaginationInput {
   offset: Int! = 0
   limit: Int = null
@@ -736,6 +751,7 @@ enum PronounEnum {
 type Query {
   currentUser: UserType!
   clientProfiles(filters: ClientProfileFilter, order: ClientProfileOrder, pagination: OffsetPaginationInput): [ClientProfileType!]! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)
+  clientProfilesPaginated(pagination: OffsetPaginationInput, filters: ClientProfileFilter, order: ClientProfileOrder): ClientProfileTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)
   clientDocument(pk: ID!): ClientDocumentType! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
   clientDocuments(pagination: OffsetPaginationInput): [ClientDocumentType!]! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
   clientProfile(pk: ID!): ClientProfileType! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -123,6 +123,16 @@ type ClientDocumentType implements AttachmentInterface {
   namespace: ClientDocumentNamespaceEnum!
 }
 
+type ClientDocumentTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [ClientDocumentType!]!
+}
+
 input ClientHouseholdMemberInput {
   name: String
   dateOfBirth: Date
@@ -657,6 +667,16 @@ type NoteType {
   privateDetails: String
 }
 
+type NoteTypeOffsetPaginated {
+  pageInfo: OffsetPaginationInfo!
+
+  """Total count of existing results."""
+  totalCount: Int!
+
+  """List of paginated results."""
+  results: [NoteType!]!
+}
+
 type OffsetPaginationInfo {
   offset: Int!
   limit: Int
@@ -754,10 +774,12 @@ type Query {
   clientProfilesPaginated(pagination: OffsetPaginationInput, filters: ClientProfileFilter, order: ClientProfileOrder): ClientProfileTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)
   clientDocument(pk: ID!): ClientDocumentType! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
   clientDocuments(pagination: OffsetPaginationInput): [ClientDocumentType!]! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
+  clientDocumentsPaginated(pagination: OffsetPaginationInput): ClientDocumentTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
   clientProfile(pk: ID!): ClientProfileType! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)
   featureControls: FeatureControlData!
   note(pk: ID!): NoteType! @hasRetvalPerm(permissions: [{app: "notes", permission: "view_note"}], any: true)
   notes(filters: NoteFilter, order: NoteOrder, pagination: OffsetPaginationInput): [NoteType!]! @hasRetvalPerm(permissions: [{app: "notes", permission: "view_note"}], any: true)
+  notesPaginated(pagination: OffsetPaginationInput, filters: NoteFilter, order: NoteOrder): NoteTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "notes", permission: "view_note"}], any: true)
   noteAttachment(pk: ID!): NoteAttachmentType! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
   noteAttachments(filters: NoteAttachmentFilter, pagination: OffsetPaginationInput): [NoteAttachmentType!]! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
   serviceRequest(pk: ID!): ServiceRequestType! @hasRetvalPerm(permissions: [{app: "notes", permission: "view_servicerequest"}], any: true)


### PR DESCRIPTION
https://betterangels.atlassian.net/browse/DEV-988

## Summary by Sourcery

Implement paginated versions of the notes, clientProfiles, and clientDocuments queries to enhance data retrieval efficiency. Refactor existing queries to utilize shared field definitions, and update tests to cover the new paginated query functionality.

New Features:
- Introduce paginated queries for notes, client profiles, and client documents, allowing for more efficient data retrieval with pagination support.

Enhancements:
- Refactor GraphQL queries to use a common set of note fields, reducing redundancy and improving maintainability.

Tests:
- Add tests for the new paginated queries to ensure they function correctly and return the expected results.