### PR TITLE
Try to fix splash

### DIFF
--- a/apps/betterangels/src/app/_layout.tsx
+++ b/apps/betterangels/src/app/_layout.tsx
@@ -13,12 +13,17 @@ import {
 import { ArrowLeftIcon, ChevronLeftIcon } from '@monorepo/expo/shared/icons';
 import { Colors } from '@monorepo/expo/shared/static';
 import { IconButton, TextRegular } from '@monorepo/expo/shared/ui-components';
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider,
+} from '@react-navigation/native';
 import { useFonts } from 'expo-font';
 import { Link, Stack, useRouter } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
-import { View } from 'react-native';
+import { useColorScheme, View } from 'react-native';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { apiUrl, demoApiUrl } from '../../config';
 
@@ -39,18 +44,17 @@ export default function RootLayout() {
     'Poppins-SemiBold': require('./assets/fonts/Poppins-SemiBold.ttf'),
   });
 
-  // Expo Router uses Error Boundaries to catch errors in the navigation tree.
   useEffect(() => {
-    if (error) throw error;
-  }, [error]);
-
-  useEffect(() => {
-    if (loaded) {
+    if (loaded || error) {
       SplashScreen.hideAsync();
+      if (error) {
+        console.warn(`Error in loading fonts: ${error}`);
+      }
     }
-  }, [loaded]);
+  }, [loaded, error]);
 
-  if (!loaded) {
+  // Return nothing until fonts are loaded (or an error occurs)
+  if (!loaded && !error) {
     return null;
   }
 
@@ -59,79 +63,82 @@ export default function RootLayout() {
 
 function RootLayoutNav() {
   const router = useRouter();
+  const colorScheme = useColorScheme();
+
   return (
-    <ApiConfigProvider productionUrl={apiUrl} demoUrl={demoApiUrl}>
-      <ApolloClientProvider>
-        <FeatureControlProvider>
-          <KeyboardProvider>
-            <KeyboardToolbarProvider>
-              <UserProvider>
-                <SnackbarProvider>
-                  <StatusBar style="light" />
-                  <Stack>
-                    <Stack.Screen
-                      name="(tabs)"
-                      options={{ headerShown: false, gestureEnabled: false }}
-                    />
-                    <Stack.Screen
-                      name="(private-screens)"
-                      options={{ headerShown: false, gestureEnabled: false }}
-                    />
-                    <Stack.Screen
-                      name="team"
-                      options={{
-                        title: '',
-                        presentation: 'modal',
-                        headerLeft: () => (
-                          <Link href="/teams">
-                            <View
-                              style={{
-                                flexDirection: 'row',
-                                alignItems: 'center',
-                              }}
+    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <ApiConfigProvider productionUrl={apiUrl} demoUrl={demoApiUrl}>
+        <ApolloClientProvider>
+          <FeatureControlProvider>
+            <KeyboardProvider>
+              <KeyboardToolbarProvider>
+                <UserProvider>
+                  <SnackbarProvider>
+                    <StatusBar style="light" />
+                    <Stack>
+                      <Stack.Screen
+                        name="(tabs)"
+                        options={{ headerShown: false, gestureEnabled: false }}
+                      />
+                      <Stack.Screen
+                        name="(private-screens)"
+                        options={{ headerShown: false, gestureEnabled: false }}
+                      />
+                      <Stack.Screen
+                        name="team"
+                        options={{
+                          title: '',
+                          presentation: 'modal',
+                          headerLeft: () => (
+                            <Link href="/teams">
+                              <View
+                                style={{
+                                  flexDirection: 'row',
+                                  alignItems: 'center',
+                                }}
+                              >
+                                <ChevronLeftIcon color={Colors.PRIMARY_LIGHT} />
+                                <TextRegular color={Colors.PRIMARY_LIGHT}>
+                                  Teams
+                                </TextRegular>
+                              </View>
+                            </Link>
+                          ),
+                        }}
+                      />
+                      <Stack.Screen
+                        name="modal"
+                        options={{ presentation: 'modal' }}
+                      />
+                      <Stack.Screen
+                        name="sign-in"
+                        options={{
+                          headerLeft: () => (
+                            <IconButton
+                              onPress={() => router.back()}
+                              variant="transparent"
+                              accessibilityLabel="goes to get started screen"
+                              accessibilityHint="goes to get started screen"
                             >
-                              <ChevronLeftIcon color={Colors.PRIMARY_LIGHT} />
-                              <TextRegular color={Colors.PRIMARY_LIGHT}>
-                                Teams
-                              </TextRegular>
-                            </View>
-                          </Link>
-                        ),
-                      }}
-                    />
-                    <Stack.Screen
-                      name="modal"
-                      options={{ presentation: 'modal' }}
-                    />
-                    <Stack.Screen
-                      name="sign-in"
-                      options={{
-                        headerLeft: () => (
-                          <IconButton
-                            onPress={() => router.back()}
-                            variant="transparent"
-                            accessibilityLabel="goes to get started screen"
-                            accessibilityHint="goes to get started screen"
-                          >
-                            <ArrowLeftIcon />
-                          </IconButton>
-                        ),
-                        headerShadowVisible: false,
-                        title: '',
-                      }}
-                    />
-                    <Stack.Screen
-                      name="auth"
-                      options={{ headerShown: false }}
-                    />
-                  </Stack>
-                  {/* </ThemeProvider> */}
-                </SnackbarProvider>
-              </UserProvider>
-            </KeyboardToolbarProvider>
-          </KeyboardProvider>
-        </FeatureControlProvider>
-      </ApolloClientProvider>
-    </ApiConfigProvider>
+                              <ArrowLeftIcon />
+                            </IconButton>
+                          ),
+                          headerShadowVisible: false,
+                          title: '',
+                        }}
+                      />
+                      <Stack.Screen
+                        name="auth"
+                        options={{ headerShown: false }}
+                      />
+                    </Stack>
+                  </SnackbarProvider>
+                </UserProvider>
+              </KeyboardToolbarProvider>
+            </KeyboardProvider>
+          </FeatureControlProvider>
+        </ApolloClientProvider>
+      </ApiConfigProvider>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary by Sourcery

Fix font loading splash screen by always hiding the splash screen after fonts have loaded or an error occurs.

Bug Fixes:
- Fixed an issue where the splash screen would not be hidden if the fonts failed to load.

Enhancements:
- Wrapped the app in a ThemeProvider to use the device's color scheme.