### PR TITLE
pdf renderer

### DIFF
--- a/apps/wildfires/src/app/pages/introduction/index.tsx
+++ b/apps/wildfires/src/app/pages/introduction/index.tsx
@@ -1,18 +1,12 @@
-import { useRef } from 'react';
 import { HorizontalLayout } from '../../layout/horizontalLayout';
-import GeneratePDF from '../../shared/components/GeneratePDF';
 import { FiresSurvey } from './firesSurvey/FiresSurvey';
 
 export function Introduction() {
-  const pageRef = useRef<HTMLDivElement | null>(null);
   return (
-    <div ref={pageRef}>
+    <div>
       <HorizontalLayout>
         <FiresSurvey />
       </HorizontalLayout>
-
-      {/* Move to results page when we have one */}
-      <GeneratePDF pageRef={pageRef} fileName="LA Disaster Relief Navigator" />
     </div>
   );
 }

--- a/apps/wildfires/src/app/pages/result/index.tsx
+++ b/apps/wildfires/src/app/pages/result/index.tsx
@@ -1,10 +1,11 @@
+import { useAtom } from 'jotai';
 import { HorizontalLayout } from '../../layout/horizontalLayout';
+import { surveyResultsAtom } from '../../shared/atoms/surveyResultsAtom';
 import BestPractices from '../../shared/components/bestPractices/BestPractices';
+import GeneratePDF from '../../shared/components/GeneratePDF';
 import Hero from '../../shared/components/hero/Hero';
 import ImportantTips from '../../shared/components/importantTips/ImportantTips';
 import Register from '../../shared/components/register/Register';
-import { useAtom } from 'jotai';
-import { surveyResultsAtom } from '../../shared/atoms/surveyResultsAtom';
 import { SurveyResults } from '../../shared/components/surveyResults/SurveyResults';
 
 export default function Result() {
@@ -21,15 +22,20 @@ export default function Result() {
         </Hero>
       </HorizontalLayout>
       <HorizontalLayout>
-        <BestPractices />
+        <div id="content-to-pdf">
+          <BestPractices />
+          {!!surveyResults && (
+            <SurveyResults className="mt-8 mb-24" results={surveyResults} />
+          )}
+          <ImportantTips />
+        </div>
+        <GeneratePDF
+          className="mb-16 md:mb-28 bg-brand-dark-blue text-white mx-auto"
+          fileName="LA Disaster Relief Navigator"
+        />
       </HorizontalLayout>
-      <HorizontalLayout>
-        <ImportantTips />
-      </HorizontalLayout>
+
       <Register />
-      {!!surveyResults && (
-        <SurveyResults className="mt-8 mb-24" results={surveyResults} />
-      )}
     </>
   );
 }

--- a/apps/wildfires/src/app/shared/components/GeneratePDF.tsx
+++ b/apps/wildfires/src/app/shared/components/GeneratePDF.tsx
@@ -1,32 +1,32 @@
-import { MutableRefObject } from 'react';
-import { useReactToPrint } from 'react-to-print';
+import html2pdf from 'html2pdf.js';
+import { Button } from './button/Button';
 
 interface GeneratePDFProps {
-  pageRef: MutableRefObject<HTMLDivElement | null>;
   fileName: string | (() => string);
+  className?: string;
 }
 
-const GeneratePDF: React.FC<GeneratePDFProps> = ({ pageRef, fileName }) => {
-  const handlePrint = useReactToPrint({
-    contentRef: pageRef,
-    documentTitle: typeof fileName === 'function' ? fileName() : fileName,
-    pageStyle: `
-      @page {
-        size: auto;
-        margin: 0;
-      }
-      body {
-        margin: 0;
-        padding: 0;
-        -webkit-print-color-adjust: exact;
-      }
-      .no-page-break {
-        page-break-inside: avoid;
-      }
-    `,
-  });
+const GeneratePDF: React.FC<GeneratePDFProps> = ({ className }) => {
+  const options = {
+    margin: [20, 20],
+    filename: 'result-content.pdf',
+    html2canvas: { scale: 2, letterRendering: true },
+    jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
+    pagebreak: { mode: 'avoid-all' },
+  };
 
-  return <button onClick={() => handlePrint()}>Download Page as PDF</button>;
+  const handleGeneratePdf = () => {
+    const element = document.getElementById('content-to-pdf');
+    if (element) {
+      html2pdf(element, options);
+    }
+  };
+
+  return (
+    <Button className={className} onClick={handleGeneratePdf}>
+      Save Your Action Plan as a PDF
+    </Button>
+  );
 };
 
 export default GeneratePDF;

--- a/apps/wildfires/src/app/types/html2pdf.d.ts
+++ b/apps/wildfires/src/app/types/html2pdf.d.ts
@@ -1,0 +1,4 @@
+declare module 'html2pdf.js' {
+  function html2pdf(element: HTMLElement, options?: any): Promise<Blob>;
+  export default html2pdf;
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "expo-web-browser": "~13.0.3",
     "graphql": "^16.9.0",
     "haversine-distance": "^1.2.3",
+    "html2pdf.js": "^0.10.2",
     "i": "^0.3.7",
     "jotai": "^2.10.3",
     "npm": "^10.9.2",
@@ -69,7 +70,6 @@
     "react-native-svg-transformer": "1.3.0",
     "react-native-web": "0.19.12",
     "react-router-dom": "6.11.2",
-    "react-to-print": "^3.0.4",
     "tailwind-merge": "^2.5.5",
     "tslib": "^2.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,7 +2976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.9":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.9, @babel/runtime@npm:^7.23.2":
   version: 7.26.0
   resolution: "@babel/runtime@npm:7.26.0"
   dependencies:
@@ -5820,6 +5820,7 @@ __metadata:
     expo-web-browser: "npm:~13.0.3"
     graphql: "npm:^16.9.0"
     haversine-distance: "npm:^1.2.3"
+    html2pdf.js: "npm:^0.10.2"
     i: "npm:^0.3.7"
     jest: "npm:^29.4.1"
     jest-circus: "npm:^29.4.1"
@@ -5855,7 +5856,6 @@ __metadata:
     react-native-web: "npm:0.19.12"
     react-router-dom: "npm:6.11.2"
     react-test-renderer: "npm:18.2.0"
-    react-to-print: "npm:^3.0.4"
     tailwind-merge: "npm:^2.5.5"
     tailwindcss: "npm:3.4.3"
     ts-jest: "npm:^29.1.0"
@@ -10893,6 +10893,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/raf@npm:^3.4.0":
+  version: 3.4.3
+  resolution: "@types/raf@npm:3.4.3"
+  checksum: 10/70b0d8ce4ed1fdd60abbee8ff2a572bd2947bd764691f98ef948748375f5012db7ee39a037dd063cfbbb52c0b7479bec68111bbb95ce5de023ec581794c9b85f
+  languageName: node
+  linkType: hard
+
 "@types/range-parser@npm:*":
   version: 1.2.7
   resolution: "@types/range-parser@npm:1.2.7"
@@ -12507,6 +12514,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"atob@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "atob@npm:2.1.2"
+  bin:
+    atob: bin/atob.js
+  checksum: 10/0624406cc0295533b38b60ab2e3b028aa7b8225f37e0cde6be3bc5c13a8015c889b192e874fd7660671179cef055f2e258855f372b0e495bd4096cf0b4785c25
+  languageName: node
+  linkType: hard
+
 "auto-bind@npm:~4.0.0":
   version: 4.0.0
   resolution: "auto-bind@npm:4.0.0"
@@ -12936,6 +12952,13 @@ __metadata:
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 10/9706c088a283058a8a99e0bf91b0a2f75497f185980d9ffa8b304de1d9e58ebda7c72c07ebf01dadedaac5b2907b2c6f566f660d62bd336c3468e960403b9d65
+  languageName: node
+  linkType: hard
+
+"base64-arraybuffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 10/15e6400d2d028bf18be4ed97702b11418f8f8779fb8c743251c863b726638d52f69571d4cc1843224da7838abef0949c670bde46936663c45ad078e89fee5c62
   languageName: node
   linkType: hard
 
@@ -13564,6 +13587,22 @@ __metadata:
   version: 1.0.30001684
   resolution: "caniuse-lite@npm:1.0.30001684"
   checksum: 10/35dd0941dd32319c87409441e8400faea32114c4a74938c29262a613160d2890a4f57902e24c770f076dbd0b85c4442aa135f9f641d4a74a9246fe624e6f780a
+  languageName: node
+  linkType: hard
+
+"canvg@npm:^3.0.6":
+  version: 3.0.10
+  resolution: "canvg@npm:3.0.10"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/raf": "npm:^3.4.0"
+    core-js: "npm:^3.8.3"
+    raf: "npm:^3.4.1"
+    regenerator-runtime: "npm:^0.13.7"
+    rgbcolor: "npm:^1.0.1"
+    stackblur-canvas: "npm:^2.0.0"
+    svg-pathdata: "npm:^6.0.3"
+  checksum: 10/b8b418483df010e38c6a63597425d5826206e8295467ca6db24a42dacc56b5960dfd484d16fdf3e144fff54777a91e551be227588b76cc9ca71fb0efd3afde0e
   languageName: node
   linkType: hard
 
@@ -14409,6 +14448,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.6.0, core-js@npm:^3.8.3":
+  version: 3.40.0
+  resolution: "core-js@npm:3.40.0"
+  checksum: 10/9c7e7d2839db6c3c7b72725a3ce5edf6dd61fc771e1551e08b5622ca7da330f2f5d3c7dcd6a6e7889baa8d4cc5a909ba75b4add0d1f3da940a2a60a3e0603be5
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:^1.0.2, core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
@@ -14588,6 +14634,15 @@ __metadata:
   dependencies:
     hyphenate-style-name: "npm:^1.0.3"
   checksum: 10/bd2f569f1870389004cfacfd7b798c0f40933d34af1f040c391a08322d097790b9a9524affb2ba4d26122e9cb8f4256afb59edb6077dbe607506944a9c673c67
+  languageName: node
+  linkType: hard
+
+"css-line-break@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "css-line-break@npm:2.1.0"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10/e75cae40de511026228d4fa69e8d464895714f8899880b8268a446b57f0faa84b490ba1bdda5ed9e7f38f99ab947c6bc941bb505d8119c49072db079c1cacea5
   languageName: node
   linkType: hard
 
@@ -15544,6 +15599,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dompurify@npm:^2.5.4":
+  version: 2.5.8
+  resolution: "dompurify@npm:2.5.8"
+  checksum: 10/d1b7653abe9cbe81c7c5af3effb0c0fbc784f06df433b48149f4962b1931487b884ce5b9c5950b7c0b749878748758810965439251e9f6baee3a15de6b9f0411
+  languageName: node
+  linkType: hard
+
 "domutils@npm:^2.5.2, domutils@npm:^2.8.0":
   version: 2.8.0
   resolution: "domutils@npm:2.8.0"
@@ -15986,6 +16048,13 @@ __metadata:
     is-date-object: "npm:^1.0.1"
     is-symbol: "npm:^1.0.2"
   checksum: 10/74aeeefe2714cf99bb40cab7ce3012d74e1e2c1bd60d0a913b467b269edde6e176ca644b5ba03a5b865fb044a29bca05671cd445c85ca2cdc2de155d7fc8fe9b
+  languageName: node
+  linkType: hard
+
+"es6-promise@npm:^4.2.5":
+  version: 4.2.8
+  resolution: "es6-promise@npm:4.2.8"
+  checksum: 10/b250c55523c496c43c9216c2646e58ec182b819e036fe5eb8d83fa16f044ecc6b8dcefc88ace2097be3d3c4d02b6aa8eeae1a66deeaf13e7bee905ebabb350a3
   languageName: node
   linkType: hard
 
@@ -18785,6 +18854,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html2canvas@npm:^1.0.0, html2canvas@npm:^1.0.0-rc.5":
+  version: 1.4.1
+  resolution: "html2canvas@npm:1.4.1"
+  dependencies:
+    css-line-break: "npm:^2.1.0"
+    text-segmentation: "npm:^1.0.3"
+  checksum: 10/595790810557a1d4287f07b6ead49aed4f169f08eb00e20c1f030b93344003e84797d28cd8a220e8ec1b78641d460ca6add11b8531960725526f11a7b9fa9900
+  languageName: node
+  linkType: hard
+
+"html2pdf.js@npm:^0.10.2":
+  version: 0.10.2
+  resolution: "html2pdf.js@npm:0.10.2"
+  dependencies:
+    es6-promise: "npm:^4.2.5"
+    html2canvas: "npm:^1.0.0"
+    jspdf: "npm:^2.3.1"
+  checksum: 10/a9bf1696529718b9849d16fcb2d93a0118e7a3fc8d283635bf64cac14e152348ff6f86dde1ea24160b5b28f62a32f5aa4b911e5e1ca79736a1f39406e4d006a2
+  languageName: node
+  linkType: hard
+
 "htmlparser2@npm:^6.1.0":
   version: 6.1.0
   resolution: "htmlparser2@npm:6.1.0"
@@ -20943,6 +21033,31 @@ __metadata:
   version: 1.3.1
   resolution: "jsonparse@npm:1.3.1"
   checksum: 10/24531e956f0f19d79e22c157cebd81b37af3486ae22f9bc1028f8c2a4d1b70df48b168ff86f8568d9c2248182de9b6da9f50f685d5e4b9d1d2d339d2a29d15bc
+  languageName: node
+  linkType: hard
+
+"jspdf@npm:^2.3.1":
+  version: 2.5.2
+  resolution: "jspdf@npm:2.5.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.2"
+    atob: "npm:^2.1.2"
+    btoa: "npm:^1.2.1"
+    canvg: "npm:^3.0.6"
+    core-js: "npm:^3.6.0"
+    dompurify: "npm:^2.5.4"
+    fflate: "npm:^0.8.1"
+    html2canvas: "npm:^1.0.0-rc.5"
+  dependenciesMeta:
+    canvg:
+      optional: true
+    core-js:
+      optional: true
+    dompurify:
+      optional: true
+    html2canvas:
+      optional: true
+  checksum: 10/8e82c5b342c99bf7a1ac2470a01b2f5a9e6638749704b89aef858daad37054160ce41081913bbc2f4a8f76fb848bc7c4296f8fa5d781de94926bc1b8d97c2238
   languageName: node
   linkType: hard
 
@@ -24230,6 +24345,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"performance-now@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "performance-now@npm:2.1.0"
+  checksum: 10/534e641aa8f7cba160f0afec0599b6cecefbb516a2e837b512be0adbe6c1da5550e89c78059c7fabc5c9ffdf6627edabe23eb7c518c4500067a898fa65c2b550
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0, picocolors@npm:^1.0.1":
   version: 1.0.1
   resolution: "picocolors@npm:1.0.1"
@@ -25280,6 +25402,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"raf@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "raf@npm:3.4.1"
+  dependencies:
+    performance-now: "npm:^2.1.0"
+  checksum: 10/4c4b4c826b09d2aec6ca809f1a3c3c12136e7ec8d13fbb91f495dd2c99cd43345240e003da3bfd16036a432e635049fc6d9f69f9187f5f22ea88bb146ec75881
+  languageName: node
+  linkType: hard
+
 "rambda@npm:^9.1.0":
   version: 9.2.1
   resolution: "rambda@npm:9.2.1"
@@ -25850,15 +25981,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-to-print@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "react-to-print@npm:3.0.4"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ~19
-  checksum: 10/10cf0e47a45b96e9243f1e704224e3c0c0e1fda8a9de142e3dda15789546726ad15d77fc1c6269db45cf62f606c9127ae896be503cf5d81f73abcf26c453ed55
-  languageName: node
-  linkType: hard
-
 "react@npm:18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
@@ -26037,7 +26159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.2":
+"regenerator-runtime@npm:^0.13.2, regenerator-runtime@npm:^0.13.7":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 10/d493e9e118abef5b099c78170834f18540c4933cedf9bfabc32d3af94abfb59a7907bd7950259cbab0a929ebca7db77301e8024e5121e6482a82f78283dfd20c
@@ -26465,6 +26587,13 @@ __metadata:
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10/2f3d11d3d8929b4bfeefc9acb03aae90f971401de0add5ae6c5e38fec14f0405e6a4aad8fdb76344bfdd20c5193110e3750cbbd28ba86d73729d222b6cf4a729
+  languageName: node
+  linkType: hard
+
+"rgbcolor@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "rgbcolor@npm:1.0.1"
+  checksum: 10/afa76637181017e13dfc39debcc41f2f994a1b7c807cc863ba53bc03268ed7a28411094c1008185446b60a9d87131abae392acbe851c96f6dcf9994497019938
   languageName: node
   linkType: hard
 
@@ -27540,6 +27669,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackblur-canvas@npm:^2.0.0":
+  version: 2.7.0
+  resolution: "stackblur-canvas@npm:2.7.0"
+  checksum: 10/ad20aa886f5141c69b682cb8dd88ee04822f7dfa9f566d0657cf8fa43f5dd69122fe42dbc7071d44f655da89784756d34705b12d03f1c1f928325a55c698ab51
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.3.4":
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
@@ -28117,6 +28253,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"svg-pathdata@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "svg-pathdata@npm:6.0.3"
+  checksum: 10/ed20b3fd20fd2f9dfa519fee2a690ec6bff84be00882c04b1461d6e5a250da3e37236c1f3abe2dae9c8dae841cc33f2700396186f894e1953dc6c0149201ac21
+  languageName: node
+  linkType: hard
+
 "svgo@npm:^3.0.2, svgo@npm:^3.2.0":
   version: 3.3.2
   resolution: "svgo@npm:3.3.2"
@@ -28393,6 +28536,15 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10/8fccb2cb6c8fcb6bb4115394feb833f8b6cf4b9503ec2485c2c90febf435cac62abe882a0c5c51a37b9bbe70640cdd05acf5f45e486ac4583389f4b0855f69e5
+  languageName: node
+  linkType: hard
+
+"text-segmentation@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "text-segmentation@npm:1.0.3"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10/86191de83f09b96f356628c3dbaf6d281eda46a4dd4c94c3827495428871b9dd44ead4ef4cdf06a188b08a3b83e3943c5911841422b55286b121ba9e04c846dd
   languageName: node
   linkType: hard
 
@@ -29588,6 +29740,15 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10/5d6949693d58cb2e636a84f3ee1c6e7b2f9c16cb1d42d0ecb386d8c025c69e327205aa1c69e2868cc06a01e5e20681fbba55a4e0ed0cce913d60334024eae798
+  languageName: node
+  linkType: hard
+
+"utrie@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "utrie@npm:1.0.2"
+  dependencies:
+    base64-arraybuffer: "npm:^1.0.2"
+  checksum: 10/0c9458380bf3113f425a268e3d605aef163bfbaea62bf24de517b62b6e6744394d8ef1cdd9b07423359aec5ed402baab4bb2c5beec64f674ec635dc2f8dbd4bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary by Sourcery

Replace the `react-to-print` library with `html2pdf.js` for generating PDFs.

New Features:
- Generate PDF files of the wildfire action plan results.

Tests:
- Remove the unused `GeneratePDF` component from the introduction page.