### PR TITLE
Make resource card headers beefier (DEV-1376)

### DIFF
--- a/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
@@ -25,7 +25,7 @@ export function ResourceCard(props: IProps) {
 
   return (
     <div className={mergeCss(parentCss)}>
-      <div className="font-bold">{title}</div>
+      <div className="font-bold text-[24px]">{title}</div>
 
       {!!shortDescription && (
         <ResourcePortableText className="mt-8" data={shortDescription} />


### PR DESCRIPTION
DEV-1376

before:
<img width="735" alt="image" src="https://github.com/user-attachments/assets/f90d30b7-128c-4437-8234-f635f3672f11" />

after:
<img width="735" alt="image" src="https://github.com/user-attachments/assets/b87355da-c043-47a1-8928-2311bc186de8" />

## Summary by Sourcery

Enhancements:
- Improve the visual prominence of resource card headers.