### PR TITLE
Fix anonymous user checking

### DIFF
--- a/apps/betterangels-backend/betterangels_backend/settings.py
+++ b/apps/betterangels-backend/betterangels_backend/settings.py
@@ -393,6 +393,7 @@ INVITATION_BACKEND = "accounts.backends.CustomInvitations"
 # Django Guardian
 # https://github.com/django-guardian/django-guardian/blob/77de2033951c2e6b8fba2ac6258defdd23902bbf/docs/configuration.rst#guardian_user_obj_perms_model
 # https://github.com/django-guardian/django-guardian/blob/77de2033951c2e6b8fba2ac6258defdd23902bbf/docs/configuration.rst#guardian_group_obj_perms_model
+ANONYMOUS_USER_NAME = "anonymoususer"
 GUARDIAN_USER_OBJ_PERMS_MODEL = "accounts.BigUserObjectPermission"
 GUARDIAN_GROUP_OBJ_PERMS_MODEL = "accounts.BigGroupObjectPermission"
 


### PR DESCRIPTION
https://github.com/BetterAngelsLA/monorepo/pull/795 broke the anonymous user for guardian.

Guardian tries to save an `AnonymousUser` account, but it's stored in lowercase as `anonymoususer`. As a result, when it later looks for the account using the uppercase version, it doesn't find the existing record.


## Summary by Sourcery

Introduce the ANONYMOUS_USER_NAME setting.

Bug Fixes:
- Fix checking for anonymous users by introducing the ANONYMOUS_USER_NAME setting in the settings module.

Chores:
- Update settings with ANONYMOUS_USER_NAME to explicitly define the anonymous user name.