### PR TITLE
Add dropshadow to resource card (DEV-1406)

### DIFF
--- a/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
@@ -20,6 +20,7 @@ export function ResourceCard(props: IProps) {
     'border',
     'p-6',
     'rounded-lg',
+    '[box-shadow:0_4px_6px_#7777771A]',
     className,
   ];
 


### PR DESCRIPTION
DEV-1406

before
<img width="784" alt="image" src="https://github.com/user-attachments/assets/540b3fa6-1e01-4e49-b57b-d24ed591a74b" />

after
<img width="769" alt="image" src="https://github.com/user-attachments/assets/9c64756d-36b1-44de-9778-8db1b9583b06" />

## Summary by Sourcery

Enhancements:
- Improve the visual separation of resource cards by adding a drop shadow.