### PR TITLE
Related object bug (DEV-1181)

### DIFF
--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -142,28 +142,19 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
             "email": "firstey_lastey@example.com",
         }
 
-        contact_1 = {
-            "id": self.client_profile_1["contacts"][0]["id"],
-            "name": "Jerryyy",
-            "email": "jerryyy@example.co",
-            "phoneNumber": "6465551212",
-            "mailingAddress": "1235 Main Street",
-            "relationshipToClient": RelationshipTypeEnum.OTHER.name,
-            "relationshipToClientOther": "bff",
-        }
-        contact_new = {
-            "name": "New guy",
-            "email": "new_guy@example.co",
-            "phoneNumber": "3475551212",
-            "mailingAddress": "1236 Main Street",
-            "relationshipToClient": RelationshipTypeEnum.UNCLE.name,
-            "relationshipToClientOther": None,
-        }
-        contacts = [contact_1, contact_new]
+        contacts: list = []
 
-        hmis_profiles: list = []
+        hmis_profile_update = {
+            "agency": HmisAgencyEnum.LAHSA.name,
+            "hmisId": "HMISidLAHSA1Updated",
+        }
+        hmis_profile_new = {
+            "hmisId": "HMISidPASADENA1New",
+            "agency": HmisAgencyEnum.PASADENA.name,
+        }
+        hmis_profiles = [hmis_profile_update, hmis_profile_new]
 
-        household_member_1 = {
+        household_member_update = {
             "id": self.client_profile_1["householdMembers"][0]["id"],
             "name": "Daffodils",
             "dateOfBirth": "1900-01-02",
@@ -180,9 +171,9 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
             "relationshipToClient": RelationshipTypeEnum.MOTHER.name,
             "relationshipToClientOther": None,
         }
-        household_members = [household_member_1, household_member_new]
+        household_members = [household_member_update, household_member_new]
 
-        client_1_phone_number_1 = {
+        client_1_phone_number_update = {
             "id": self.client_profile_1["phoneNumbers"][0]["id"],
             "number": "2125551212",
             "isPrimary": False,
@@ -191,12 +182,12 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
             "number": "6465551212",
             "isPrimary": True,
         }
-        client_1_phone_numbers = [client_1_phone_number_1, client_1_phone_number_new]
-        client_1_social_media_profile_2 = {
+        client_1_phone_numbers = [client_1_phone_number_update, client_1_phone_number_new]
+        client_1_social_media_profile_new = {
             "platform": SocialMediaEnum.TWITTER.name,
             "platformUserId": "bortman",
         }
-        client_1_social_media_profiles = [client_1_social_media_profile_2]
+        client_1_social_media_profiles = [client_1_social_media_profile_new]
 
         variables = {
             "id": self.client_profile_1["id"],
@@ -236,9 +227,9 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
         client_profile = response["data"]["updateClientProfile"]
 
         # Add display fields to nested objects and update variables
-        expected_household_member_1 = {"displayGender": "Non-binary", **household_member_1}
+        expected_household_member_update = {"displayGender": "Non-binary", **household_member_update}
         expected_household_member_new = {"displayGender": "pangender", **household_member_new}
-        expected_household_members = [expected_household_member_1, expected_household_member_new]
+        expected_household_members = [expected_household_member_update, expected_household_member_new]
         variables["householdMembers"] = expected_household_members
 
         expected_client_profile = {
@@ -256,8 +247,12 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
             ignore_order=True,
             exclude_regex_paths=[r"\['id'\]$"],
         )
-
         self.assertFalse(client_differences)
+
+        client_profile_2 = ClientProfile.objects.get(id=self.client_profile_2["id"])
+
+        self.assertEqual(client_profile_2.hmis_profiles.count(), 1)
+        self.assertEqual(client_profile_2.phone_numbers.count(), 1)
 
     def test_partial_update_client_profile_mutation(self) -> None:
         # Manually update profile photo because it's created after the client profile fixture.

--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -250,9 +250,10 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
         self.assertFalse(client_differences)
 
         client_profile_2 = ClientProfile.objects.get(id=self.client_profile_2["id"])
-
         self.assertEqual(client_profile_2.hmis_profiles.count(), 1)
         self.assertEqual(client_profile_2.phone_numbers.count(), 1)
+        self.assertEqual(client_profile_2.hmis_profiles.first().hmis_id, "HMISidPASADENA2")  # type: ignore
+        self.assertEqual(client_profile_2.phone_numbers.first().number, "3475551212")
 
     def test_partial_update_client_profile_mutation(self) -> None:
         # Manually update profile photo because it's created after the client profile fixture.

--- a/apps/betterangels-backend/clients/tests/utils.py
+++ b/apps/betterangels-backend/clients/tests/utils.py
@@ -200,6 +200,10 @@ class ClientProfileGraphQLBaseTestCase(GraphQLBaseTestCase):
         self.client_1_phone_number_2 = {
             "number": "7185551212",
         }
+        self.client_2_phone_number_1 = {
+            "number": "3475551212",
+            "isPrimary": True,
+        }
         self.client_profile_1_phone_numbers = [self.client_1_phone_number_1, self.client_1_phone_number_2]
 
         self.client_1_social_media_profile_1 = {
@@ -270,7 +274,7 @@ class ClientProfileGraphQLBaseTestCase(GraphQLBaseTestCase):
                 "maritalStatus": None,
                 "nickname": None,
                 "phoneNumber": None,
-                "phoneNumbers": [],
+                "phoneNumbers": [self.client_2_phone_number_1],
                 "physicalDescription": None,
                 "placeOfBirth": None,
                 "preferredCommunication": [],


### PR DESCRIPTION
DEV-1181

found a major bug where we were deleting ALL related records of a given type when updating a client profile, because the `delete` wasn't being limited to objects related to the given profile.