### PR TITLE
Adding Google Translate Element to Web App

### DIFF
--- a/apps/wildfires/index.html
+++ b/apps/wildfires/index.html
@@ -15,4 +15,11 @@
 <body>
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
+  <div id="google_translate_element"></div>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
+    }
+  </script>
+  <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>

--- a/apps/wildfires/src/app/layout/footer.tsx
+++ b/apps/wildfires/src/app/layout/footer.tsx
@@ -28,7 +28,7 @@ export function Footer(props: IParams): ReactElement {
       <a href="https://www.betterangels.la/" className="flex mb-8 md:mb-0">
         <BetterAngelsLogoIcon className="h-7 md:h-10 text-brand-sky-blue fill-current" />
         <div className="text-white flex ml-2 text-xl md:text-4xl">
-          <div className="font-normal">
+          <div className="font-normal notranslate">
             Better<span className="font-semibold">Angels</span>
           </div>
         </div>

--- a/apps/wildfires/src/app/layout/header.tsx
+++ b/apps/wildfires/src/app/layout/header.tsx
@@ -31,7 +31,7 @@ export function Header(props: IParams): ReactElement {
       <Link to="/" className="flex items-center">
         <BetterAngelsLogoIcon className="h-7 sm:h-10 text-brand-sky-blue fill-current" />
         <div className="text-white flex ml-2 text-xl md:text-4xl">
-          <div className="font-normal">
+          <div className="font-normal notranslate">
             Wildfire <span className="font-semibold">LA</span>
           </div>
         </div>

--- a/apps/wildfires/src/app/pages/introduction/firesSurvey/components/SurveyCheckbox.tsx
+++ b/apps/wildfires/src/app/pages/introduction/firesSurvey/components/SurveyCheckbox.tsx
@@ -75,7 +75,11 @@ export function SurveyCheckbox(props: IProps): ReactElement {
       <div className={mergeCss(checkboxContainerCss)}>
         {checked && <CheckIcon className="text-white h-8" />}
       </div>
-      <div className={mergeCss(labelCss)}>{label}</div>
+      {['Palisades', 'Eaton', 'Kennet', 'Hurst'].includes(label) ? (
+        <div className={mergeCss(labelCss) + " notranslate"}>{label}</div>
+      ) : (
+        <div className={mergeCss(labelCss)}>{label}</div>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
Added the Google Translate to the Wildfire web app. Excluded the names of the wildfires as well as the "Wildfire LA" and "BetterAngels" text in the header/footer from translation to avoid confusion.