### PR TITLE
swap Wildfire announcement icon with checkbox (DEV-1462)

### DIFF
--- a/apps/wildfires/src/app/shared/components/bestPractices/BestPractices.tsx
+++ b/apps/wildfires/src/app/shared/components/bestPractices/BestPractices.tsx
@@ -1,4 +1,4 @@
-import { WFAnnouncement } from '@monorepo/react/icons';
+import { WFCheckbox } from '@monorepo/react/icons';
 
 import BestPracticesCard from './BestPracticesCard';
 
@@ -25,7 +25,7 @@ export default function BestPractices() {
             </a>
           </>
         }
-        Icon={WFAnnouncement}
+        Icon={WFCheckbox}
       />
     </div>
   );

--- a/apps/wildfires/src/app/shared/components/bestPractices/BestPracticesCard.tsx
+++ b/apps/wildfires/src/app/shared/components/bestPractices/BestPracticesCard.tsx
@@ -22,7 +22,7 @@ export default function BestPracticesCard(props: IBestPracticesCardProps) {
         }`}
       />
       <div className="min-w-[50px] h-[50px] md:min-w-[100px] md:h-[100px] rounded-full bg-white flex items-center justify-center">
-        <Icon className="h-6 w-6 md:h-10 md:w-10 text-brand-dark-blue" />
+        <Icon className="h-[40px] w-[40px] lg:h-[60px] lg:w-[60px] text-brand-dark-blue" />
       </div>
       <div>
         <h3 className="text-xl md:text-[32px] md:leading-[1.2] font-bold mb-4 pr-6 md:pr-0">

--- a/libs/expo/shared/icons/src/assets/third_party/tabler/LICENSE
+++ b/libs/expo/shared/icons/src/assets/third_party/tabler/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2024 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/expo/shared/icons/src/assets/third_party/tabler/svg/tabler:checkbox.svg
+++ b/libs/expo/shared/icons/src/assets/third_party/tabler/svg/tabler:checkbox.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="m9 11l3 3l8-8"/><path d="M20 12v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h9"/></g></svg>

--- a/libs/react/icons/src/lib/components/wfCheckbox.tsx
+++ b/libs/react/icons/src/lib/components/wfCheckbox.tsx
@@ -1,0 +1,5 @@
+import svg from '../../../../../../libs/expo/shared/icons/src/assets/third_party/tabler/svg/tabler:checkbox.svg';
+
+import { createSvgComponent } from '../../toComponent';
+
+export default createSvgComponent(svg);

--- a/libs/react/icons/src/lib/index.ts
+++ b/libs/react/icons/src/lib/index.ts
@@ -27,4 +27,5 @@ export { default as SearchIcon } from './components/searchIcon';
 export { default as ShareIcon } from './components/shareIcon';
 export { default as UsersIcon } from './components/usersIcon';
 export { default as WFAnnouncement } from './components/wfAnnouncement';
+export { default as WFCheckbox } from './components/wfCheckbox';
 export { default as WFLinkIcon } from './components/wfLinkIcon';


### PR DESCRIPTION
DEV-1462

before 
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/10e7a011-569a-4e53-b732-dbe3ffb14bd7" />
<img width="409" alt="image" src="https://github.com/user-attachments/assets/e62e3543-64de-4938-938b-0eb939ab14db" />


after
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/7838bb40-8ac2-46bc-8903-8919d9493f45" />

<img width="451" alt="image" src="https://github.com/user-attachments/assets/a8bee672-c31b-4828-b05a-ff6d4fab353a" />


## Summary by Sourcery

Replace the Wildfire announcement icon with a checkbox icon.