### PR TITLE
update filePreview for SingleDocUploads to handle pdf (DEV-1117)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/MultipleDocUploads.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/MultipleDocUploads.tsx
@@ -78,15 +78,6 @@ export default function MultipleDocUploads(props: IMultipleDocUploadsProps) {
     });
   };
 
-  const onFilenameClear = (index: number) => {
-    setDocs({
-      ...docs,
-      [docType]: docs[docType]?.map((file, i) =>
-        i === index ? { ...file, name: '' } : file
-      ),
-    });
-  };
-
   const onFilenameChange = (index: number, value: string) => {
     setDocs({
       ...docs,
@@ -96,9 +87,9 @@ export default function MultipleDocUploads(props: IMultipleDocUploadsProps) {
     });
   };
 
-  const uploadedDocs = (docs && docs[docType]) || [];
+  const docsToUpload = (docs && docs[docType]) || [];
 
-  const allDocsValid = uploadedDocs.every((file) => {
+  const allDocsValid = docsToUpload.every((file) => {
     return !!file.name && !!file.type && !!file.uri;
   });
 
@@ -106,7 +97,7 @@ export default function MultipleDocUploads(props: IMultipleDocUploadsProps) {
     <>
       <Section
         loading={loading}
-        disabled={!uploadedDocs.length || !allDocsValid}
+        disabled={!docsToUpload.length || !allDocsValid}
         title={title}
         onSubmit={uploadDocuments}
         onCancel={() => {
@@ -155,11 +146,10 @@ export default function MultipleDocUploads(props: IMultipleDocUploadsProps) {
           </Pressable>
         </View>
 
-        {uploadedDocs.length > 0 && (
+        {docsToUpload.length > 0 && (
           <UploadPreview
-            files={uploadedDocs}
+            files={docsToUpload}
             onRemoveFile={onRemoveFile}
-            onFilenameClear={onFilenameClear}
             onFilenameChange={onFilenameChange}
           />
         )}

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/FilePreview.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/FilePreview.tsx
@@ -1,16 +1,21 @@
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { FilePdfIcon, NoteIcon } from '@monorepo/expo/shared/icons';
 import { Colors, Spacings } from '@monorepo/expo/shared/static';
+import { FileThumbnailSizeDefault } from 'libs/expo/shared/static/src/lib/thumbnail';
 import { View } from 'react-native';
+import { TThumbnailSize } from '../UploadModal/types';
 import DeleteButton from './DeleteButton';
 
 export interface IFilePreview {
   file: ReactNativeFile;
+  thumbnailSize?: TThumbnailSize;
   onDelete: () => void;
 }
 
 export default function FilePreview(props: IFilePreview) {
-  const { file, onDelete } = props;
+  const { file, thumbnailSize, onDelete } = props;
+
+  const previewSize = thumbnailSize || FileThumbnailSizeDefault;
 
   const isPdf = file.type === 'application/pdf';
 
@@ -24,14 +29,13 @@ export default function FilePreview(props: IFilePreview) {
     <View
       style={{
         position: 'relative',
-        height: 133,
-        width: 104,
         marginBottom: Spacings.sm,
         borderWidth: 1,
         borderColor: Colors.NEUTRAL_LIGHT,
         borderRadius: 8,
         justifyContent: 'center',
         alignItems: 'center',
+        ...previewSize,
       }}
     >
       <DeleteButton onDelete={onDelete} accessibilityHint={accessibilityHint} />

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/FilePreview.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/FilePreview.tsx
@@ -1,7 +1,10 @@
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { FilePdfIcon, NoteIcon } from '@monorepo/expo/shared/icons';
-import { Colors, Spacings } from '@monorepo/expo/shared/static';
-import { FileThumbnailSizeDefault } from 'libs/expo/shared/static/src/lib/thumbnail';
+import {
+  Colors,
+  FileThumbnailSizeDefault,
+  Spacings,
+} from '@monorepo/expo/shared/static';
 import { View } from 'react-native';
 import { TThumbnailSize } from '../UploadModal/types';
 import DeleteButton from './DeleteButton';

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/ImageFilePreview.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/ImageFilePreview.tsx
@@ -1,26 +1,30 @@
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { Colors, Spacings } from '@monorepo/expo/shared/static';
+import { ImageThumbnailSizeDefault } from 'libs/expo/shared/static/src/lib/thumbnail';
 import { Image, View } from 'react-native';
+import { TThumbnailSize } from '../UploadModal/types';
 import DeleteButton from './DeleteButton';
 
 export interface IImageFilePreview {
   file: ReactNativeFile;
+  thumbnailSize?: TThumbnailSize;
   onDelete: () => void;
 }
 
 export default function ImageFilePreview(props: IImageFilePreview) {
-  const { file, onDelete } = props;
+  const { file, thumbnailSize, onDelete } = props;
+
+  const previewSize = thumbnailSize || ImageThumbnailSizeDefault;
 
   return (
     <View
       style={{
         position: 'relative',
-        width: 236,
-        height: 395,
         marginBottom: Spacings.sm,
         borderWidth: 1,
         borderColor: Colors.NEUTRAL_LIGHT,
         borderRadius: 8,
+        ...previewSize,
       }}
     >
       <DeleteButton onDelete={onDelete} accessibilityHint="deletes the image" />

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/ImageFilePreview.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/ImageFilePreview.tsx
@@ -1,6 +1,9 @@
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
-import { Colors, Spacings } from '@monorepo/expo/shared/static';
-import { ImageThumbnailSizeDefault } from 'libs/expo/shared/static/src/lib/thumbnail';
+import {
+  Colors,
+  ImageThumbnailSizeDefault,
+  Spacings,
+} from '@monorepo/expo/shared/static';
 import { Image, View } from 'react-native';
 import { TThumbnailSize } from '../UploadModal/types';
 import DeleteButton from './DeleteButton';

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadPreview/index.tsx
@@ -2,18 +2,19 @@ import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { Spacings } from '@monorepo/expo/shared/static';
 import { BasicInput, TextBold } from '@monorepo/expo/shared/ui-components';
 import { View } from 'react-native';
+import { TThumbnailSize } from '../UploadModal/types';
 import FilePreview from './FilePreview';
 import ImageFilePreview from './ImageFilePreview';
 
 export interface IUploadPreview {
   files: ReactNativeFile[];
   onRemoveFile: (index: number) => void;
-  onFilenameClear: (index: number) => void;
   onFilenameChange: (index: number, value: string) => void;
+  thumbnailSize?: TThumbnailSize;
 }
 
 export default function UploadPreview(props: IUploadPreview) {
-  const { files, onRemoveFile, onFilenameClear, onFilenameChange } = props;
+  const { files, thumbnailSize, onRemoveFile, onFilenameChange } = props;
 
   let title = 'Uploaded file';
 
@@ -35,12 +36,17 @@ export default function UploadPreview(props: IUploadPreview) {
             {isImage && (
               <ImageFilePreview
                 file={file}
+                thumbnailSize={thumbnailSize}
                 onDelete={() => onRemoveFile(index)}
               />
             )}
 
             {!isImage && (
-              <FilePreview onDelete={() => onRemoveFile(index)} file={file} />
+              <FilePreview
+                file={file}
+                thumbnailSize={thumbnailSize}
+                onDelete={() => onRemoveFile(index)}
+              />
             )}
 
             <BasicInput
@@ -51,8 +57,8 @@ export default function UploadPreview(props: IUploadPreview) {
               errorMessage={
                 !file.name.trim() ? 'file name is required' : undefined
               }
-              onDelete={() => onFilenameClear(index)}
-              onChangeText={(e) => onFilenameChange(index, e)}
+              onDelete={() => onFilenameChange(index, '')}
+              onChangeText={(val) => onFilenameChange(index, val)}
             />
           </View>
         );

--- a/libs/expo/shared/static/src/lib/index.ts
+++ b/libs/expo/shared/static/src/lib/index.ts
@@ -4,4 +4,9 @@ export { Radiuses } from './radiuses';
 export { Regex } from './regex';
 export { Shadow } from './shadow';
 export { Spacings, TSpacing } from './spacings';
-export { thumbnailSizes } from './thumbnail';
+export {
+  FileThumbnailSizeDefault,
+  IdThumbnailSize,
+  ImageThumbnailSizeDefault,
+  thumbnailSizes,
+} from './thumbnail';

--- a/libs/expo/shared/static/src/lib/thumbnail.ts
+++ b/libs/expo/shared/static/src/lib/thumbnail.ts
@@ -9,8 +9,23 @@ type TThumbnailSize = {
   width: number;
 };
 
+export const ImageThumbnailSizeDefault: TThumbnailSize = {
+  height: 395,
+  width: 236,
+};
+
+export const FileThumbnailSizeDefault: TThumbnailSize = {
+  height: 133,
+  width: 104,
+};
+
+export const IdThumbnailSize: TThumbnailSize = {
+  height: 86.5,
+  width: 129,
+};
+
 export const thumbnailSizes: Record<DocType, TThumbnailSize> = {
-  [DocType.BirthCertificate]: { height: 395, width: 236 },
-  [DocType.SocialSecurityCard]: { height: 86.5, width: 129 },
-  [DocType.PhotoId]: { height: 86.5, width: 129 },
+  [DocType.BirthCertificate]: ImageThumbnailSizeDefault,
+  [DocType.SocialSecurityCard]: IdThumbnailSize,
+  [DocType.PhotoId]: IdThumbnailSize,
 };


### PR DESCRIPTION
[Doc Library] Enable uploading from local files
https://betterangels.atlassian.net/browse/DEV-1117

* implements pdf uploads/previews with `SingleDocUploads`
* updates to `MultipleDocUploads`
* opened against epic branch: `OUT-109/pdf-upload--epic`

## Summary by Sourcery

Update the file preview for single document uploads to handle PDF files.

New Features:
- Display a preview of PDF files in the single document upload modal.

Tests:
- Add tests for PDF file preview.

## Summary by Sourcery

Implement PDF file preview functionality in the single document upload modal and refactor the document upload logic for better code clarity. Add tests to ensure the new PDF preview feature works as expected and introduce configurable thumbnail sizes for various document types.

New Features:
- Enable PDF file preview in the single document upload modal.

Enhancements:
- Refactor document upload logic to improve code readability and maintainability.
- Introduce thumbnail size configurations for different document types.

Tests:
- Add tests to verify the functionality of PDF file preview.