### PR TITLE
style PDF page breaks (DEV-1362)

### DIFF
--- a/apps/wildfires/src/app/shared/components/GeneratePDF.tsx
+++ b/apps/wildfires/src/app/shared/components/GeneratePDF.tsx
@@ -8,11 +8,14 @@ interface GeneratePDFProps {
 
 const GeneratePDF: React.FC<GeneratePDFProps> = ({ className }) => {
   const options = {
-    margin: [0, 10],
+    margin: [5, 10],
     filename: 'result-content.pdf',
-    html2canvas: { scale: 1, letterRendering: true },
+    html2canvas: {
+      scale: 2,
+      letterRendering: true,
+    },
     jsPDF: { unit: 'mm', format: 'a4', orientation: 'portrait' },
-    pagebreak: { mode: 'avoid-all' },
+    pagebreak: { mode: 'css' },
   };
 
   const handleGeneratePdf = () => {

--- a/apps/wildfires/src/app/shared/components/bestPractices/BestPractices.tsx
+++ b/apps/wildfires/src/app/shared/components/bestPractices/BestPractices.tsx
@@ -4,7 +4,7 @@ import BestPracticesCard from './BestPracticesCard';
 
 export default function BestPractices() {
   return (
-    <div className="w-full my-8 md:my-24">
+    <div className="w-full my-8 md:my-24 break-inside-avoid">
       <BestPracticesCard
         bgColor="bg-brand-yellow-light"
         title="Document everything!"

--- a/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
@@ -22,6 +22,7 @@ export function ResourceCard(props: IProps) {
     'rounded-lg',
     'bg-white',
     '[box-shadow:0_4px_6px_#7777771A]',
+    'break-inside-avoid',
     className,
   ];
 
@@ -38,7 +39,7 @@ export function ResourceCard(props: IProps) {
       )}
 
       {!!resourceLink && (
-        <ResourceLink className="self-end mt-8" href={resourceLink} />
+        <ResourceLink className="ml-auto mt-8" href={resourceLink} />
       )}
     </div>
   );

--- a/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
@@ -20,7 +20,7 @@ export function SurveyResources(props: IProps) {
 
   return (
     <div className={mergeCss(parentCss)}>
-      <div className="mt-12 md:mt-20 mb-8 md:mb-12 font-bold text-xl md:text-2xl">
+      <div className="mt-12 md:mt-20 mb-8 md:mb-12 font-bold text-xl md:text-2xl break-before-page">
         Resources
       </div>
 
@@ -42,7 +42,7 @@ export function SurveyResources(props: IProps) {
       )}
 
       {!!alertResources.length && (
-        <div className="mt-12 md:mt-16">
+        <div className="mt-12 md:mt-16 break-inside-avoid">
           <AlertResources
             className="mb-12 md:mb-20 last:mb-0"
             alerts={alertResources}

--- a/apps/wildfires/src/app/shared/components/surveyResources/shared/ResourceLink.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/shared/ResourceLink.tsx
@@ -10,7 +10,7 @@ type IProps = {
 export function ResourceLink(props: IProps) {
   const { href, target = '_blank', className } = props;
 
-  const parentCss = ['flex', className];
+  const parentCss = ['flex', 'items-center', 'gap-2', className];
 
   if (!href) {
     return null;
@@ -19,8 +19,7 @@ export function ResourceLink(props: IProps) {
   return (
     <a className={mergeCss(parentCss)} href={href} target={target}>
       <div className="font-bold">Visit Resource Site</div>
-
-      <WFLinkIcon className="h-6 ml-[10px]" />
+      <WFLinkIcon className="h-6 min-w-6" />
     </a>
   );
 }


### PR DESCRIPTION
DEV-1362

## Summary by Sourcery

Improve PDF styling for page breaks.

Enhancements:
- Style PDF page breaks using CSS and adjust margins.
- Improve layout of resource links and cards.
- Update the resources and best practices sections to avoid page breaks within elements.