### PR TITLE
alerts section (DEV-1365)

### DIFF
--- a/apps/wildfires/src/app/shared/clients/sanityCms/queries/utils/normalizeQueryString.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/queries/utils/normalizeQueryString.ts
@@ -1,0 +1,7 @@
+export function normalizeQueryString(query: string): string {
+  if (!query) {
+    return '';
+  }
+
+  return query.replace(/\s+/g, ' ').trim();
+}

--- a/apps/wildfires/src/app/shared/components/surveyResources/AlertResources.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/AlertResources.tsx
@@ -1,0 +1,47 @@
+// AlertResources.tsx
+
+import { TResource } from '../../clients/sanityCms/types';
+import { sortByPriority } from '../../utils/sort';
+import { mergeCss } from '../../utils/styles/mergeCss';
+import { ResourceCard } from './ResourceCard';
+
+type IProps = {
+  className?: string;
+  resources?: TResource[];
+};
+
+export function AlertResources(props: IProps) {
+  const { resources, className } = props;
+
+  const parentCss = [
+    'flex',
+    'flex-col',
+    'bg-[#FFFEE0]',
+    'px-4',
+    'py-[52px]',
+    'rounded-xl',
+    className,
+  ];
+
+  if (!resources?.length) {
+    return null;
+  }
+
+  const sortedResources = sortByPriority<TResource>(resources, 'priority');
+
+  return (
+    <div className={mergeCss(parentCss)}>
+      <div className="uppercase text-lg font-bold mb-10 lg:mb-[60px]">
+        alerts
+      </div>
+
+      {sortedResources.map((resource) => (
+        <ResourceCard
+          key={resource.slug}
+          className="mb-4 lg:mb-10 last:mb-0"
+          resource={resource}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/wildfires/src/app/shared/components/surveyResources/AlertResources.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/AlertResources.tsx
@@ -1,5 +1,3 @@
-// AlertResources.tsx
-
 import { TResource } from '../../clients/sanityCms/types';
 import { sortByPriority } from '../../utils/sort';
 import { mergeCss } from '../../utils/styles/mergeCss';
@@ -7,27 +5,27 @@ import { ResourceCard } from './ResourceCard';
 
 type IProps = {
   className?: string;
-  resources?: TResource[];
+  alerts?: TResource[];
 };
 
 export function AlertResources(props: IProps) {
-  const { resources, className } = props;
+  const { alerts, className } = props;
 
   const parentCss = [
     'flex',
     'flex-col',
-    'bg-[#FFFEE0]',
+    'bg-[#FFFEE0]', // TODO: get named color
     'px-4',
     'py-[52px]',
     'rounded-xl',
     className,
   ];
 
-  if (!resources?.length) {
+  if (!alerts?.length) {
     return null;
   }
 
-  const sortedResources = sortByPriority<TResource>(resources, 'priority');
+  const sortedAlerts = sortByPriority<TResource>(alerts, 'priority');
 
   return (
     <div className={mergeCss(parentCss)}>
@@ -35,11 +33,11 @@ export function AlertResources(props: IProps) {
         alerts
       </div>
 
-      {sortedResources.map((resource) => (
+      {sortedAlerts.map((alert) => (
         <ResourceCard
-          key={resource.slug}
+          key={alert.slug}
           className="mb-4 lg:mb-10 last:mb-0"
-          resource={resource}
+          resource={alert}
         />
       ))}
     </div>

--- a/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
@@ -20,6 +20,7 @@ export function ResourceCard(props: IProps) {
     'border',
     'p-6',
     'rounded-lg',
+    'bg-white',
     '[box-shadow:0_4px_6px_#7777771A]',
     className,
   ];

--- a/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
@@ -1,6 +1,7 @@
 import { groupBy, sortBy, uniqueBy } from 'remeda';
 import { TResource, TTagCategory } from '../../clients/sanityCms/types';
 import { mergeCss } from '../../utils/styles/mergeCss';
+import { AlertResources } from './AlertResources';
 import { ResourceGroupCard } from './ResourceGroupCard';
 type IProps = {
   className?: string;
@@ -12,7 +13,10 @@ export function SurveyResources(props: IProps) {
 
   const parentCss = [className];
 
-  const groupedAndSortedResources = groupResources(resources);
+  const baseResources = resources.filter((r) => r.resourceType === 'resource');
+  const alertResources = resources.filter((r) => r.resourceType === 'alert');
+
+  const baseResourcesGroupedSorted = groupResources(baseResources);
 
   return (
     <div className={mergeCss(parentCss)}>
@@ -20,18 +24,31 @@ export function SurveyResources(props: IProps) {
         Resources
       </div>
 
-      {groupedAndSortedResources.map((categoryResources) => {
-        const { category, resources } = categoryResources;
+      {!!baseResourcesGroupedSorted.length && (
+        <div>
+          {baseResourcesGroupedSorted.map((categoryResources) => {
+            const { category, resources } = categoryResources;
 
-        return (
-          <ResourceGroupCard
-            key={category.slug}
+            return (
+              <ResourceGroupCard
+                key={category.slug}
+                className="mb-12 md:mb-20 last:mb-0"
+                resourceCategory={category.name}
+                resources={resources}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {!!alertResources.length && (
+        <div className="mt-12 md:mt-16">
+          <AlertResources
             className="mb-12 md:mb-20 last:mb-0"
-            resourceCategory={category.name}
-            resources={resources}
+            resources={alertResources}
           />
-        );
-      })}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
@@ -45,7 +45,7 @@ export function SurveyResources(props: IProps) {
         <div className="mt-12 md:mt-16">
           <AlertResources
             className="mb-12 md:mb-20 last:mb-0"
-            resources={alertResources}
+            alerts={alertResources}
           />
         </div>
       )}

--- a/apps/wildfires/src/app/shared/components/surveyResults/SurveyResults.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResults/SurveyResults.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { surveyConfig } from '../../../pages/introduction/firesSurvey/config/config';
-import { fetchResourcesByTagsFn } from '../../clients/sanityCms/queries/fetchResourcesByTagsFn';
+import { fetchAllAlertsAndResourcesByTagsFn } from '../../clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn';
 import { toTResources } from '../../clients/sanityCms/utils/toTResource';
 import { mergeCss } from '../../utils/styles/mergeCss';
 import { TAnswer, TOption, TSurveyResults } from '../survey/types';
@@ -74,7 +74,7 @@ export function SurveyResults(props: IProps) {
 
   const { isLoading, isError, data, error } = useQuery({
     queryKey: queryTags,
-    queryFn: () => fetchResourcesByTagsFn(queryTags),
+    queryFn: () => fetchAllAlertsAndResourcesByTagsFn(queryTags),
     refetchOnWindowFocus: false,
     retry: 1,
   });


### PR DESCRIPTION
### Results - Alerts
https://betterangels.atlassian.net/browse/DEV-1365

**deployed to**: https://wildfires.dev.betterangels.la/alerts

## Summary by Sourcery

Introduce an alerts section to display alert resources.

New Features:
- Display alerts fetched from Sanity CMS in a dedicated "Alerts" section within the Survey Resources component.

Tests:
- No tests were added or modified as part of this change.