### PR TITLE
Wildfire header bigger logo (DEV-1375)

### DIFF
--- a/apps/wildfires/src/app/layout/header.tsx
+++ b/apps/wildfires/src/app/layout/header.tsx
@@ -25,7 +25,7 @@ export function Header(props: IParams): ReactElement {
 
   return (
     <header className={mergeCss(parentCss)}>
-      <HomeLink className="h-8 md:h-12" />
+      <HomeLink className="h-8 md:h-14" />
       <MenuDesktop />
       <MenuBtnMobile className="block lg:hidden" />
     </header>

--- a/apps/wildfires/src/app/layout/header.tsx
+++ b/apps/wildfires/src/app/layout/header.tsx
@@ -25,7 +25,7 @@ export function Header(props: IParams): ReactElement {
 
   return (
     <header className={mergeCss(parentCss)}>
-      <HomeLink className="h-8 md:h-14" />
+      <HomeLink className="min-w-[116px] w-[116px] md:w-[260px] md:min-w-[260px]" />
       <MenuDesktop />
       <MenuBtnMobile className="block lg:hidden" />
     </header>

--- a/apps/wildfires/src/app/shared/components/navBar/MenuDesktop.tsx
+++ b/apps/wildfires/src/app/shared/components/navBar/MenuDesktop.tsx
@@ -14,9 +14,9 @@ export function MenuDesktop(props: IProps) {
 
   return (
     <div className={mergeCss(parentCss)}>
-      <AboutLink className="mr-8 hidden lg:flex" />
+      <AboutLink className="mx-8 hidden lg:flex" />
       <GoogleTranslateBtn className="mr-8" />
-      <DonateButton className="hidden lg:flex" />
+      <DonateButton className="hidden lg:flex text-center" />
     </div>
   );
 }

--- a/apps/wildfires/src/app/shared/components/navBar/shared/AboutLink.tsx
+++ b/apps/wildfires/src/app/shared/components/navBar/shared/AboutLink.tsx
@@ -15,7 +15,7 @@ export function AboutLink(props: IProps) {
       <div className="hidden lg:block text-right">
         About LA Disaster Relief Navigator
       </div>
-      <div className="lg:hidden">About LA Disaster Relief Navigator</div>
+      <div className="lg:hidden">About</div>
     </Link>
   );
 }

--- a/apps/wildfires/src/app/shared/components/navBar/shared/AboutLink.tsx
+++ b/apps/wildfires/src/app/shared/components/navBar/shared/AboutLink.tsx
@@ -12,8 +12,10 @@ export function AboutLink(props: IProps) {
 
   return (
     <Link className={mergeCss(parentCss)} to="/about">
-      <div className="hidden lg:block">About LA Disaster Relief Navigator</div>
-      <div className="lg:hidden">About</div>
+      <div className="hidden lg:block text-right">
+        About LA Disaster Relief Navigator
+      </div>
+      <div className="lg:hidden">About LA Disaster Relief Navigator</div>
     </Link>
   );
 }


### PR DESCRIPTION
DEV-1375

## Summary by Sourcery

Enhancements:
- Increase the maximum height of the logo from 12 units to 14 units on medium and large screens.