### PR TITLE
libs/react: add checkbox and expandable components (DEV-1080)

### DIFF
--- a/apps/shelter-web/src/assets/styles/global.css
+++ b/apps/shelter-web/src/assets/styles/global.css
@@ -6,6 +6,7 @@
   --font-primary: 'Poppins', 'sans-serif';
   --color-primary-20: #052b73;
   --color-primary-60: #216af8;
+  --color-primary-95: #dae7ff;
   --color-steel-blue: #375c76;
   --color-neutral-40: #62676f;
   --color-neutral-70: #a8aeb8;

--- a/apps/shelter-web/tailwind.config.js
+++ b/apps/shelter-web/tailwind.config.js
@@ -23,6 +23,7 @@ module.exports = {
       colors: {
         'primary-20': 'var(--color-primary-20)',
         'primary-60': 'var(--color-primary-60)',
+        'primary-95': 'var(--color-primary-95)',
         'steel-blue': 'var(--color-steel-blue)',
         'neutral-40': 'var(--color-neutral-40)',
         'neutral-70': 'var(--color-neutral-70)',

--- a/libs/assets/src/icons/LICENSE
+++ b/libs/assets/src/icons/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2024 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/assets/src/icons/svg/check.svg
+++ b/libs/assets/src/icons/svg/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M20 7L10 17l-5-5"/>
+</svg>

--- a/libs/assets/src/icons/svg/chevronDown.svg
+++ b/libs/assets/src/icons/svg/chevronDown.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M5 7.5L10 12.5L15 7.5" stroke="currentColor" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/libs/react/components/src/lib-utils/mergeCss.ts
+++ b/libs/react/components/src/lib-utils/mergeCss.ts
@@ -1,0 +1,14 @@
+import clsx, { ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function mergeCss(classes?: ClassValue[] | string) {
+  if (!classes) {
+    return '';
+  }
+
+  if (typeof classes === 'string') {
+    return classes;
+  }
+
+  return twMerge(clsx(...classes));
+}

--- a/libs/react/components/src/lib/ExpandableContainer/ExpandableContainer.tsx
+++ b/libs/react/components/src/lib/ExpandableContainer/ExpandableContainer.tsx
@@ -1,0 +1,75 @@
+import { ChevronDownIcon } from '@monorepo/react/icons';
+import {
+  Dispatch,
+  PropsWithChildren,
+  ReactNode,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
+import { mergeCss } from '../../lib-utils/mergeCss';
+
+interface IProps extends PropsWithChildren {
+  className?: string;
+  header?: ReactNode | string;
+  disabled?: boolean;
+  open?: boolean;
+  onClick?: (opened: boolean) => void;
+}
+
+export function ExpandableContainer(props: IProps) {
+  const {
+    header,
+    disabled,
+    className,
+    open = false,
+    children,
+    onClick,
+  } = props;
+
+  const [isOpen, setIsOpen]: [boolean, Dispatch<SetStateAction<boolean>>] =
+    useState<boolean>(open);
+
+  useEffect((): void => {
+    setIsOpen(open);
+  }, [setIsOpen, open]);
+
+  function onExpanCollapse(): void {
+    if (disabled) {
+      return;
+    }
+
+    const newOpenState = !isOpen;
+
+    setIsOpen(newOpenState);
+
+    if (onClick) {
+      onClick(newOpenState);
+    }
+  }
+
+  const parentCss = [className];
+
+  const headerCss = [
+    'flex',
+    'justify-between',
+    'items-center',
+    disabled ? '' : 'cursor-pointer',
+  ];
+
+  const iconCss = ['h-5', isOpen ? 'rotate-180' : 'rotate-none'];
+
+  const contentCss = ['mt-6'];
+
+  return (
+    <div className={mergeCss(parentCss)}>
+      <div className={mergeCss(headerCss)} onClick={onExpanCollapse}>
+        {!!header && header}
+        <ChevronDownIcon className={mergeCss(iconCss)} strokeWidth={2} />
+      </div>
+      {isOpen && !disabled && (
+        <div className={mergeCss(contentCss)}>{children}</div>
+      )}
+    </div>
+  );
+}

--- a/libs/react/components/src/lib/ExpandableContainer/index.ts
+++ b/libs/react/components/src/lib/ExpandableContainer/index.ts
@@ -1,0 +1,1 @@
+export { ExpandableContainer as default } from './ExpandableContainer';

--- a/libs/react/components/src/lib/Form/Checkbox.tsx
+++ b/libs/react/components/src/lib/Form/Checkbox.tsx
@@ -1,0 +1,63 @@
+import { CheckIcon } from '@monorepo/react/icons';
+import { ReactElement } from 'react';
+import { mergeCss } from '../../lib-utils/mergeCss';
+
+export type ICheckbox = {
+  label: string;
+  checked?: boolean;
+  onChange: (checked: boolean) => void;
+  className?: string;
+  required?: boolean;
+  disabled?: boolean;
+};
+
+export function Checkbox(props: ICheckbox): ReactElement {
+  const { checked, onChange, label, disabled, className } = props;
+
+  function handleChange(): void {
+    if (disabled) {
+      return;
+    }
+
+    onChange(!checked);
+  }
+
+  const parentCss = [
+    'flex',
+    'justify-between',
+    'items-start',
+    'w-full',
+    'text-sm',
+    'px-4',
+    'py-2',
+    'border',
+    'rounded-lg',
+    checked ? 'border-primary-95 bg-primary-95' : 'border-neutral-90 bg-white',
+    className,
+  ];
+
+  const checkboxContainerCss = [
+    'mt-0.5',
+    'w-4',
+    'h-4',
+    'overflow-hidden',
+    'flex',
+    'items-center',
+    'border',
+    checked ? 'border-primary-20 bg-primary-20' : 'border-neutral-90 bg-white',
+    'rounded-sm',
+  ];
+
+  return (
+    <button
+      className={mergeCss(parentCss)}
+      onClick={handleChange}
+      disabled={disabled}
+    >
+      <div className="text-left text-wrap">{label}</div>
+      <div className={mergeCss(checkboxContainerCss)}>
+        {checked && <CheckIcon className="text-white" />}
+      </div>
+    </button>
+  );
+}

--- a/libs/react/components/src/lib/Form/CheckboxGroup.tsx
+++ b/libs/react/components/src/lib/Form/CheckboxGroup.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { mergeCss } from '../../lib-utils/mergeCss';
+import { Checkbox } from './Checkbox';
+
+type TCheckboxOptionKv = {
+  label: string;
+  value: string;
+};
+
+type TCheckboxOption = string | TCheckboxOptionKv;
+
+function normalizeOptions(options: TCheckboxOption[]): TCheckboxOptionKv[] {
+  if (!options) {
+    return [];
+  }
+
+  return options.map((option) => {
+    if (typeof option === 'string') {
+      return {
+        label: option,
+        value: option,
+      };
+    }
+
+    return option;
+  });
+}
+
+export type TProps = {
+  className?: string;
+  options: TCheckboxOption[];
+  onChange: (selected: string[]) => void;
+};
+
+export function CheckboxGroup(props: TProps) {
+  const { className, options, onChange } = props;
+
+  const [cbxOptions, setCbxOptions] = useState<TCheckboxOptionKv[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  useEffect(() => {
+    const normalized = normalizeOptions(options);
+
+    setCbxOptions(normalized);
+  }, [options]);
+
+  useEffect(() => {
+    onChange(selected);
+  }, [selected]);
+
+  function handleChange(value: string, checked: boolean) {
+    // add
+    if (checked) {
+      return setSelected((prev) => {
+        const idx = prev.indexOf(value);
+
+        if (idx > -1) {
+          return prev;
+        }
+
+        return [...prev, value];
+      });
+    }
+
+    // or remove
+    return setSelected((prev) => {
+      const idx = prev.indexOf(value);
+
+      if (idx < 0) {
+        return prev;
+      }
+
+      const copy = [...prev];
+
+      copy.splice(idx, 1);
+
+      return copy;
+    });
+  }
+
+  let parentCss = ['flex', 'flex-col', className];
+
+  return (
+    <div className={mergeCss(parentCss)}>
+      {cbxOptions.map((option, idx: number) => {
+        const isChecked = selected.indexOf(option.value) > -1;
+
+        return (
+          <Checkbox
+            key={idx}
+            className="mb-2 last:mb-0"
+            label={option.label}
+            checked={isChecked}
+            onChange={(checked) => handleChange(option.value, checked)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/libs/react/components/src/lib/Form/index.ts
+++ b/libs/react/components/src/lib/Form/index.ts
@@ -1,0 +1,2 @@
+export { Checkbox } from './Checkbox';
+export { CheckboxGroup } from './CheckboxGroup';

--- a/libs/react/components/src/lib/index.ts
+++ b/libs/react/components/src/lib/index.ts
@@ -1,4 +1,6 @@
 export { default as Button } from './Button';
 export { default as Card } from './Card';
+export { default as ExpandableContainer } from './ExpandableContainer';
+export * from './Form';
 export { default as Pill } from './Pill';
 export { default as PillContainer } from './PillContainer';

--- a/libs/react/icons/src/lib/components/checkIcon.tsx
+++ b/libs/react/icons/src/lib/components/checkIcon.tsx
@@ -1,0 +1,4 @@
+import svg from '../../../../../assets/src/icons/svg/check.svg';
+import { createSvgComponent } from '../../toComponent';
+
+export default createSvgComponent(svg);

--- a/libs/react/icons/src/lib/components/chevronDownIcon.tsx
+++ b/libs/react/icons/src/lib/components/chevronDownIcon.tsx
@@ -1,0 +1,4 @@
+import svg from '../../../../../assets/src/icons/svg/chevronDown.svg';
+import { createSvgComponent } from '../../toComponent';
+
+export default createSvgComponent(svg);

--- a/libs/react/icons/src/lib/index.ts
+++ b/libs/react/icons/src/lib/index.ts
@@ -1,3 +1,5 @@
+export { default as CheckIcon } from './components/checkIcon';
+export { default as ChevronDownIcon } from './components/chevronDownIcon';
 export { default as CloseIcon } from './components/closeIcon';
 export { default as FilterIcon } from './components/filterIcon';
 export { default as FindMeIcon } from './components/findMeIcon';


### PR DESCRIPTION
### Filter Shelter Results
https://betterangels.atlassian.net/browse/DEV-1080

Partial PR
* expandable container
* checkbox + checkboxGroup
* add `--color-primary-95` to shelter css


screnshot:

<img width="367" alt="image" src="https://github.com/user-attachments/assets/9807b1fa-98e5-44f7-bbd4-53c30a5c1ce6" />

## Summary by Sourcery

Add checkbox and expandable container components to the React library.

New Features:
- Added `Checkbox` and `CheckboxGroup` components for form elements.
- Added `ExpandableContainer` component to display expandable content sections.