### PR TITLE
Disable new arch

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -127,7 +127,7 @@ export default {
         projectId: '53171ba4-60ca-40cb-b3e6-b0c2393677b8',
       },
     },
-    newArchEnabled: true,
+    newArchEnabled: false,
     owner: 'better-angels',
     runtimeVersion: process.env.RUNTIME_VERSION,
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "~3.16.1",
     "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "~4.6.0",
+    "react-native-screens": "~4.4.0",
     "react-native-select-dropdown": "^4.0.1",
     "react-native-svg": "15.8.0",
     "react-native-svg-transformer": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,7 +4737,7 @@ __metadata:
     react-native-paper: "npm:^5.12.5"
     react-native-reanimated: "npm:~3.16.1"
     react-native-safe-area-context: "npm:4.12.0"
-    react-native-screens: "npm:~4.6.0"
+    react-native-screens: "npm:~4.4.0"
     react-native-select-dropdown: "npm:^4.0.1"
     react-native-svg: "npm:15.8.0"
     react-native-svg-transformer: "npm:1.3.0"
@@ -22506,16 +22506,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:~4.6.0":
-  version: 4.6.0
-  resolution: "react-native-screens@npm:4.6.0"
+"react-native-screens@npm:~4.4.0":
+  version: 4.4.0
+  resolution: "react-native-screens@npm:4.4.0"
   dependencies:
     react-freeze: "npm:^1.0.0"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10/c3200fb6e7962c8b7713645e8c2efd0fd6305d284c82c923fcba6cd32bf7e281c4669b8ae169dc49e3ac939429b5c1ffa4bf5d45373cb20e8094567d797fa903
+  checksum: 10/a70d036674611b327c01e6c3a147b9d22b59d7e58cfd82a9df5a070fac26af17b65bcd1ec911ec3516c6d9e2782a48577b5ac2f576a196ad5fff1fddcf17bf38
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
React native maps currently doesn't support new arch

https://github.com/react-native-maps/react-native-maps/issues/5206

## Summary by Sourcery

Disable new architecture support for React Native Maps.

Bug Fixes:
- Disabled new architecture support to address compatibility issues with React Native Maps.

Enhancements:
- Downgraded `react-native-screens` from 4.6.0 to 4.4.0 to ensure compatibility with the disabled new architecture.