### PR TITLE
shelter: set viewport maximum-scale=1 (DEV-1151)

### DIFF
--- a/apps/shelter-web/index.html
+++ b/apps/shelter-web/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="LA Homeless Shelter search.">
   <meta name="keywords" content="shelters" />
   <base href="/" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=1">
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="stylesheet" href="/src/assets/styles/fonts.css" />
   <link rel="stylesheet" href="/src/assets/styles/global.css" />


### PR DESCRIPTION
Shelter DB UI issue
https://betterangels.atlassian.net/browse/DEV-1151

Note: this disables zooming by setting `maximum-scale=1`, which comes with accessibility concerns. However, it looks like devices ignore that, which it fixes the issue.
More on the issue on the ticket.

Preview: https://shelter.dev.betterangels.la/zoom

## Summary by Sourcery

Bug Fixes:
- Fix the search box breaking on mobile devices by setting the viewport maximum-scale to 1.