### PR TITLE
set modal mask z-index above google skiptranslate bar (DEV-1393)

### DIFF
--- a/apps/wildfires/src/app/shared/modal/modalMask.tsx
+++ b/apps/wildfires/src/app/shared/modal/modalMask.tsx
@@ -15,12 +15,13 @@ export function ModalMask(props: IProps) {
   const [_modal, setModal] = useAtom(modalAtom);
 
   const parentCss: string = [
+    // z-index should be above z-index of google skiptranslate bar, which is 10000001
+    'z-[90000001]',
     'top-0',
     'left-0',
     'right-0',
     'bottom-0',
     'fixed',
-    'z-max',
     'flex',
     'justify-center',
     'items-center',


### PR DESCRIPTION
### Nav close hidden behind translate bar on mobile
https://betterangels.atlassian.net/browse/DEV-1393

**demo:** https://wildfires.dev.betterangels.la/modal-close

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where the navigation close button was hidden behind the translate bar on mobile.