### PR TITLE
Save user emails lowercase (DEV-1164)

### DIFF
--- a/apps/betterangels-backend/accounts/models.py
+++ b/apps/betterangels-backend/accounts/models.py
@@ -102,6 +102,12 @@ class User(AbstractBaseUser, PermissionsMixin):
             organization__in=user_organizations, template__name__in=authorized_permission_groups
         ).exists()
 
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        if self.email:
+            self.email = self.email.lower()
+
+        super().save(*args, **kwargs)
+
 
 class ExtendedOrganizationInvitation(OrganizationInvitation):
     accepted = models.BooleanField(default=False)

--- a/apps/betterangels-backend/accounts/tests/test_models.py
+++ b/apps/betterangels-backend/accounts/tests/test_models.py
@@ -51,3 +51,7 @@ class UserModelTestCase(ParametrizedTestCase, TestCase):
 
         remove_organization_permission_group(unauthorized_org)
         self.assertEqual(user.is_outreach_authorized, should_succeed)
+
+    def test_save(self) -> None:
+        user = User.objects.create(username="lowercaseme", email="LOWERCASEME@EXAMPLE.COM")
+        self.assertEqual(user.email, "lowercaseme@example.com")


### PR DESCRIPTION
DEV-1164

## Summary by Sourcery

Bug Fixes:
- Fix issue where user emails were not saved in lowercase.