### PR TITLE
scrollTop on route change and survey question next (DEV-1309)

### DIFF
--- a/apps/wildfires/src/app/app.tsx
+++ b/apps/wildfires/src/app/app.tsx
@@ -1,16 +1,19 @@
 import { Route, Routes } from 'react-router-dom';
 import { MainLayout } from './layout/mainLayout';
 import { routeChildren } from './routes/appRoutes';
+import { useScrollTopOnLocationChange } from './shared/hooks/useScrollTopOnLocationChange';
 
 export function App() {
+  useScrollTopOnLocationChange();
+
   return (
-      <Routes>
-        <Route path="/" element={<MainLayout />}>
-          {routeChildren.map((route) => (
-            <Route key={route.path} path={route.path} element={route.element} />
-          ))}
-        </Route>
-      </Routes>
+    <Routes>
+      <Route path="/" element={<MainLayout />}>
+        {routeChildren.map((route) => (
+          <Route key={route.path} path={route.path} element={route.element} />
+        ))}
+      </Route>
+    </Routes>
   );
 }
 

--- a/apps/wildfires/src/app/pages/introduction/firesSurvey/FiresSurvey.tsx
+++ b/apps/wildfires/src/app/pages/introduction/firesSurvey/FiresSurvey.tsx
@@ -25,11 +25,16 @@ export function FiresSurvey() {
     navigateTo(surveyResultsPagePath);
   }
 
+  function onFormRender() {
+    window.scrollTo(0, 0);
+  }
+
   return (
     <SurveyProvider
       surveyForms={surveyConfig}
       ui={customUi}
       onSurveyEnd={onSurveyEnd}
+      onFormRender={onFormRender}
     >
       <Survey className="mt-8" onChange={onChange} />
     </SurveyProvider>

--- a/apps/wildfires/src/app/shared/components/survey/provider/SurveyProvider.tsx
+++ b/apps/wildfires/src/app/shared/components/survey/provider/SurveyProvider.tsx
@@ -8,10 +8,11 @@ export type TSurveyProvider = {
   surveyForms: TSurveyForm[];
   ui?: TSurveyUi;
   onSurveyEnd?: (results: TSurveyResults) => void;
+  onFormRender?: () => void;
 };
 
 export default function SurveyProvider(props: TSurveyProvider): ReactElement {
-  const { surveyForms, ui, onSurveyEnd, children } = props;
+  const { surveyForms, ui, onFormRender, onSurveyEnd, children } = props;
 
   const initialForm = surveyForms[0];
 
@@ -115,6 +116,10 @@ export default function SurveyProvider(props: TSurveyProvider): ReactElement {
 
     if (nextForm) {
       setCurrentForm(nextForm);
+
+      if (onFormRender) {
+        onFormRender();
+      }
 
       setFormHistory((prev) => {
         return [...prev, nextForm];

--- a/apps/wildfires/src/app/shared/hooks/useScrollTopOnLocationChange.tsx
+++ b/apps/wildfires/src/app/shared/hooks/useScrollTopOnLocationChange.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+export const useScrollTopOnLocationChange = (): void => {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
+};


### PR DESCRIPTION
### Scroll to to top on new question or page change
https://betterangels.atlassian.net/browse/DEV-1309

## Summary by Sourcery

Scroll the page to the top on route changes and when navigating to the next survey question.

New Features:
- Automatically scroll to the top of the page when the route changes.
- Automatically scroll to the top of the page when the user navigates to the next question in a survey.