### PR TITLE
Prevent duplicate survey submissions (DEV-1365)

### DIFF
--- a/apps/wildfires/src/app/pages/result/index.tsx
+++ b/apps/wildfires/src/app/pages/result/index.tsx
@@ -1,5 +1,5 @@
+// src/app/pages/result/index.tsx
 import { useAtom } from 'jotai';
-import { useEffect } from 'react';
 import { HorizontalLayout } from '../../layout/horizontalLayout';
 import { surveyResultsAtom } from '../../shared/atoms/surveyResultsAtom';
 import GeneratePDF from '../../shared/components/GeneratePDF';
@@ -9,42 +9,12 @@ import ImportantTips from '../../shared/components/importantTips/ImportantTips';
 import Partners from '../../shared/components/partners/Partners';
 import Register from '../../shared/components/register/Register';
 import { SurveyResults } from '../../shared/components/surveyResults/SurveyResults';
-
-const currentDomain = window.location.origin;
-const basename = import.meta.env.VITE_APP_BASE_PATH || '/';
+import useSurveySubmission from '../../shared/hooks/useSurveySubmission';
 
 export default function Result() {
   const [surveyResults] = useAtom(surveyResultsAtom);
 
-  const submitSurvey = async (survey: any) => {
-    try {
-      const newDate = new Date();
-
-      const surveyData = {
-        answers: survey.answers,
-        timestamp: newDate,
-        referrer_base: basename,
-      };
-
-      await fetch(`${currentDomain}/api/submitResults`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(surveyData),
-      });
-    } catch (error) {
-      console.error('Request failed', error);
-    }
-  };
-
-  useEffect(() => {
-    if (!surveyResults) {
-      return;
-    }
-
-    submitSurvey(surveyResults);
-  }, [surveyResults]);
+  useSurveySubmission(surveyResults || null);
 
   return (
     <>
@@ -58,7 +28,7 @@ export default function Result() {
       <HorizontalLayout>
         <div id="content-to-pdf">
           <BestPractices />
-          {!!surveyResults && (
+          {surveyResults && (
             <SurveyResults className="mt-8 mb-24" results={surveyResults} />
           )}
           <ImportantTips />

--- a/apps/wildfires/src/app/pages/result/index.tsx
+++ b/apps/wildfires/src/app/pages/result/index.tsx
@@ -1,4 +1,3 @@
-// src/app/pages/result/index.tsx
 import { useAtom } from 'jotai';
 import { HorizontalLayout } from '../../layout/horizontalLayout';
 import { surveyResultsAtom } from '../../shared/atoms/surveyResultsAtom';

--- a/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
+++ b/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
@@ -1,5 +1,4 @@
-// src/hooks/useSurveySubmission.ts
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { isDeepEqual } from 'remeda';
 import { v4 as uuidv4 } from 'uuid';
 import { TSurveyResults } from '../../shared/components/survey/types';
@@ -14,85 +13,101 @@ interface StoredSurveyData {
 type SubmissionStatus = 'idle' | 'loading' | 'success' | 'error';
 
 /**
- * Custom hook to handle survey submission with unique IDs and localStorage persistence.
+ * Custom hook to handle survey submission with retry logic and localStorage persistence.
  *
  * @param surveyResults - The current survey results.
+ * @param maxRetries - Maximum number of retries for failed submissions (default: 3).
+ * @param retryDelay - Delay between retries in milliseconds (default: 1000 ms).
  * @returns The current submission status.
  */
 const useSurveySubmission = (
-  surveyResults: TSurveyResults | null
+  surveyResults: TSurveyResults | null,
+  maxRetries = 3,
+  retryDelay = 1000
 ): SubmissionStatus => {
   const [storedData, setStoredDataState] = useState<StoredSurveyData | null>(
     () => {
       const data = localStorage.getItem(LOCAL_STORAGE_KEY);
-      return data ? (JSON.parse(data) as StoredSurveyData) : null;
+      return data ? JSON.parse(data) : null;
     }
   );
 
   const [status, setStatus] = useState<SubmissionStatus>('idle');
 
-  useEffect(() => {
-    if (!surveyResults) return;
-
-    const { answers } = surveyResults;
-
-    // If there's no stored data, treat this as the first submission
-    if (!storedData) {
-      const newID = uuidv4();
-      submitSurvey(surveyResults, newID);
-      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
-      setStoredDataState(newStoredData);
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
-      return;
-    }
-
-    // Compare current answers with stored answers
-    if (!isDeepEqual(answers, storedData.answers)) {
-      const newID = uuidv4();
-      submitSurvey(surveyResults, newID);
-      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
-      setStoredDataState(newStoredData);
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
-    } else {
-      console.log('No changes in answers. Submission skipped.');
-    }
-  }, [surveyResults, storedData]);
+  // Track active submissions to prevent duplicates
+  const isSubmitting = useRef(false);
 
   /**
-   * Submits the survey data to the server.
+   * Attempts to submit the survey data to the server.
    *
    * @param survey - The survey results.
    * @param surveyID - The unique identifier for the survey.
+   * @param retries - Current retry attempt (default: 0).
    */
-  const submitSurvey = async (survey: TSurveyResults, surveyID: string) => {
-    setStatus('loading');
-    try {
-      const surveyData = {
-        id: surveyID,
-        answers: survey.answers,
-        timestamp: new Date(),
-        referrer_base: import.meta.env.VITE_APP_BASE_PATH || '/',
-      };
+  const attemptSubmission = useCallback(
+    async (survey: TSurveyResults, surveyID: string, retries = 0) => {
+      setStatus('loading');
+      isSubmitting.current = true;
 
-      const response = await fetch(
-        `${window.location.origin}/api/submitResults`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(surveyData),
+      try {
+        const response = await fetch(
+          `${window.location.origin}/api/submitResults`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              id: surveyID,
+              answers: survey.answers,
+              timestamp: new Date(),
+              referrer_base: import.meta.env.VITE_APP_BASE_PATH || '/',
+            }),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error(`Server error: ${response.statusText}`);
         }
-      );
 
-      if (!response.ok) {
-        throw new Error(`Server error: ${response.statusText}`);
+        // Update localStorage and state after a successful submission
+        const newStoredData: StoredSurveyData = {
+          answers: survey.answers,
+          surveyID,
+        };
+        setStoredDataState(newStoredData);
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
+        setStatus('success');
+        console.log('Survey submitted successfully:', surveyID);
+      } catch (error) {
+        console.error(`Attempt ${retries + 1} failed:`, error);
+
+        if (retries < maxRetries) {
+          setTimeout(
+            () => attemptSubmission(survey, surveyID, retries + 1),
+            retryDelay
+          );
+        } else {
+          setStatus('error');
+          console.error(`Max retries reached for survey ID: ${surveyID}`);
+        }
+      } finally {
+        isSubmitting.current = false;
       }
-      console.log('Survey submitted successfully with ID:', surveyID);
-      setStatus('success');
-    } catch (error) {
-      console.error('Survey submission failed:', error);
-      setStatus('error');
+    },
+    [maxRetries, retryDelay]
+  );
+
+  useEffect(() => {
+    if (!surveyResults || isSubmitting.current) return;
+
+    const { answers } = surveyResults;
+    const isNewSubmission =
+      !storedData || !isDeepEqual(answers, storedData.answers);
+
+    if (isNewSubmission) {
+      const surveyID = uuidv4();
+      attemptSubmission(surveyResults, surveyID);
     }
-  };
+  }, [surveyResults, storedData, attemptSubmission]);
 
   return status;
 };

--- a/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
+++ b/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
@@ -1,5 +1,4 @@
-// src/hooks/useSurveySubmission.ts
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { isDeepEqual } from 'remeda';
 import { v4 as uuidv4 } from 'uuid';
 import { TSurveyResults } from '../../shared/components/survey/types';
@@ -14,85 +13,95 @@ interface StoredSurveyData {
 type SubmissionStatus = 'idle' | 'loading' | 'success' | 'error';
 
 /**
- * Custom hook to handle survey submission with unique IDs and localStorage persistence.
+ * Custom hook to handle survey submission with retry logic and localStorage persistence.
  *
  * @param surveyResults - The current survey results.
+ * @param maxRetries - Maximum number of retries for failed submissions (default: 3).
+ * @param retryDelay - Delay between retries in milliseconds (default: 1000 ms).
  * @returns The current submission status.
  */
 const useSurveySubmission = (
-  surveyResults: TSurveyResults | null
+  surveyResults: TSurveyResults | null,
+  maxRetries = 3,
+  retryDelay = 1000
 ): SubmissionStatus => {
   const [storedData, setStoredDataState] = useState<StoredSurveyData | null>(
     () => {
       const data = localStorage.getItem(LOCAL_STORAGE_KEY);
-      return data ? (JSON.parse(data) as StoredSurveyData) : null;
+      return data ? JSON.parse(data) : null;
     }
   );
 
   const [status, setStatus] = useState<SubmissionStatus>('idle');
 
+  /**
+   * Attempts to submit the survey data to the server.
+   *
+   * @param survey - The survey results.
+   * @param surveyID - The unique identifier for the survey.
+   * @param retries - Current retry attempt (default: 0).
+   */
+  const attemptSubmission = useCallback(
+    async (survey: TSurveyResults, surveyID: string, retries = 0) => {
+      setStatus('loading');
+
+      try {
+        const response = await fetch(
+          `${window.location.origin}/api/submitResults`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              id: surveyID,
+              answers: survey.answers,
+              timestamp: new Date(),
+              referrer_base: import.meta.env.VITE_APP_BASE_PATH || '/',
+            }),
+          }
+        );
+
+        if (!response.ok) {
+          throw new Error(`Server error: ${response.statusText}`);
+        }
+
+        // Update localStorage and state after a successful submission
+        const newStoredData: StoredSurveyData = {
+          answers: survey.answers,
+          surveyID,
+        };
+        setStoredDataState(newStoredData);
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
+        setStatus('success');
+        console.log('Survey submitted successfully:', surveyID);
+      } catch (error) {
+        console.error(`Attempt ${retries + 1} failed:`, error);
+
+        if (retries < maxRetries) {
+          setTimeout(
+            () => attemptSubmission(survey, surveyID, retries + 1),
+            retryDelay
+          );
+        } else {
+          setStatus('error');
+          console.error(`Max retries reached for survey ID: ${surveyID}`);
+        }
+      }
+    },
+    [maxRetries, retryDelay]
+  );
+
   useEffect(() => {
     if (!surveyResults) return;
 
     const { answers } = surveyResults;
+    const isNewSubmission =
+      !storedData || !isDeepEqual(answers, storedData.answers);
 
-    // If there's no stored data, treat this as the first submission
-    if (!storedData) {
-      const newID = uuidv4();
-      submitSurvey(surveyResults, newID);
-      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
-      setStoredDataState(newStoredData);
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
-      return;
+    if (isNewSubmission) {
+      const surveyID = uuidv4();
+      attemptSubmission(surveyResults, surveyID);
     }
-
-    // Compare current answers with stored answers
-    if (!isDeepEqual(answers, storedData.answers)) {
-      const newID = uuidv4();
-      submitSurvey(surveyResults, newID);
-      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
-      setStoredDataState(newStoredData);
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
-    } else {
-      console.log('No changes in answers. Submission skipped.');
-    }
-  }, [surveyResults, storedData]);
-
-  /**
-   * Submits the survey data to the server.
-   *
-   * @param survey - The survey results.
-   * @param surveyID - The unique identifier for the survey.
-   */
-  const submitSurvey = async (survey: TSurveyResults, surveyID: string) => {
-    setStatus('loading');
-    try {
-      const surveyData = {
-        id: surveyID,
-        answers: survey.answers,
-        timestamp: new Date(),
-        referrer_base: import.meta.env.VITE_APP_BASE_PATH || '/',
-      };
-
-      const response = await fetch(
-        `${window.location.origin}/api/submitResults`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(surveyData),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error(`Server error: ${response.statusText}`);
-      }
-      console.log('Survey submitted successfully with ID:', surveyID);
-      setStatus('success');
-    } catch (error) {
-      console.error('Survey submission failed:', error);
-      setStatus('error');
-    }
-  };
+  }, [surveyResults, storedData, attemptSubmission]);
 
   return status;
 };

--- a/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
+++ b/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
@@ -1,0 +1,100 @@
+// src/hooks/useSurveySubmission.ts
+import { useEffect, useState } from 'react';
+import { isDeepEqual } from 'remeda';
+import { v4 as uuidv4 } from 'uuid';
+import { TSurveyResults } from '../../shared/components/survey/types';
+
+const LOCAL_STORAGE_KEY = 'survey_submission';
+
+interface StoredSurveyData {
+  answers: TSurveyResults['answers'];
+  surveyID: string;
+}
+
+type SubmissionStatus = 'idle' | 'loading' | 'success' | 'error';
+
+/**
+ * Custom hook to handle survey submission with unique IDs and localStorage persistence.
+ *
+ * @param surveyResults - The current survey results.
+ * @returns The current submission status.
+ */
+const useSurveySubmission = (
+  surveyResults: TSurveyResults | null
+): SubmissionStatus => {
+  const [storedData, setStoredDataState] = useState<StoredSurveyData | null>(
+    () => {
+      const data = localStorage.getItem(LOCAL_STORAGE_KEY);
+      return data ? (JSON.parse(data) as StoredSurveyData) : null;
+    }
+  );
+
+  const [status, setStatus] = useState<SubmissionStatus>('idle');
+
+  useEffect(() => {
+    if (!surveyResults) return;
+
+    const { answers } = surveyResults;
+
+    // If there's no stored data, treat this as the first submission
+    if (!storedData) {
+      const newID = uuidv4();
+      submitSurvey(surveyResults, newID);
+      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
+      setStoredDataState(newStoredData);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
+      return;
+    }
+
+    // Compare current answers with stored answers
+    if (!isDeepEqual(answers, storedData.answers)) {
+      const newID = uuidv4();
+      submitSurvey(surveyResults, newID);
+      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
+      setStoredDataState(newStoredData);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
+    } else {
+      console.log('No changes in answers. Submission skipped.');
+    }
+  }, [surveyResults, storedData]);
+
+  /**
+   * Submits the survey data to the server.
+   *
+   * @param survey - The survey results.
+   * @param surveyID - The unique identifier for the survey.
+   */
+  const submitSurvey = async (survey: TSurveyResults, surveyID: string) => {
+    setStatus('loading');
+    try {
+      const surveyData = {
+        id: surveyID,
+        answers: survey.answers,
+        timestamp: new Date(),
+        referrer_base: import.meta.env.VITE_APP_BASE_PATH || '/',
+      };
+
+      const response = await fetch(
+        `${window.location.origin}/api/submitResults`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(surveyData),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Server error: ${response.statusText}`);
+      }
+      console.log('Survey submitted successfully with ID:', surveyID);
+      setStatus('success');
+    } catch (error) {
+      console.error('Survey submission failed:', error);
+      setStatus('error');
+    }
+  };
+
+  return status;
+};
+
+export default useSurveySubmission;

--- a/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
+++ b/apps/wildfires/src/app/shared/hooks/useSurveySubmission.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+// src/hooks/useSurveySubmission.ts
+import { useEffect, useState } from 'react';
 import { isDeepEqual } from 'remeda';
 import { v4 as uuidv4 } from 'uuid';
 import { TSurveyResults } from '../../shared/components/survey/types';
@@ -13,95 +14,85 @@ interface StoredSurveyData {
 type SubmissionStatus = 'idle' | 'loading' | 'success' | 'error';
 
 /**
- * Custom hook to handle survey submission with retry logic and localStorage persistence.
+ * Custom hook to handle survey submission with unique IDs and localStorage persistence.
  *
  * @param surveyResults - The current survey results.
- * @param maxRetries - Maximum number of retries for failed submissions (default: 3).
- * @param retryDelay - Delay between retries in milliseconds (default: 1000 ms).
  * @returns The current submission status.
  */
 const useSurveySubmission = (
-  surveyResults: TSurveyResults | null,
-  maxRetries = 3,
-  retryDelay = 1000
+  surveyResults: TSurveyResults | null
 ): SubmissionStatus => {
   const [storedData, setStoredDataState] = useState<StoredSurveyData | null>(
     () => {
       const data = localStorage.getItem(LOCAL_STORAGE_KEY);
-      return data ? JSON.parse(data) : null;
+      return data ? (JSON.parse(data) as StoredSurveyData) : null;
     }
   );
 
   const [status, setStatus] = useState<SubmissionStatus>('idle');
 
-  /**
-   * Attempts to submit the survey data to the server.
-   *
-   * @param survey - The survey results.
-   * @param surveyID - The unique identifier for the survey.
-   * @param retries - Current retry attempt (default: 0).
-   */
-  const attemptSubmission = useCallback(
-    async (survey: TSurveyResults, surveyID: string, retries = 0) => {
-      setStatus('loading');
-
-      try {
-        const response = await fetch(
-          `${window.location.origin}/api/submitResults`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              id: surveyID,
-              answers: survey.answers,
-              timestamp: new Date(),
-              referrer_base: import.meta.env.VITE_APP_BASE_PATH || '/',
-            }),
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error(`Server error: ${response.statusText}`);
-        }
-
-        // Update localStorage and state after a successful submission
-        const newStoredData: StoredSurveyData = {
-          answers: survey.answers,
-          surveyID,
-        };
-        setStoredDataState(newStoredData);
-        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
-        setStatus('success');
-        console.log('Survey submitted successfully:', surveyID);
-      } catch (error) {
-        console.error(`Attempt ${retries + 1} failed:`, error);
-
-        if (retries < maxRetries) {
-          setTimeout(
-            () => attemptSubmission(survey, surveyID, retries + 1),
-            retryDelay
-          );
-        } else {
-          setStatus('error');
-          console.error(`Max retries reached for survey ID: ${surveyID}`);
-        }
-      }
-    },
-    [maxRetries, retryDelay]
-  );
-
   useEffect(() => {
     if (!surveyResults) return;
 
     const { answers } = surveyResults;
-    const isNewSubmission =
-      !storedData || !isDeepEqual(answers, storedData.answers);
 
-    if (isNewSubmission) {
-      const surveyID = uuidv4();
-      attemptSubmission(surveyResults, surveyID);
+    // If there's no stored data, treat this as the first submission
+    if (!storedData) {
+      const newID = uuidv4();
+      submitSurvey(surveyResults, newID);
+      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
+      setStoredDataState(newStoredData);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
+      return;
     }
-  }, [surveyResults, storedData, attemptSubmission]);
+
+    // Compare current answers with stored answers
+    if (!isDeepEqual(answers, storedData.answers)) {
+      const newID = uuidv4();
+      submitSurvey(surveyResults, newID);
+      const newStoredData: StoredSurveyData = { answers, surveyID: newID };
+      setStoredDataState(newStoredData);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newStoredData));
+    } else {
+      console.log('No changes in answers. Submission skipped.');
+    }
+  }, [surveyResults, storedData]);
+
+  /**
+   * Submits the survey data to the server.
+   *
+   * @param survey - The survey results.
+   * @param surveyID - The unique identifier for the survey.
+   */
+  const submitSurvey = async (survey: TSurveyResults, surveyID: string) => {
+    setStatus('loading');
+    try {
+      const surveyData = {
+        id: surveyID,
+        answers: survey.answers,
+        timestamp: new Date(),
+        referrer_base: import.meta.env.VITE_APP_BASE_PATH || '/',
+      };
+
+      const response = await fetch(
+        `${window.location.origin}/api/submitResults`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(surveyData),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Server error: ${response.statusText}`);
+      }
+      console.log('Survey submitted successfully with ID:', surveyID);
+      setStatus('success');
+    } catch (error) {
+      console.error('Survey submission failed:', error);
+      setStatus('error');
+    }
+  };
 
   return status;
 };


### PR DESCRIPTION
DEV-1365

Currently, survey submissions are not unique, and refreshing the results page causes multiple submissions of the same survey. To resolve this issue, we need to generate a unique identifier (UUID) for each survey when it is created and include this identifier in the payload to ensure submissions are unique.

## Summary by Sourcery

Prevent duplicate survey submissions by generating a unique identifier for each survey and including it in the payload.

New Features:
- Added unique identifiers to survey submissions to prevent duplicates.

Tests:
- Added unit tests for the useSurveySubmission hook.