### PR TITLE
convert sanity response to TResources

### DIFF
--- a/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/queries/fetchAllAlertsAndResourcesByTagsFn.ts
@@ -1,11 +1,13 @@
 import { sanityClient } from '../sanityClient';
+import { TResource } from '../types';
+import { toTResources } from '../utils/toTResource';
 import { normalizeQueryString } from './utils/normalizeQueryString';
 
 const DEFAULT_QUERY = `*[_type == "resource" &&  (resourceType == "alert")]`;
 
 export const fetchAllAlertsAndResourcesByTagsFn = async (
   tags: string[]
-): Promise<any[]> => {
+): Promise<TResource[]> => {
   try {
     const queryParams = generateQueryParams(tags);
 
@@ -15,7 +17,7 @@ export const fetchAllAlertsAndResourcesByTagsFn = async (
       throw new Error('invalid response');
     }
 
-    return response;
+    return toTResources(response);
   } catch (error) {
     let errorMessage = 'Unknown error';
 

--- a/apps/wildfires/src/app/shared/clients/sanityCms/types.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/types.ts
@@ -4,11 +4,12 @@ export type TResource = {
   title: string;
   slug: string;
   resourceType: 'resource' | 'alert';
-  resourceLink?: string;
-  tipsDescription?: PortableTextBlock | null;
-  priority?: number;
+  resourceLink?: string | null;
+  usefulTipsLink?: string | null;
+  priority?: number | null;
   tags?: TTag[];
-  shortDescription?: PortableTextBlock | null;
+  tipsDescription?: PortableTextBlock[] | null;
+  shortDescription?: PortableTextBlock[] | null;
 };
 
 export type TTag = {

--- a/apps/wildfires/src/app/shared/clients/sanityCms/utils/toTResource.ts
+++ b/apps/wildfires/src/app/shared/clients/sanityCms/utils/toTResource.ts
@@ -2,7 +2,7 @@ import { PortableTextBlock } from '@portabletext/react';
 import { TResource } from '../types';
 import { toTTags } from './toTTag';
 
-function toPortableTextBlock(item: any): PortableTextBlock | null {
+function toPortableTextBlocks(item: any): PortableTextBlock[] | null {
   if (!Array.isArray(item)) {
     return null;
   }
@@ -11,7 +11,7 @@ function toPortableTextBlock(item: any): PortableTextBlock | null {
     return null;
   }
 
-  return item as unknown as PortableTextBlock;
+  return item as unknown as PortableTextBlock[];
 }
 
 export function toTResources(items: any): TResource[] {
@@ -33,10 +33,11 @@ export function toTResource(item: any): TResource | null {
     title: item.title,
     slug: item.slug,
     resourceType: item.resourceType,
-    resourceLink: item.resourceLink,
-    tipsDescription: item.tipsDescription,
-    priority: Number.isInteger(item.priority) ? item.priority : undefined,
-    shortDescription: toPortableTextBlock(item.shortDescription),
     tags: toTTags(item.tags),
+    usefulTipsLink: item.usefulTipsLink,
+    resourceLink: item.resourceLink,
+    shortDescription: toPortableTextBlocks(item.shortDescription),
+    tipsDescription: toPortableTextBlocks(item.tipsDescription),
+    priority: Number.isInteger(item.priority) ? item.priority : undefined,
   };
 }

--- a/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/ResourceCard.tsx
@@ -32,6 +32,7 @@ export function ResourceCard(props: IProps) {
       {!!shortDescription && (
         <ResourcePortableText className="mt-8" data={shortDescription} />
       )}
+
       {!!tipsDescription && <ResourceTipsDescription data={tipsDescription} />}
 
       {!!resourceLink && (

--- a/apps/wildfires/src/app/shared/components/surveyResources/shared/ResourcePortableText.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/shared/ResourcePortableText.tsx
@@ -3,13 +3,17 @@ import { mergeCss } from '../../../utils/styles/mergeCss';
 
 type IProps = {
   className?: string;
-  data: PortableTextBlock;
+  data: PortableTextBlock[] | null;
 };
 
 export function ResourcePortableText(props: IProps) {
   const { data, className } = props;
 
   const parentCss = ['survey-rich-text', className];
+
+  if (!data?.length) {
+    return null;
+  }
 
   return (
     <div className={mergeCss(parentCss)}>

--- a/apps/wildfires/src/app/shared/components/surveyResources/shared/ResourceTipsDescription.tsx
+++ b/apps/wildfires/src/app/shared/components/surveyResources/shared/ResourceTipsDescription.tsx
@@ -6,13 +6,17 @@ import { ResourceCallout } from './ResourceCallout';
 
 type IProps = {
   className?: string;
-  data: PortableTextBlock;
+  data: PortableTextBlock[] | null;
 };
 
 export function ResourceTipsDescription(props: IProps) {
   const { data, className } = props;
 
   const parentCss = ['wisiwig', className];
+
+  if (!data?.length) {
+    return null;
+  }
 
   return (
     <ResourceCallout


### PR DESCRIPTION
### Enforce Types for resource data returned from sanity cms
https://betterangels.atlassian.net/browse/DEV-1449

**demo at**: https://wildfires.dev.betterangels.la/types

## Summary by Sourcery

Enforce types for resource data returned from Sanity CMS. Convert the response from Sanity CMS to typed data.