### PR TITLE
Capitalize metadata of wildfire website description (DEV-1326)

### DIFF
--- a/apps/wildfires/index.html
+++ b/apps/wildfires/index.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8" />
   <title>LA Disaster Relief Navigator</title>
   <meta name="description"
-        content="resource finder for people impacted by fires in los angeles">
+        content="Resource finder for people impacted by fires in los angeles">
   <meta name="keywords" content="la los angeles wildfires" />
   <base href="/" />
   <meta name="viewport"
@@ -11,11 +11,9 @@
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="stylesheet" href="/src/assets/styles/fonts.css" />
   <link rel="stylesheet" href="/src/assets/styles/global.css" />
-  <script
-    type="text/javascript"
-    src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
-    async
-  ></script>
+  <script type="text/javascript"
+          src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
+          async></script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
DEV-1326

## Summary by Sourcery

Documentation:
- Capitalize the first letter of the "description" metadata tag content on the Wildfires website.