### PR TITLE
Update CSRF Link Handling

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/LoginForm/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/LoginForm/index.tsx
@@ -83,6 +83,7 @@ export default function LoginForm({
       }
     } catch (error) {
       setErrorMessage('Something went wrong. Please try again.');
+      switchEnvironment('production');
     }
     setIsLoading(false);
   };

--- a/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
+++ b/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
@@ -3,10 +3,9 @@ import { getItem, setItem } from '@monorepo/expo/shared/utils';
 import { CSRF_COOKIE_NAME } from './constants';
 
 class CSRFTokenManager {
-  private currentToken: string | null = null;
+  private currentTokens = new Map<string, string>();
   private inProgress = new Map<string, Promise<string | null>>();
 
-  // Compute a storage key based on the API URL.
   private getKey(apiUrl: string): string {
     try {
       const origin = new URL(apiUrl).origin.replace(/[^a-zA-Z0-9]/g, '_');
@@ -19,22 +18,21 @@ class CSRFTokenManager {
   async getToken(apiUrl: string, customFetch = fetch): Promise<string | null> {
     const key = this.getKey(apiUrl);
 
-    // Check the in‑memory cache first.
-    if (this.currentToken) return this.currentToken;
+    // Check the in-memory cache first.
+    const cached = this.currentTokens.get(key);
+    if (cached) return cached;
 
     // Then try AsyncStorage.
     const stored = await getItem(key);
     if (stored) {
-      this.currentToken = stored;
+      this.currentTokens.set(key, stored);
       return stored;
     }
 
-    // If a request is already in progress, return its promise.
+    // If a request is already in progress for this key, return its promise.
     if (this.inProgress.has(key)) {
       const pending = this.inProgress.get(key);
-      if (pending !== undefined) {
-        return pending;
-      }
+      if (pending !== undefined) return pending;
     }
 
     // Otherwise, start a new request.
@@ -47,7 +45,7 @@ class CSRFTokenManager {
         );
         const token = match ? match[1] : null;
         if (token) {
-          this.currentToken = token;
+          this.currentTokens.set(key, token);
           await setItem(key, token);
         }
         return token;
@@ -68,14 +66,14 @@ class CSRFTokenManager {
     const match = cookies.match(new RegExp(`${CSRF_COOKIE_NAME}=([^;]+)`));
     if (match) {
       const token = match[1];
-      this.currentToken = token;
+      this.currentTokens.set(key, token);
       await setItem(key, token);
     }
   }
 
   async clearToken(apiUrl: string): Promise<void> {
     const key = this.getKey(apiUrl);
-    this.currentToken = null;
+    this.currentTokens.delete(key);
     await setItem(key, '');
   }
 }

--- a/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
+++ b/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
@@ -1,0 +1,83 @@
+// csrf-manager.ts
+import { getItem, setItem } from '@monorepo/expo/shared/utils';
+import { CSRF_COOKIE_NAME } from './constants';
+
+class CSRFTokenManager {
+  private currentToken: string | null = null;
+  private inProgress = new Map<string, Promise<string | null>>();
+
+  // Compute a storage key based on the API URL.
+  private getKey(apiUrl: string): string {
+    try {
+      const origin = new URL(apiUrl).origin.replace(/[^a-zA-Z0-9]/g, '_');
+      return `${CSRF_COOKIE_NAME}_${origin}`;
+    } catch {
+      return `${CSRF_COOKIE_NAME}_${apiUrl.replace(/[^a-zA-Z0-9]/g, '_')}`;
+    }
+  }
+
+  async getToken(apiUrl: string, customFetch = fetch): Promise<string | null> {
+    const key = this.getKey(apiUrl);
+
+    // Check the in‑memory cache first.
+    if (this.currentToken) return this.currentToken;
+
+    // Then try AsyncStorage.
+    const stored = await getItem(key);
+    if (stored) {
+      this.currentToken = stored;
+      return stored;
+    }
+
+    // If a request is already in progress, return its promise.
+    if (this.inProgress.has(key)) {
+      const pending = this.inProgress.get(key);
+      if (pending !== undefined) {
+        return pending;
+      }
+    }
+
+    // Otherwise, start a new request.
+    const promise = (async () => {
+      try {
+        const res = await customFetch(apiUrl, { credentials: 'include' });
+        const cookieHeader = res.headers?.get('Set-Cookie') || '';
+        const match = cookieHeader.match(
+          new RegExp(`${CSRF_COOKIE_NAME}=([^;]+)`)
+        );
+        const token = match ? match[1] : null;
+        if (token) {
+          this.currentToken = token;
+          await setItem(key, token);
+        }
+        return token;
+      } catch (error) {
+        console.error('CSRF token fetch failed:', error);
+        return null;
+      } finally {
+        this.inProgress.delete(key);
+      }
+    })();
+
+    this.inProgress.set(key, promise);
+    return promise;
+  }
+
+  async updateTokenFromCookies(apiUrl: string, cookies: string): Promise<void> {
+    const key = this.getKey(apiUrl);
+    const match = cookies.match(new RegExp(`${CSRF_COOKIE_NAME}=([^;]+)`));
+    if (match) {
+      const token = match[1];
+      this.currentToken = token;
+      await setItem(key, token);
+    }
+  }
+
+  async clearToken(apiUrl: string): Promise<void> {
+    const key = this.getKey(apiUrl);
+    this.currentToken = null;
+    await setItem(key, '');
+  }
+}
+
+export const csrfManager = new CSRFTokenManager();

--- a/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
+++ b/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
@@ -1,4 +1,3 @@
-// csrf-manager.ts
 import { getItem, setItem } from '@monorepo/expo/shared/utils';
 import { CSRF_COOKIE_NAME } from './constants';
 

--- a/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
+++ b/libs/expo/shared/clients/src/lib/apollo/links/csrf-manager.ts
@@ -21,7 +21,7 @@ class CSRFTokenManager {
     const cached = this.currentTokens.get(key);
     if (cached) return cached;
 
-    // Then try AsyncStorage.
+    // Then try SecureStorage.
     const stored = await getItem(key);
     if (stored) {
       this.currentTokens.set(key, stored);

--- a/libs/expo/shared/clients/src/lib/apollo/links/csrf.ts
+++ b/libs/expo/shared/clients/src/lib/apollo/links/csrf.ts
@@ -1,68 +1,54 @@
+// csrf.ts
 import { ApolloLink, FetchResult, Observable } from '@apollo/client';
-import { getItem, setItem } from '@monorepo/expo/shared/utils';
-import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from './constants';
+import { CSRF_HEADER_NAME } from './constants';
+import { csrfManager } from './csrf-manager';
 
-const csrfTokenRegex = new RegExp(`${CSRF_COOKIE_NAME}=([^;]+)`);
-
-const extractCsrfToken = async (apiUrl: string, customFetch = fetch) => {
-  let csrfToken = await getItem(CSRF_COOKIE_NAME);
-  if (!csrfToken) {
-    const response = await customFetch(apiUrl, { credentials: 'include' });
-    const cookies = response.headers?.get('Set-Cookie');
-    const match = cookies?.match(csrfTokenRegex);
-    if (match) {
-      csrfToken = match[1];
-      await setItem(CSRF_COOKIE_NAME, csrfToken);
-    }
-  }
-  return csrfToken;
-};
-
-const updateHeadersWithCsrf = (csrfToken: string | null) =>
-  csrfToken ? { [CSRF_HEADER_NAME]: csrfToken } : {};
-
-export const csrfLink = (apiUrl: string, customFetch = fetch) =>
-  new ApolloLink(
+export const csrfLink = (apiUrl: string, customFetch = fetch) => {
+  return new ApolloLink(
     (operation, forward) =>
       new Observable((observer) => {
-        const processOperation = async () => {
+        (async () => {
           try {
-            const csrfToken = await extractCsrfToken(apiUrl, customFetch);
+            // Retrieve (or fetch) the CSRF token via the centralized manager.
+            const csrfToken = await csrfManager.getToken(apiUrl, customFetch);
+
+            // Inject the token into the outgoing headers.
             operation.setContext(({ headers = {} }) => ({
               headers: {
                 ...headers,
-                ...updateHeadersWithCsrf(csrfToken),
+                ...(csrfToken ? { [CSRF_HEADER_NAME]: csrfToken } : {}),
               },
             }));
 
+            // Forward the operation.
             forward(operation).subscribe({
               next: (response: FetchResult) => {
+                // Access context properties using bracket notation.
                 const context = operation.getContext();
                 const combinedCookies = [
-                  // Extract 'set-cookie' header from the GraphQL response if it exists
                   context['response']?.headers?.get('set-cookie'),
-                  // Extract 'set-cookie' headers from any REST responses and filter out any null or undefined values
-                  ...((context['restResponses'] as Response[]) || [])
-                    .map((res) => res?.headers.get('set-cookie'))
-                    .filter(Boolean),
+                  ...(context['restResponses'] || []).map((res: Response) =>
+                    res.headers.get('set-cookie')
+                  ),
                 ]
                   .filter(Boolean)
                   .join('; ');
 
-                const match = combinedCookies.match(csrfTokenRegex);
-                if (match) {
-                  setItem(CSRF_COOKIE_NAME, match[1]);
-                }
+                // Update the token via the manager if new cookies are present.
+                csrfManager
+                  .updateTokenFromCookies(apiUrl, combinedCookies)
+                  .catch(console.error);
+
                 observer.next(response);
               },
               error: observer.error.bind(observer),
               complete: observer.complete.bind(observer),
             });
-          } catch (err) {
-            console.error('Error in CSRF Apollo Link:', err);
-            observer.error(err);
+          } catch (error) {
+            console.error('CSRF link error:', error);
+            observer.error(error);
           }
-        };
-        processOperation();
+        })();
       })
   );
+};

--- a/libs/expo/shared/clients/src/lib/apollo/links/csrf.ts
+++ b/libs/expo/shared/clients/src/lib/apollo/links/csrf.ts
@@ -1,4 +1,3 @@
-// csrf.ts
 import { ApolloLink, FetchResult, Observable } from '@apollo/client';
 import { CSRF_HEADER_NAME } from './constants';
 import { csrfManager } from './csrf-manager';
@@ -20,10 +19,8 @@ export const csrfLink = (apiUrl: string, customFetch = fetch) => {
               },
             }));
 
-            // Forward the operation.
             forward(operation).subscribe({
               next: (response: FetchResult) => {
-                // Access context properties using bracket notation.
                 const context = operation.getContext();
                 const combinedCookies = [
                   context['response']?.headers?.get('set-cookie'),
@@ -34,7 +31,6 @@ export const csrfLink = (apiUrl: string, customFetch = fetch) => {
                   .filter(Boolean)
                   .join('; ');
 
-                // Update the token via the manager if new cookies are present.
                 csrfManager
                   .updateTokenFromCookies(apiUrl, combinedCookies)
                   .catch(console.error);

--- a/libs/expo/shared/clients/src/lib/http/ApiConfigProvider.tsx
+++ b/libs/expo/shared/clients/src/lib/http/ApiConfigProvider.tsx
@@ -1,7 +1,5 @@
-import { setItem } from '@monorepo/expo/shared/utils';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { CSRF_COOKIE_NAME } from '../apollo/links/constants';
 
 interface ApiConfigContextType {
   baseUrl: string;
@@ -48,10 +46,7 @@ export const ApiConfigProvider = ({
     if (environment === env) return;
 
     try {
-      await Promise.all([
-        AsyncStorage.setItem('currentEnvironment', env),
-        setItem(CSRF_COOKIE_NAME, ''),
-      ]);
+      await Promise.all([AsyncStorage.setItem('currentEnvironment', env)]);
       setEnvironment(env);
     } catch (error) {
       console.error('Error switching environment:', error);


### PR DESCRIPTION
## Summary by Sourcery

Refactor CSRF token handling to use a centralized manager and improve storage logic.

Enhancements:
- Centralize CSRF token management to avoid redundant fetches and storage.
- Store CSRF tokens based on the API origin to prevent conflicts.
- Improve token extraction from GraphQL and REST responses.

Tests:
- Update tests to reflect the new CSRF handling logic.