### PR TITLE
add created_at to service request admin (DEV-1472)

### DIFF
--- a/apps/betterangels-backend/notes/admin.py
+++ b/apps/betterangels-backend/notes/admin.py
@@ -122,6 +122,7 @@ class ServiceRequestAdmin(admin.ModelAdmin):
         "client__first_name",
         "client__last_name",
     )
+    readonly_fields = ("created_at",)
 
     @admin.display(description="Service")
     def service_name(self, obj: ServiceRequest) -> str:


### PR DESCRIPTION
DEV-1472

## Summary by Sourcery

Enhancements:
- Make `created_at` a read-only field in the Django admin for Service Requests.