### PR TITLE
add ba:a yarn command to run adb reverse required for android emulator (DEV-1522)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "storybook:build": "nx storybook build expo-shared-ui-components",
     "server": "nx start betterangels-backend",
     "ba": "nx start betterangels",
+    "ba:a": "adb reverse tcp:8000 tcp:8000 && yarn ba",
     "ba:build-dev": "nx build betterangels --profile development",
     "shelter": "nx serve shelter-web --port 8083",
     "fires": "nx serve wildfires --port 8200"


### PR DESCRIPTION
### Add yarn command to start metro server and run adb revers for Android emulator
https://betterangels.atlassian.net/browse/DEV-1522

- hard coded ports for now

## Summary by Sourcery

Adds a new `yarn ba:a` command that runs `adb reverse` to allow the Android emulator to connect to the Metro server.