### PR TITLE
Remove wildfire Resources header (DEV-1447)

### DIFF
--- a/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/SurveyResources.tsx
@@ -20,10 +20,6 @@ export function SurveyResources(props: IProps) {
 
   return (
     <div className={mergeCss(parentCss)}>
-      <div className="mt-12 md:mt-20 mb-8 md:mb-12 font-bold text-xl md:text-2xl break-before-page">
-        Resources
-      </div>
-
       {!!baseResourcesGroupedSorted.length && (
         <div>
           {baseResourcesGroupedSorted.map((categoryResources) => {


### PR DESCRIPTION
DEV-1447

before
<img width="971" alt="image" src="https://github.com/user-attachments/assets/283ed0c4-fda1-4ede-9521-d300dce8a60c" />

after
<img width="976" alt="image" src="https://github.com/user-attachments/assets/4c5fbfc3-fb97-43a8-b879-83740ef929bd" />


## Summary by Sourcery

Enhancements:
- Remove the unnecessary "Resources" header.