### PR TITLE
Wildfire survey nav mb same as mt (DEV-1405)

### DIFF
--- a/apps/wildfires/src/app/shared/components/survey/Survey.tsx
+++ b/apps/wildfires/src/app/shared/components/survey/Survey.tsx
@@ -92,7 +92,11 @@ export function Survey(props: IProps) {
         onAnswer={handleAnswer}
       />
 
-      <SurveyNav className="mt-14" onNext={onClickNext} onPrev={onClickPrev} />
+      <SurveyNav
+        className="mt-14 mb-14"
+        onNext={onClickNext}
+        onPrev={onClickPrev}
+      />
     </div>
   );
 }


### PR DESCRIPTION
DEV-1405

before
<img width="797" alt="image" src="https://github.com/user-attachments/assets/c8bbdc9e-c67a-465c-abf8-3d3e57e5d9f7" />


after
<img width="842" alt="image" src="https://github.com/user-attachments/assets/45ec6b59-60c3-453d-959f-66bfb4bf2cdc" />


## Summary by Sourcery

Enhancements:
- Improve the visual layout of the wildfire survey navigation.