### PR TITLE
dev(928): add placeholder text

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/SingleDocUploads.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/SingleDocUploads.tsx
@@ -164,6 +164,7 @@ export default function SingleDocUploads(props: ISingleDocUploadsProps) {
                 />
               </View>
               <BasicInput
+                placeholder={"Enter a file name"}
                 label="File Name"
                 value={docs?.[docType]?.name}
                 onDelete={() =>

--- a/libs/expo/betterangels/src/lib/screens/PublicNote/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/PublicNote/index.tsx
@@ -133,6 +133,7 @@ export default function PublicNote({ noteId }: { noteId: string }) {
               textAlignVertical="top"
               accessibilityLabel="HMIS input"
               style={styles.input}
+              placeholder={"Enter a GIRP note or you can tap on Regenerate button below to regenerate the GIRP format interaction"}
             />
           </View>
         </View>


### PR DESCRIPTION
DEV-928

## Summary by Sourcery

Introduce placeholder text in input fields to enhance user guidance in the SingleDocUploads and PublicNote components.

New Features:
- Add placeholder text to the file name input field in the SingleDocUploads component.
- Add placeholder text to the input field in the PublicNote component to guide users on entering or regenerating GIRP notes.