### PR TITLE
Add ShelterOrder and fix flaky test (DEV-1122)

### DIFF
--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1002,7 +1002,7 @@ type Query {
   task(pk: ID!): TaskType! @hasRetvalPerm(permissions: [{app: "notes", permission: "view_task"}], any: true)
   tasks(order: TaskOrder, pagination: OffsetPaginationInput): [TaskType!]! @hasRetvalPerm(permissions: [{app: "notes", permission: "view_task"}], any: true)
   shelter(pk: ID!): ShelterType!
-  shelters(pagination: OffsetPaginationInput): ShelterTypeOffsetPaginated!
+  shelters(pagination: OffsetPaginationInput, order: ShelterOrder): ShelterTypeOffsetPaginated!
 }
 
 enum RaceEnum {
@@ -1193,6 +1193,10 @@ type ShelterLocationType {
   place: String!
   latitude: Float!
   longitude: Float!
+}
+
+input ShelterOrder {
+  name: Ordering
 }
 
 type ShelterPhotoType {

--- a/apps/betterangels-backend/shelters/tests/test_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_queries.py
@@ -9,6 +9,7 @@ from django.apps import apps
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from model_bakery import baker
+from model_bakery.recipe import seq
 from places import Places
 from shelters.enums import (
     AccessibilityChoices,
@@ -126,7 +127,7 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             funders_other="funders other",
             location=self.shelter_location,
             max_stay=7,
-            name="name",
+            name=seq("name "),  # type: ignore
             on_site_security=True,
             organization=self.shelter_organization,
             other_rules="other rules",
@@ -254,7 +255,7 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             "entryInfo": "entry info",
             "fundersOther": "funders other",
             "maxStay": 7,
-            "name": "name",
+            "name": "name 1",
             "onSiteSecurity": True,
             "otherRules": "other rules",
             "otherServices": "other services",
@@ -321,8 +322,8 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
 
     def test_shelters_query(self) -> None:
         query = f"""
-            query ViewShelters($offset: Int, $limit: Int) {{
-                shelters(pagination: {{offset: $offset, limit: $limit}}) {{
+            query ViewShelters($offset: Int, $limit: Int, $order: ShelterOrder) {{
+                shelters(pagination: {{offset: $offset, limit: $limit}}, order: $order) {{
                     totalCount
                     pageInfo {{
                         limit
@@ -337,9 +338,10 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
         """
 
         expected_query_count = 22
+        variables = {"order": {"name": "ASC"}}
 
         with self.assertNumQueries(expected_query_count):
-            response = self.execute_graphql(query)
+            response = self.execute_graphql(query, variables)
 
         shelters = response["data"]["shelters"]["results"]
 

--- a/apps/betterangels-backend/shelters/types.py
+++ b/apps/betterangels-backend/shelters/types.py
@@ -155,7 +155,12 @@ class FunderType:
     name: Optional[FunderChoices]
 
 
-@strawberry_django.type(Shelter)
+@strawberry_django.ordering.order(Shelter)
+class ShelterOrder:
+    name: auto
+
+
+@strawberry_django.type(Shelter, order=ShelterOrder)  # type: ignore
 class ShelterType:
     id: ID
     accessibility: List[AccessibilityType]


### PR DESCRIPTION
DEV-1122

## Summary by Sourcery

Add the ShelterOrder input type to enable ordering of shelter queries by name and fix a flaky test by using a sequence for consistent naming in test data.

New Features:
- Introduce the ShelterOrder input type to allow ordering of shelter queries by name.

Bug Fixes:
- Fix a flaky test by ensuring consistent naming in test data using a sequence.