### PR TITLE
use sanityClient for cms queries (DEV-1378)

### DIFF
--- a/apps/wildfires/.env.sample
+++ b/apps/wildfires/.env.sample
@@ -1,0 +1,2 @@
+VITE_CMS_SANITY_PROJECT_ID='prject Id for Wildfires project in Sanity.io CMS'
+VITE_CMS_SANITY_DATASET='dataset name to use for sanity Sanity.io CMS queries: `production` or other'

--- a/apps/wildfires/package.json
+++ b/apps/wildfires/package.json
@@ -26,7 +26,11 @@
     "@tanstack/react-query": "*",
     "@portabletext/react": "*",
     "html2pdf.js": "*",
-    "react-ga4": "*"
+    "react-ga4": "*",
+    "remeda": "*",
+    "@portabletext/types": "*",
+    "uuid": "*",
+    "@sanity/client": "*"
   },
   "devDependencies": {}
 }

--- a/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
@@ -3,10 +3,30 @@ import { normalizeQueryString } from './utils/normalizeQueryString';
 
 const DEFAULT_QUERY = `*[_type == "resource" &&  (resourceType == "alert")]`;
 
-export const fetchAllAlertsAndResourcesByTagsFn = async (tags: string[]) => {
+export const fetchAllAlertsAndResourcesByTagsFn = async (
+  tags: string[]
+): Promise<any[]> => {
   const queryParams = generateQueryParams(tags);
 
-  return await sanityClient.fetch(queryParams);
+  try {
+    const response = await sanityClient.fetch(queryParams);
+
+    if (!Array.isArray(response)) {
+      throw new Error('invalid response');
+    }
+
+    return response;
+  } catch (error) {
+    let errorMessage = 'Unknown error';
+
+    if (error instanceof Error) {
+      errorMessage = error.message;
+    }
+
+    console.error(`Failed to fetch resouces from Sanity: ${errorMessage}`);
+
+    return [];
+  }
 };
 
 function generateQueryParams(tags: string[]): string {

--- a/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
@@ -1,23 +1,13 @@
-import { CMS_BASE_URL } from '../sanityClient';
+import { sanityClient } from '../sanityClient';
 import { normalizeQueryString } from './utils/normalizeQueryString';
 
 const DEFAULT_QUERY = `*[_type == "resource" &&  (resourceType == "alert")]`;
 
 export const fetchAllAlertsAndResourcesByTagsFn = async (tags: string[]) => {
-  const url = generateUrl(tags);
-
-  const response = await fetch(url);
-
-  return response.json();
-};
-
-function generateUrl(tags: string[]): string {
   const queryParams = generateQueryParams(tags);
 
-  const encodedQuery = encodeURIComponent(queryParams);
-
-  return `${CMS_BASE_URL}?query=${encodedQuery}`;
-}
+  return await sanityClient.fetch(queryParams);
+};
 
 function generateQueryParams(tags: string[]): string {
   if (!tags.length) {

--- a/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
@@ -6,9 +6,9 @@ const DEFAULT_QUERY = `*[_type == "resource" &&  (resourceType == "alert")]`;
 export const fetchAllAlertsAndResourcesByTagsFn = async (
   tags: string[]
 ): Promise<any[]> => {
-  const queryParams = generateQueryParams(tags);
-
   try {
+    const queryParams = generateQueryParams(tags);
+
     const response = await sanityClient.fetch(queryParams);
 
     if (!Array.isArray(response)) {

--- a/apps/wildfires/src/app/shared/clients/sanityCms/sanityClient.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/sanityClient.ts
@@ -1,2 +1,14 @@
-export const CMS_BASE_URL =
-  'https://4v490tec.apicdn.sanity.io/v2022-03-07/data/query/production';
+import { createClient } from '@sanity/client';
+
+const DEFAULT_DATASET = 'production';
+const DEFAULT_PROJECT_ID = '4v490tec';
+
+const dataset = import.meta.env.VITE_CMS_SANITY_DATASET;
+const projectId = import.meta.env.VITE_CMS_SANITY_PROJECT_ID;
+
+export const sanityClient = createClient({
+  projectId: projectId || DEFAULT_PROJECT_ID,
+  dataset: dataset || DEFAULT_DATASET,
+  useCdn: true,
+  apiVersion: '2025-01-17', // use current date (YYYY-MM-DD) to target the latest API version
+});

--- a/apps/wildfires/src/app/shared/components/surveyResults/SurveyResults.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResults/SurveyResults.tsx
@@ -2,7 +2,6 @@ import { useQuery } from '@tanstack/react-query';
 
 import { surveyConfig } from '../../../pages/introduction/firesSurvey/config/config';
 import { fetchAllAlertsAndResourcesByTagsFn } from '../../clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn';
-import { toTResources } from '../../clients/sanityCms/utils/toTResource';
 import { mergeCss } from '../../utils/styles/mergeCss';
 import { TAnswer, TOption, TSurveyResults } from '../survey/types';
 import { getAllQuestions } from '../survey/utils/validateConfig';
@@ -81,11 +80,9 @@ export function SurveyResults(props: IProps) {
 
   const parentCss = [className];
 
-  const resources = toTResources(data?.result);
-
   return (
     <div className={mergeCss(parentCss)}>
-      {resources && <SurveyResources resources={resources} />}
+      {!!data?.length && <SurveyResources resources={data} />}
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/datetimepicker": "8.0.1",
     "@react-native-picker/picker": "2.7.5",
+    "@sanity/client": "^6.27.1",
     "@tanstack/react-query": "^5.64.2",
     "@teovilla/react-native-web-maps": "^0.9.5",
     "@vis.gl/react-google-maps": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5753,6 +5753,7 @@ __metadata:
     "@react-native-async-storage/async-storage": "npm:1.23.1"
     "@react-native-community/datetimepicker": "npm:8.0.1"
     "@react-native-picker/picker": "npm:2.7.5"
+    "@sanity/client": "npm:^6.27.1"
     "@storybook/addon-essentials": "npm:^7.6.20"
     "@storybook/addon-react-native-web": "npm:^0.0.24"
     "@storybook/core-server": "npm:^7.6.20"
@@ -8844,6 +8845,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sanity/client@npm:^6.27.1":
+  version: 6.27.1
+  resolution: "@sanity/client@npm:6.27.1"
+  dependencies:
+    "@sanity/eventsource": "npm:^5.0.2"
+    get-it: "npm:^8.6.6"
+    rxjs: "npm:^7.0.0"
+  checksum: 10/782017a66e768830856e95bf8906bb181f10eceaf77e37b3eac2c4e3c8732f5e78f2b828351d60bca77b7fae71097177a972fe702c98fb2ee3fe0c108b3b09e4
+  languageName: node
+  linkType: hard
+
+"@sanity/eventsource@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@sanity/eventsource@npm:5.0.2"
+  dependencies:
+    "@types/event-source-polyfill": "npm:1.0.5"
+    "@types/eventsource": "npm:1.1.15"
+    event-source-polyfill: "npm:1.0.31"
+    eventsource: "npm:2.0.2"
+  checksum: 10/a877f6175f2134e3f12119ec11b4f919ca03b7bd01dd7e400c88704f8de8085bfbe09216f225fc54344bcacba2f230642a3ea4a5f08e861652d742b3a1c4fa60
+  languageName: node
+  linkType: hard
+
 "@segment/loosely-validate-event@npm:^2.0.0":
   version: 2.0.0
   resolution: "@segment/loosely-validate-event@npm:2.0.0"
@@ -10650,6 +10674,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/event-source-polyfill@npm:1.0.5":
+  version: 1.0.5
+  resolution: "@types/event-source-polyfill@npm:1.0.5"
+  checksum: 10/f506b68710162f2ade1bccbc5691b8c67e5a703e565df2bc0b7b5be2637ba838ef81ec6c10b03248fe4d054386d95a6e827c7aace6e924986c2b9985f77b55de
+  languageName: node
+  linkType: hard
+
+"@types/eventsource@npm:1.1.15":
+  version: 1.1.15
+  resolution: "@types/eventsource@npm:1.1.15"
+  checksum: 10/52e024f5aebfd6bc166f2162d6e408cf788886007e571519c75f8c3623feaa3c5a74681fd3a128de6d21b28ef88dd683421264f10d5c98728959b99b1229b85e
+  languageName: node
+  linkType: hard
+
 "@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:^4.17.33":
   version: 4.19.5
   resolution: "@types/express-serve-static-core@npm:4.19.5"
@@ -10685,6 +10723,15 @@ __metadata:
   version: 3.2.1
   resolution: "@types/find-cache-dir@npm:3.2.1"
   checksum: 10/bf5c4e96da40247cd9e6327f54dfccda961a0fb2d70e3c71bd05def94de4c2e6fb310fe8ecb0f04ecf5dbc52214e184b55a2337b0f87250d4ae1e2e7d58321e4
+  languageName: node
+  linkType: hard
+
+"@types/follow-redirects@npm:^1.14.4":
+  version: 1.14.4
+  resolution: "@types/follow-redirects@npm:1.14.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/bbf83961176957109dd92d350c2045a8550647886b78770a731b6e54cf97279c9ef21a55d6ee075243012ed3a4fab03cb5b184866cb975509f83de456a5b670a
   languageName: node
   linkType: hard
 
@@ -10926,6 +10973,15 @@ __metadata:
   version: 1.0.3
   resolution: "@types/pretty-hrtime@npm:1.0.3"
   checksum: 10/288061dff992c8107d5c7b5a1277bbb0a314a27eb10087dea628a08fa37694a655191a69e25a212c95e61e498363c48ad9e281d23964a448f6c14100a6be0910
+  languageName: node
+  linkType: hard
+
+"@types/progress-stream@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@types/progress-stream@npm:2.0.5"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/d97352a6146e4b5fa132b91352c6860ebebec48af3d52658a3b446ce1cb885d94e623b7a7d8ea2ddcaacf7a4b8ea67a4c30609c578b66c8ed49d31813adc2955
   languageName: node
   linkType: hard
 
@@ -15257,6 +15313,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "decompress-response@npm:7.0.0"
+  dependencies:
+    mimic-response: "npm:^3.1.0"
+  checksum: 10/dfd216a4b24c6a9840e19986e8a9ca62e0b6ae35458e4135fdb84f2ba531a03ddc6ccfdc72782a361583c7d12a59787503381bd8372bf83f849eafadbaa8629c
+  languageName: node
+  linkType: hard
+
 "dedent@npm:^0.7.0":
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
@@ -16752,6 +16817,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-source-polyfill@npm:1.0.31":
+  version: 1.0.31
+  resolution: "event-source-polyfill@npm:1.0.31"
+  checksum: 10/901628a2fa1f83a430b657fdde6c86346df37956e208cd765c6761a8bca36c799a2372e37e48bc9e536956ae84a2b742e6ef20f1c5f047f79d8d2b4607bee3b8
+  languageName: node
+  linkType: hard
+
 "event-target-shim@npm:^5.0.0, event-target-shim@npm:^5.0.1":
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
@@ -16770,6 +16842,13 @@ __metadata:
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: 10/a3d47e285e28d324d7180f1e493961a2bbb4cad6412090e4dec114f4db1f5b560c7696ee8e758f55e23913ede856e3689cd3aa9ae13c56b5d8314cd3b3ddd1be
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:2.0.2":
+  version: 2.0.2
+  resolution: "eventsource@npm:2.0.2"
+  checksum: 10/e1c4c3664cebf9efdd55c90818ef847099f298bf521768d479cf22d8a681e666b3042de85327711ba6a8414ac6a04c70d2aeb4f405bba8239a8c36e06a019374
   languageName: node
   linkType: hard
 
@@ -17931,6 +18010,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.15.9":
+  version: 1.15.9
+  resolution: "follow-redirects@npm:1.15.9"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 10/e3ab42d1097e90d28b913903841e6779eb969b62a64706a3eb983e894a5db000fbd89296f45f08885a0e54cd558ef62e81be1165da9be25a6c44920da10f424c
+  languageName: node
+  linkType: hard
+
 "fontfaceobserver@npm:^2.1.0":
   version: 2.3.0
   resolution: "fontfaceobserver@npm:2.3.0"
@@ -18281,6 +18370,21 @@ __metadata:
     has-symbols: "npm:^1.0.3"
     hasown: "npm:^2.0.0"
   checksum: 10/85bbf4b234c3940edf8a41f4ecbd4e25ce78e5e6ad4e24ca2f77037d983b9ef943fd72f00f3ee97a49ec622a506b67db49c36246150377efcda1c9eb03e5f06d
+  languageName: node
+  linkType: hard
+
+"get-it@npm:^8.6.6":
+  version: 8.6.7
+  resolution: "get-it@npm:8.6.7"
+  dependencies:
+    "@types/follow-redirects": "npm:^1.14.4"
+    "@types/progress-stream": "npm:^2.0.5"
+    decompress-response: "npm:^7.0.0"
+    follow-redirects: "npm:^1.15.9"
+    is-retry-allowed: "npm:^2.2.0"
+    progress-stream: "npm:^2.0.0"
+    tunnel-agent: "npm:^0.6.0"
+  checksum: 10/16cee597c3282e968676521f03ce3f4ce2f4a1ea4af781512e38225ed2b9945e4ab1b184b3eb7d5836f2b32e62181f8d7b599bdaa31b3c74c380603c9e477abd
   languageName: node
   linkType: hard
 
@@ -20001,6 +20105,13 @@ __metadata:
   dependencies:
     is-unc-path: "npm:^1.0.0"
   checksum: 10/3271a0df109302ef5e14a29dcd5d23d9788e15ade91a40b942b035827ffbb59f7ce9ff82d036ea798541a52913cbf9d2d0b66456340887b51f3542d57b5a4c05
+  languageName: node
+  linkType: hard
+
+"is-retry-allowed@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "is-retry-allowed@npm:2.2.0"
+  checksum: 10/6d8685530871f0b040346cc72322d90122473e921149affa16de363d6c2a6e46bc76abdfaac3259b93994ec8e7f70fbe67bbb080190e440533ff728e6a64494d
   languageName: node
   linkType: hard
 
@@ -25478,6 +25589,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"progress-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "progress-stream@npm:2.0.0"
+  dependencies:
+    speedometer: "npm:~1.0.0"
+    through2: "npm:~2.0.3"
+  checksum: 10/839f1009f9feb3d14cbb9bef16eebaecf9560af7b7f64003bfb42c4db1a8e52b32d6bb5a14299a38522046c26bac1bbad1a99eec6fb8fc42b1d4ed3f21f22a41
+  languageName: node
+  linkType: hard
+
 "progress@npm:2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
@@ -27160,7 +27281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.5, rxjs@npm:^7.8.0":
+"rxjs@npm:^7.0.0, rxjs@npm:^7.5.5, rxjs@npm:^7.8.0":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -27985,6 +28106,13 @@ __metadata:
     select-hose: "npm:^2.0.0"
     spdy-transport: "npm:^3.0.0"
   checksum: 10/d29b89e48e7d762e505a2f83b1bc2c92268bd518f1b411864ab42a9e032e387d10467bbce0d8dbf8647bf4914a063aa1d303dff85e248f7a57f81a7b18ac34ef
+  languageName: node
+  linkType: hard
+
+"speedometer@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "speedometer@npm:1.0.0"
+  checksum: 10/6b322bbb0607c9994fba2a6ac189cf6caea4ce9f5067c1ccfc2848b55883f65d48292bfed4244ce855573ed7cdf0f69943ae6e507f7ec90eef232b64cdba6237
   languageName: node
   linkType: hard
 
@@ -29002,7 +29130,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through2@npm:^2.0.1":
+"through2@npm:^2.0.1, through2@npm:~2.0.3":
   version: 2.0.5
   resolution: "through2@npm:2.0.5"
   dependencies:


### PR DESCRIPTION
### Move to sanity client
https://betterangels.atlassian.net/browse/DEV-1378

**deployed to:** https://wildfires.dev.betterangels.la/sanity-client

## Summary by Sourcery

Switch to using the `sanityClient` for CMS queries.

New Features:
- Add support for environment variables to configure the Sanity project ID and dataset.

Enhancements:
- Use the `@sanity/client` library to query the Sanity CMS instead of fetching data directly via URL.