### PR TITLE
Make logo bigger (DEV-1408)

### DIFF
--- a/apps/wildfires/src/app/layout/header.tsx
+++ b/apps/wildfires/src/app/layout/header.tsx
@@ -16,8 +16,8 @@ export function Header(props: IParams): ReactElement {
     'flex',
     'items-center',
     'justify-between',
-    'h-[72px]',
-    'md:h-[104px]',
+    'h-[104px]',
+    'md:h-[110px]',
     'text-white',
     'relative',
     className,
@@ -25,8 +25,8 @@ export function Header(props: IParams): ReactElement {
 
   return (
     <header className={mergeCss(parentCss)}>
-      <HomeLink className="min-w-[116px] w-[116px] md:w-[260px] md:min-w-[260px]" />
-      <MenuDesktop/>
+      <HomeLink className="min-w-[200px] w-[200px] md:w-[300px] md:min-w-[300px]" />
+      <MenuDesktop />
       <MenuBtnMobile className="block lg:hidden" />
     </header>
   );


### PR DESCRIPTION
DEV-1408

## Summary by Sourcery

Increase the size of the header and logo to improve their visibility on the page.

New Features:
- Increase the width of the home link from 116px to 200px on mobile and from 260px to 300px on desktop.

Enhancements:
- Increase the height of the header component on desktop from 104px to 110px and on mobile from 72px to 104px.