### PR TITLE
Don't display UDIDs in CI (DEV-960)

### DIFF
--- a/.github/actions/expo-build/action.yml
+++ b/.github/actions/expo-build/action.yml
@@ -84,8 +84,9 @@ runs:
 
           if [[ "$(echo "$build_output" | jq length)" -eq 0 ]]; then
             echo "No existing $platform build found for runtime version ${{ inputs.runtime-version }}. Starting a new build."
+            # Pipe these logs to /dev/null since we don't want to display UDIDs
             build_output=$(eas build --profile "${{ inputs.profile }}" --platform "$platform" \
-              --freeze-credentials --non-interactive --no-wait --json)
+              --freeze-credentials --non-interactive --no-wait --json > /dev/null 2>&1)
           else
             echo "$platform build found for runtime version ${{ inputs.runtime-version }}."
           fi

--- a/.github/actions/expo-build/action.yml
+++ b/.github/actions/expo-build/action.yml
@@ -84,9 +84,9 @@ runs:
 
           if [[ "$(echo "$build_output" | jq length)" -eq 0 ]]; then
             echo "No existing $platform build found for runtime version ${{ inputs.runtime-version }}. Starting a new build."
-            # Pipe these logs to /dev/null since we don't want to display UDIDs
+            # Set logs to error since we don't want to display UDIDs
             build_output=$(eas build --profile "${{ inputs.profile }}" --platform "$platform" \
-              --freeze-credentials --non-interactive --no-wait --json > /dev/null 2>&1)
+              --freeze-credentials --non-interactive --no-wait --json --build-logger-level=error)
           else
             echo "$platform build found for runtime version ${{ inputs.runtime-version }}."
           fi

--- a/.github/actions/expo-build/action.yml
+++ b/.github/actions/expo-build/action.yml
@@ -78,12 +78,14 @@ runs:
 
         for platform in "${platforms[@]}"; do
           # Check for existing builds for the platform
+          # Suppress stderr to hide sensitive details like UDIDs
           build_output=$(eas build:list --platform "$platform" \
             --buildProfile "${{ inputs.profile }}" --runtimeVersion "${{ inputs.runtime-version }}" \
             --limit 1 --json --non-interactive 2>/dev/null)
 
           if [[ "$(echo "$build_output" | jq length)" -eq 0 ]]; then
             echo "No existing $platform build found for runtime version ${{ inputs.runtime-version }}. Starting a new build."
+            # Suppress stderr to hide sensitive details like UDIDs
             build_output=$(eas build --profile "${{ inputs.profile }}" --platform "$platform" \
               --freeze-credentials --non-interactive --no-wait --json 2>/dev/null)
           else

--- a/.github/actions/expo-build/action.yml
+++ b/.github/actions/expo-build/action.yml
@@ -80,12 +80,12 @@ runs:
           # Check for existing builds for the platform
           build_output=$(eas build:list --platform "$platform" \
             --buildProfile "${{ inputs.profile }}" --runtimeVersion "${{ inputs.runtime-version }}" \
-            --limit 1 --json --non-interactive 2>&1)
+            --limit 1 --json --non-interactive 2>/dev/null)
 
           if [[ "$(echo "$build_output" | jq length)" -eq 0 ]]; then
             echo "No existing $platform build found for runtime version ${{ inputs.runtime-version }}. Starting a new build."
             build_output=$(eas build --profile "${{ inputs.profile }}" --platform "$platform" \
-              --freeze-credentials --non-interactive --no-wait --json > /dev/null 2>&1)
+              --freeze-credentials --non-interactive --no-wait --json 2>/dev/null)
           else
             echo "$platform build found for runtime version ${{ inputs.runtime-version }}."
           fi

--- a/.github/actions/expo-build/action.yml
+++ b/.github/actions/expo-build/action.yml
@@ -84,9 +84,8 @@ runs:
 
           if [[ "$(echo "$build_output" | jq length)" -eq 0 ]]; then
             echo "No existing $platform build found for runtime version ${{ inputs.runtime-version }}. Starting a new build."
-            # Set logs to error since we don't want to display UDIDs
             build_output=$(eas build --profile "${{ inputs.profile }}" --platform "$platform" \
-              --freeze-credentials --non-interactive --no-wait --json --build-logger-level=error)
+              --freeze-credentials --non-interactive --no-wait --json > /dev/null 2>&1)
           else
             echo "$platform build found for runtime version ${{ inputs.runtime-version }}."
           fi

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.29',
+    version: '1.0.30',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -39,7 +39,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.28',
+      buildNumber: '1.0.29',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -78,7 +78,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 28,
+      versionCode: 29,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.31',
+    version: '1.0.29',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -39,7 +39,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.32',
+      buildNumber: '1.0.28',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -78,7 +78,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 32,
+      versionCode: 28,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -39,7 +39,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.31',
+      buildNumber: '1.0.32',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -78,7 +78,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 31,
+      versionCode: 32,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.30',
+    version: '1.0.31',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -39,7 +39,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.29',
+      buildNumber: '1.0.30',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -78,7 +78,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 29,
+      versionCode: 30,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -39,7 +39,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.30',
+      buildNumber: '1.0.31',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -78,7 +78,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 30,
+      versionCode: 31,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',


### PR DESCRIPTION
DEV-960

## Summary by Sourcery

CI:
- Modify CI workflow to suppress UDID display by redirecting build logs to /dev/null.

## Summary by Sourcery

CI:
- Suppress stderr in CI scripts to prevent displaying sensitive details like UDIDs.