### PR TITLE
update clientProfile resolver to catch hmis dupes

### DIFF
--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -65,7 +65,8 @@ CLIENT_RELATED_CLS_NAME_BY_RELATED_NAME: dict[str, dict[str, Any]] = {
 def validate_unique_hmis(
     data: List[Dict[str, Any]],
 ) -> RelOperationMessage | None:
-    for item in data:
+    # for item in data:
+    for index, item in enumerate(data):
         id = item.get("id", None)
         hmis_id = item.get("hmis_id", "")
         agency = item.get("agency", "")
@@ -73,12 +74,16 @@ def validate_unique_hmis(
         duplicate = HmisProfile.objects.filter(hmis_id=hmis_id, agency=agency)
 
         if duplicate.exists():
+            print('DUPLICATE FOR IDX: ', index)
+
             return RelOperationMessage(
                     relation="HmisProfile",
                     relation_id=id,
                     meta=RelHmisMeta(
                         hmis_id=hmis_id,
                         agency=agency,
+                        # index=index,
+                        index=1,
                     )
                 )
 

--- a/apps/betterangels-backend/common/graphql/types.py
+++ b/apps/betterangels-backend/common/graphql/types.py
@@ -117,6 +117,7 @@ class DeletedObjectType:
 class RelHmisMeta:
     hmis_id: str
     agency: str
+    index: int
 
 @strawberry.type
 class RelOperationMessage:

--- a/apps/betterangels-backend/common/graphql/types.py
+++ b/apps/betterangels-backend/common/graphql/types.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import strawberry
 import strawberry_django
@@ -112,3 +112,35 @@ class FeatureControlData:
 @strawberry.type
 class DeletedObjectType:
     id: int
+
+@strawberry.type
+class RelHmisMeta:
+    hmis_id: str
+    agency: str
+
+@strawberry.type
+class RelOperationMessage:
+    relation: str
+    relation_id: Optional[int] = None
+    msg: Optional[str] = None
+    meta: Optional[RelHmisMeta] = None
+
+    def __hash__(self) -> int:
+        return hash((self.msg, self.relation, self.relation_id))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, RelOperationMessage):
+            return (self.msg, self.relation, self.relation_id) == (other.msg, other.relation, other.relation_id)
+        return False
+
+@strawberry.type
+class RelOperationInfo:
+    messages: List[RelOperationMessage]
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.messages))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, RelOperationInfo):
+            return tuple(self.messages) == tuple(other.messages)
+        return False

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1021,6 +1021,22 @@ enum RaceEnum {
   OTHER
 }
 
+type RelHmisMeta {
+  hmisId: String!
+  agency: String!
+}
+
+type RelOperationInfo {
+  messages: [RelOperationMessage!]!
+}
+
+type RelOperationMessage {
+  relation: String!
+  relationId: Int
+  msg: String
+  meta: RelHmisMeta
+}
+
 enum RelationshipTypeEnum {
   CURRENT_CASE_MANAGER
   PAST_CASE_MANAGER
@@ -1468,7 +1484,7 @@ input UpdateClientProfileInput {
   user: UpdateUserInput
 }
 
-union UpdateClientProfilePayload = ClientProfileType | OperationInfo
+union UpdateClientProfilePayload = ClientProfileType | RelOperationInfo | OperationInfo
 
 union UpdateClientProfilePhotoPayload = ClientProfileType | OperationInfo
 

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1024,6 +1024,7 @@ enum RaceEnum {
 type RelHmisMeta {
   hmisId: String!
   agency: String!
+  index: Int!
 }
 
 type RelOperationInfo {

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -1345,6 +1345,25 @@ export enum RaceEnum {
   WhiteCaucasian = 'WHITE_CAUCASIAN'
 }
 
+export type RelHmisMeta = {
+  __typename?: 'RelHmisMeta';
+  agency: Scalars['String']['output'];
+  hmisId: Scalars['String']['output'];
+};
+
+export type RelOperationInfo = {
+  __typename?: 'RelOperationInfo';
+  messages: Array<RelOperationMessage>;
+};
+
+export type RelOperationMessage = {
+  __typename?: 'RelOperationMessage';
+  meta?: Maybe<RelHmisMeta>;
+  msg?: Maybe<Scalars['String']['output']>;
+  relation: Scalars['String']['output'];
+  relationId?: Maybe<Scalars['Int']['output']>;
+};
+
 export enum RelationshipTypeEnum {
   Aunt = 'AUNT',
   Child = 'CHILD',
@@ -1587,8 +1606,8 @@ export type ShelterPropertyInput = {
   demographics?: InputMaybe<Array<DemographicChoices>>;
   parking?: InputMaybe<Array<ParkingChoices>>;
   pets?: InputMaybe<Array<PetChoices>>;
-  roomStyle?: InputMaybe<Array<RoomStyleChoices>>;
-  shelterType?: InputMaybe<Array<ShelterChoices>>;
+  roomStyles?: InputMaybe<Array<RoomStyleChoices>>;
+  shelterTypes?: InputMaybe<Array<ShelterChoices>>;
   specialSituationRestrictions?: InputMaybe<Array<SpecialSituationRestrictionChoices>>;
 };
 
@@ -1803,7 +1822,7 @@ export type UpdateClientProfileInput = {
   veteranStatus?: InputMaybe<YesNoPreferNotToSayEnum>;
 };
 
-export type UpdateClientProfilePayload = ClientProfileType | OperationInfo;
+export type UpdateClientProfilePayload = ClientProfileType | OperationInfo | RelOperationInfo;
 
 export type UpdateClientProfilePhotoPayload = ClientProfileType | OperationInfo;
 

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -1349,6 +1349,7 @@ export type RelHmisMeta = {
   __typename?: 'RelHmisMeta';
   agency: Scalars['String']['output'];
   hmisId: Scalars['String']['output'];
+  index: Scalars['Int']['output'];
 };
 
 export type RelOperationInfo = {

--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/AddEditClient.graphql
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/AddEditClient.graphql
@@ -8,6 +8,17 @@ mutation UpdateClientProfile($data: UpdateClientProfileInput!) {
       }
     }
 
+    ... on RelOperationInfo {
+      messages {
+        relation
+        relationId
+        meta {
+          hmisId
+          agency
+        }
+      }
+    }
+
     ... on ClientProfileType {
       id
     }

--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/HmisProfiles.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/HmisProfiles.tsx
@@ -22,8 +22,18 @@ export default function HmisProfiles() {
     watch,
     control,
     formState: { errors },
+    clearErrors,
     resetField,
   } = useFormContext<UpdateClientProfileInput | CreateClientProfileInput>();
+
+  console.log();
+  console.log('| -------------  HmisProfiles errors  ------------- |');
+  console.log(errors);
+  console.log();
+  console.log();
+  console.log('| -------------  errors.hmisProfiles[0]  ------------- |');
+  console.log(errors && errors.hmisProfiles && errors.hmisProfiles[0]);
+  console.log();
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -34,12 +44,27 @@ export default function HmisProfiles() {
   const hmisProfiles = watch('hmisProfiles') || [];
 
   const onReset = () => {
+    console.log();
+    console.log('| -------------  RESET`  ------------- |');
+    console.log();
     setValue('hmisProfiles', []);
   };
 
   const onItemReset = (index: number) => {
-    resetField(`hmisProfiles.${index}.agency`);
-    resetField(`hmisProfiles.${index}.hmisId`);
+    console.log();
+    console.log('| -------------  RESET ITEM  ------------- |');
+    console.log();
+
+    // resetField(`hmisProfiles.${index}.agency`);
+    // resetField(`hmisProfiles.${index}.hmisId`);
+
+    const updatedProfiles = [...hmisProfiles];
+    updatedProfiles[index] = {
+      agency: HmisAgencyEnum.Lahsa,
+      hmisId: '',
+    };
+    setValue('hmisProfiles', updatedProfiles);
+    clearErrors(`hmisProfiles.${index}`);
   };
 
   return (
@@ -76,7 +101,7 @@ export default function HmisProfiles() {
               Enter the ID #
             </TextBold>
             <TextRegular size="sm">
-              Pair your HMIS ID type with a specific ID
+              Pair your HMIS ID type with a specific ID xx
             </TextRegular>
             <Input
               mt="xs"
@@ -86,7 +111,8 @@ export default function HmisProfiles() {
               error={errors.hmisProfiles && !!errors.hmisProfiles[index]}
               errorMessage={
                 errors.hmisProfiles && errors.hmisProfiles[index]
-                  ? 'Enter HMIS ID or remove this entry'
+                  ? errors.hmisProfiles[index]?.message ||
+                    'Enter HMIS ID or remove this entry'
                   : ''
               }
               rules={{

--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/PersonalInfo/index.tsx
@@ -2,13 +2,9 @@ import { Spacings } from '@monorepo/expo/shared/static';
 import { Accordion } from '@monorepo/expo/shared/ui-components';
 import { RefObject } from 'react';
 import { ScrollView, View } from 'react-native';
-import CaliforniaId from './CaliforniaId';
-import Dob from './Dob';
-import FullName from './FullName';
 import HmisProfiles from './HmisProfiles';
 import LivingSituation from './LivingSituation';
 import PreferredLanguage from './PreferredLanguage';
-import ProfilePhoto from './ProfilePhoto';
 import VeteranStatus from './VeteranStatus';
 
 interface IPersonalInfoProps {
@@ -41,10 +37,10 @@ export default function PersonalInfo(props: IPersonalInfoProps) {
             gap: Spacings.xs,
           }}
         >
-          {clientId && <ProfilePhoto clientId={clientId} />}
-          <FullName />
-          <Dob />
-          <CaliforniaId />
+          {/* {clientId && <ProfilePhoto clientId={clientId} />} */}
+          {/* <FullName /> */}
+          {/* <Dob /> */}
+          {/* <CaliforniaId /> */}
           <HmisProfiles />
           <PreferredLanguage />
           <VeteranStatus />

--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/__generated__/AddEditClient.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/__generated__/AddEditClient.generated.ts
@@ -8,7 +8,7 @@ export type UpdateClientProfileMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateClientProfileMutation = { __typename?: 'Mutation', updateClientProfile: { __typename?: 'ClientProfileType', id: string } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } };
+export type UpdateClientProfileMutation = { __typename?: 'Mutation', updateClientProfile: { __typename?: 'ClientProfileType', id: string } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } | { __typename?: 'RelOperationInfo', messages: Array<{ __typename?: 'RelOperationMessage', relation: string, relationId?: number | null, meta?: { __typename?: 'RelHmisMeta', hmisId: string, agency: string } | null }> } };
 
 export type UpdateClientProfilePhotoMutationVariables = Types.Exact<{
   data: Types.ClientProfilePhotoInput;
@@ -47,6 +47,16 @@ export const UpdateClientProfileDocument = gql`
         kind
         field
         message
+      }
+    }
+    ... on RelOperationInfo {
+      messages {
+        relation
+        relationId
+        meta {
+          hmisId
+          agency
+        }
       }
     }
     ... on ClientProfileType {

--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/index.tsx
@@ -202,9 +202,9 @@ export default function AddEditClient({ id }: { id?: string }) {
       ) {
         console.log();
         console.log(
-          '| -------------  operationResult.messages -- RelOperationInfo  ------------- |'
+          '| -------------  operationResult -- RelOperationInfo  ------------- |'
         );
-        console.log(operationResult.messages);
+        console.log(operationResult);
         console.log();
 
         // const relation = operationResult.messages[0].relation;
@@ -224,10 +224,11 @@ export default function AddEditClient({ id }: { id?: string }) {
         if (result.relation === 'HmisProfile') {
           console.log('***************** HmisProfile ID: ', result.relationId);
           console.log('***************** HmisProfile meta: ', result.meta);
-          // methods.setError('user.email', {
-          //   type: 'manual',
-          //   message: 'HMIS DUPE !!!!.',
-          // });
+
+          methods.setError('hmisProfiles.0', {
+            type: 'manual',
+            message: 'my dupe message.',
+          });
 
           return;
         }

--- a/libs/expo/betterangels/src/lib/screens/AddEditClient/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AddEditClient/index.tsx
@@ -163,6 +163,7 @@ export default function AddEditClient({ id }: { id?: string }) {
     delete values.profilePhoto;
     try {
       let operationResult;
+
       if (id) {
         const input = {
           ...(values as UpdateClientProfileInput),
@@ -194,6 +195,44 @@ export default function AddEditClient({ id }: { id?: string }) {
         });
         operationResult = createResponse.data?.createClientProfile;
       }
+
+      if (
+        operationResult?.__typename === 'RelOperationInfo' &&
+        operationResult.messages.length > 0
+      ) {
+        console.log();
+        console.log(
+          '| -------------  operationResult.messages -- RelOperationInfo  ------------- |'
+        );
+        console.log(operationResult.messages);
+        console.log();
+
+        // const relation = operationResult.messages[0].relation;
+        const result = operationResult.messages[0];
+
+        // [{
+        //   "__typename": "RelOperationMessage",
+        //   "meta": {
+        //     "__typename": "RelHmisMeta",
+        //     "agency": "lahsa",
+        //     "hmisId": "Xxx"
+        //   },
+        //   "relation": "HmisProfile",
+        //   "relationId": 18
+        // }]
+
+        if (result.relation === 'HmisProfile') {
+          console.log('***************** HmisProfile ID: ', result.relationId);
+          console.log('***************** HmisProfile meta: ', result.meta);
+          // methods.setError('user.email', {
+          //   type: 'manual',
+          //   message: 'HMIS DUPE !!!!.',
+          // });
+
+          return;
+        }
+      }
+
       if (
         operationResult?.__typename === 'OperationInfo' &&
         operationResult.messages.length > 0
@@ -228,7 +267,9 @@ export default function AddEditClient({ id }: { id?: string }) {
         router.replace('/');
       }
     } catch (err) {
+      console.log('################################### CAUGHT ERR');
       console.error(err);
+      console.log('-------');
 
       showSnackbar({
         message: 'Sorry, there was an error updating this profile.',

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -1345,6 +1345,25 @@ export enum RaceEnum {
   WhiteCaucasian = 'WHITE_CAUCASIAN'
 }
 
+export type RelHmisMeta = {
+  __typename?: 'RelHmisMeta';
+  agency: Scalars['String']['output'];
+  hmisId: Scalars['String']['output'];
+};
+
+export type RelOperationInfo = {
+  __typename?: 'RelOperationInfo';
+  messages: Array<RelOperationMessage>;
+};
+
+export type RelOperationMessage = {
+  __typename?: 'RelOperationMessage';
+  meta?: Maybe<RelHmisMeta>;
+  msg?: Maybe<Scalars['String']['output']>;
+  relation: Scalars['String']['output'];
+  relationId?: Maybe<Scalars['Int']['output']>;
+};
+
 export enum RelationshipTypeEnum {
   Aunt = 'AUNT',
   Child = 'CHILD',
@@ -1587,8 +1606,8 @@ export type ShelterPropertyInput = {
   demographics?: InputMaybe<Array<DemographicChoices>>;
   parking?: InputMaybe<Array<ParkingChoices>>;
   pets?: InputMaybe<Array<PetChoices>>;
-  roomStyle?: InputMaybe<Array<RoomStyleChoices>>;
-  shelterType?: InputMaybe<Array<ShelterChoices>>;
+  roomStyles?: InputMaybe<Array<RoomStyleChoices>>;
+  shelterTypes?: InputMaybe<Array<ShelterChoices>>;
   specialSituationRestrictions?: InputMaybe<Array<SpecialSituationRestrictionChoices>>;
 };
 
@@ -1803,7 +1822,7 @@ export type UpdateClientProfileInput = {
   veteranStatus?: InputMaybe<YesNoPreferNotToSayEnum>;
 };
 
-export type UpdateClientProfilePayload = ClientProfileType | OperationInfo;
+export type UpdateClientProfilePayload = ClientProfileType | OperationInfo | RelOperationInfo;
 
 export type UpdateClientProfilePhotoPayload = ClientProfileType | OperationInfo;
 

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -1349,6 +1349,7 @@ export type RelHmisMeta = {
   __typename?: 'RelHmisMeta';
   agency: Scalars['String']['output'];
   hmisId: Scalars['String']['output'];
+  index: Scalars['Int']['output'];
 };
 
 export type RelOperationInfo = {


### PR DESCRIPTION
## Summary by Sourcery

Catch duplicate HMIS profiles when updating client profiles.

New Features:
- Added validation to prevent the creation of duplicate HMIS profiles.

Bug Fixes:
- Fixed a bug where duplicate HMIS profiles could be created.