### PR TITLE
wildfire full first page print (DEV-1468)

### DIFF
--- a/apps/wildfires/src/assets/styles/global.css
+++ b/apps/wildfires/src/assets/styles/global.css
@@ -210,10 +210,13 @@ textarea:focus {
     min-height: 200px !important;
     padding: 3rem 0 !important;
     justify-content: center !important;
+    height: 275mm;
   }
 
   .hero-print h1 {
     font-size: 2.5rem !important; /* 40px */
+    page-break-before: always;
+    page-break-after: always;
   }
 
   /* Ensure the container fits within the print area */


### PR DESCRIPTION
DEV-1468

<img width="1062" alt="image" src="https://github.com/user-attachments/assets/4055febe-f668-4c63-ba7f-2c7ae138b96a" />


## Summary by Sourcery

Adjust the styling of the hero section for print layouts to ensure it fits within the printable area and takes up the full first page.

New Features:
- Add page breaks before and after the hero section title in print layouts.

Enhancements:
- Set a fixed height for the hero section in print layouts.