### PR TITLE
add mimeType to gql AttachmentInterface (DEV-1507)

### DIFF
--- a/apps/betterangels-backend/clients/tests/test_queries.py
+++ b/apps/betterangels-backend/clients/tests/test_queries.py
@@ -38,6 +38,7 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
                 name
             }
             attachmentType
+            mimeType
             originalFilename
             namespace
         }
@@ -407,6 +408,7 @@ class ClientDocumentQueryTestCase(ClientProfileGraphQLBaseTestCase):
                         name
                     }
                     attachmentType
+                    mimeType
                     originalFilename
                     namespace
                 }
@@ -434,6 +436,7 @@ class ClientDocumentQueryTestCase(ClientProfileGraphQLBaseTestCase):
                         name
                     }
                     attachmentType
+                    mimeType
                     originalFilename
                     namespace
                 }
@@ -463,6 +466,7 @@ class ClientDocumentQueryTestCase(ClientProfileGraphQLBaseTestCase):
                             name
                         }
                         attachmentType
+                        mimeType
                         originalFilename
                         namespace
                     }

--- a/apps/betterangels-backend/clients/tests/utils.py
+++ b/apps/betterangels-backend/clients/tests/utils.py
@@ -363,6 +363,7 @@ class ClientProfileGraphQLBaseTestCase(GraphQLBaseTestCase):
                     ... on ClientDocumentType {
                         id
                         attachmentType
+                        mimeType
                         file {
                             name
                         }

--- a/apps/betterangels-backend/common/graphql/types.py
+++ b/apps/betterangels-backend/common/graphql/types.py
@@ -69,6 +69,7 @@ class AttachmentInterface:
     id: ID
     file: auto
     attachment_type: auto
+    mime_type: auto
     original_filename: auto
     created_at: auto
     updated_at: auto

--- a/apps/betterangels-backend/notes/tests/test_queries.py
+++ b/apps/betterangels-backend/notes/tests/test_queries.py
@@ -477,6 +477,7 @@ class NoteAttachmentQueryTestCase(NoteGraphQLBaseTestCase):
                         name
                     }
                     attachmentType
+                    mimeType
                     originalFilename
                     namespace
                 }
@@ -499,6 +500,7 @@ class NoteAttachmentQueryTestCase(NoteGraphQLBaseTestCase):
                         name
                     }
                     attachmentType
+                    mimeType
                     originalFilename
                     namespace
                 }

--- a/apps/betterangels-backend/notes/tests/utils.py
+++ b/apps/betterangels-backend/notes/tests/utils.py
@@ -453,6 +453,7 @@ class NoteGraphQLBaseTestCase(GraphQLBaseTestCase):
                     ... on NoteAttachmentType {
                         id
                         attachmentType
+                        mimeType
                         file {
                             name
                         }

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -63,6 +63,7 @@ interface AttachmentInterface {
   id: ID!
   file: DjangoFileType!
   attachmentType: AttachmentType!
+  mimeType: String!
   originalFilename: String
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -224,6 +225,7 @@ type ClientDocumentType implements AttachmentInterface {
   id: ID!
   file: DjangoFileType!
   attachmentType: AttachmentType!
+  mimeType: String!
   originalFilename: String
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -814,6 +816,7 @@ type NoteAttachmentType implements AttachmentInterface {
   id: ID!
   file: DjangoFileType!
   attachmentType: AttachmentType!
+  mimeType: String!
   originalFilename: String
   createdAt: DateTime!
   updatedAt: DateTime!

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -70,6 +70,7 @@ export type AttachmentInterface = {
   createdAt: Scalars['DateTime']['output'];
   file: DjangoFileType;
   id: Scalars['ID']['output'];
+  mimeType: Scalars['String']['output'];
   originalFilename?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -235,6 +236,7 @@ export type ClientDocumentType = AttachmentInterface & {
   createdAt: Scalars['DateTime']['output'];
   file: DjangoFileType;
   id: Scalars['ID']['output'];
+  mimeType: Scalars['String']['output'];
   namespace: ClientDocumentNamespaceEnum;
   originalFilename?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
@@ -1008,6 +1010,7 @@ export type NoteAttachmentType = AttachmentInterface & {
   createdAt: Scalars['DateTime']['output'];
   file: DjangoFileType;
   id: Scalars['ID']['output'];
+  mimeType: Scalars['String']['output'];
   namespace: NoteNamespaceEnum;
   originalFilename?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -70,6 +70,7 @@ export type AttachmentInterface = {
   createdAt: Scalars['DateTime']['output'];
   file: DjangoFileType;
   id: Scalars['ID']['output'];
+  mimeType: Scalars['String']['output'];
   originalFilename?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
 };
@@ -235,6 +236,7 @@ export type ClientDocumentType = AttachmentInterface & {
   createdAt: Scalars['DateTime']['output'];
   file: DjangoFileType;
   id: Scalars['ID']['output'];
+  mimeType: Scalars['String']['output'];
   namespace: ClientDocumentNamespaceEnum;
   originalFilename?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];
@@ -1008,6 +1010,7 @@ export type NoteAttachmentType = AttachmentInterface & {
   createdAt: Scalars['DateTime']['output'];
   file: DjangoFileType;
   id: Scalars['ID']['output'];
+  mimeType: Scalars['String']['output'];
   namespace: NoteNamespaceEnum;
   originalFilename?: Maybe<Scalars['String']['output']>;
   updatedAt: Scalars['DateTime']['output'];


### PR DESCRIPTION
### Add mimeType to AttachmentInterface in graphQL
https://betterangels.atlassian.net/browse/DEV-1507

## Summary by Sourcery

New Features:
- Added `mimeType` field to `AttachmentInterface` to expose MIME type information.