### PR TITLE
Capitalize Los Angeles (DEV-1326)

### DIFF
--- a/apps/wildfires/index.html
+++ b/apps/wildfires/index.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8" />
   <title>LA Disaster Relief Navigator</title>
   <meta name="description"
-        content="Resource finder for people impacted by fires in los angeles">
+        content="Resource finder for people impacted by fires in Los Angeles">
   <meta name="keywords" content="la los angeles wildfires" />
   <base href="/" />
   <meta name="viewport"


### PR DESCRIPTION
DEV-1326

## Summary by Sourcery

Documentation:
- Update the metadata description to capitalize "Los Angeles".