### PR TITLE
Use paginated query; Dedupe results (DEV-1155, DEV-1486)

### DIFF
--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -242,10 +242,6 @@ class Query:
         extensions=[HasRetvalPerm(perms=[ClientProfilePermissions.VIEW])],
     )
 
-    active_client_profiles: OffsetPaginated[ClientProfileType] = strawberry_django.offset_paginated(
-        extensions=[HasRetvalPerm(perms=[ClientProfilePermissions.VIEW])],
-    )
-
     client_profiles_paginated: OffsetPaginated[ClientProfileType] = strawberry_django.offset_paginated(
         extensions=[HasRetvalPerm(perms=[ClientProfilePermissions.VIEW])],
     )

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1067,7 +1067,6 @@ type Query {
   currentUser: UserType!
   availableOrganizations: [OrganizationType!]! @hasPerm(permissions: [{app: "notes", permission: "add_note"}], any: true)
   clientProfiles(filters: ClientProfileFilter, order: ClientProfileOrder, pagination: OffsetPaginationInput): [ClientProfileType!]! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)
-  activeClientProfiles(pagination: OffsetPaginationInput, filters: ClientProfileFilter, order: ClientProfileOrder): ClientProfileTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)
   clientProfilesPaginated(pagination: OffsetPaginationInput, filters: ClientProfileFilter, order: ClientProfileOrder): ClientProfileTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "clients", permission: "view_clientprofile"}], any: true)
   clientDocument(pk: ID!): ClientDocumentType! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)
   clientDocuments(pagination: OffsetPaginationInput): [ClientDocumentType!]! @hasRetvalPerm(permissions: [{app: "common", permission: "view_attachment"}], any: true)

--- a/apps/betterangels/package.json
+++ b/apps/betterangels/package.json
@@ -69,7 +69,8 @@
     "@nx/js": "*",
     "@types/google.maps": "*",
     "expo-updates": "*",
-    "@react-native-cookies/cookies": "*"
+    "@react-native-cookies/cookies": "*",
+    "remeda": "*"
   },
   "scripts": {
     "eas-build-pre-install": "corepack enable",

--- a/libs/expo/betterangels/src/lib/screens/Clients/Clients.graphql
+++ b/libs/expo/betterangels/src/lib/screens/Clients/Clients.graphql
@@ -63,3 +63,47 @@ query ClientProfiles(
     }
   }
 }
+
+query ClientProfilesPaginated(
+  $filters: ClientProfileFilter
+  $pagination: OffsetPaginationInput
+  $order: ClientProfileOrder
+) {
+  clientProfilesPaginated(
+    filters: $filters
+    pagination: $pagination
+    order: $order
+  ) {
+    totalCount
+    pageInfo {
+      limit
+      offset
+    }
+    results {
+      id
+      age
+      dateOfBirth
+      heightInInches
+      mailingAddress
+      nickname
+      residenceAddress
+      hmisProfiles {
+        id
+        agency
+        hmisId
+      }
+      profilePhoto {
+        name
+        url
+      }
+      user {
+        id
+        email
+        firstName
+        lastName
+        username
+      }
+      displayCaseManager # TODO: This shouldn't be here. Temporary fix while we figure out type generation.
+    }
+  }
+}

--- a/libs/expo/betterangels/src/lib/screens/Clients/__generated__/Clients.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/Clients/__generated__/Clients.generated.ts
@@ -19,6 +19,15 @@ export type ClientProfilesQueryVariables = Types.Exact<{
 
 export type ClientProfilesQuery = { __typename?: 'Query', clientProfiles: Array<{ __typename?: 'ClientProfileType', id: string, age?: number | null, dateOfBirth?: any | null, heightInInches?: number | null, mailingAddress?: string | null, nickname?: string | null, residenceAddress?: string | null, displayCaseManager: string, hmisProfiles?: Array<{ __typename?: 'HmisProfileType', id: string, agency: Types.HmisAgencyEnum, hmisId: string }> | null, profilePhoto?: { __typename?: 'DjangoImageType', name: string, url: string } | null, user: { __typename?: 'UserType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, username: string } }> };
 
+export type ClientProfilesPaginatedQueryVariables = Types.Exact<{
+  filters?: Types.InputMaybe<Types.ClientProfileFilter>;
+  pagination?: Types.InputMaybe<Types.OffsetPaginationInput>;
+  order?: Types.InputMaybe<Types.ClientProfileOrder>;
+}>;
+
+
+export type ClientProfilesPaginatedQuery = { __typename?: 'Query', clientProfilesPaginated: { __typename?: 'ClientProfileTypeOffsetPaginated', totalCount: number, pageInfo: { __typename?: 'OffsetPaginationInfo', limit?: number | null, offset: number }, results: Array<{ __typename?: 'ClientProfileType', id: string, age?: number | null, dateOfBirth?: any | null, heightInInches?: number | null, mailingAddress?: string | null, nickname?: string | null, residenceAddress?: string | null, displayCaseManager: string, hmisProfiles?: Array<{ __typename?: 'HmisProfileType', id: string, agency: Types.HmisAgencyEnum, hmisId: string }> | null, profilePhoto?: { __typename?: 'DjangoImageType', name: string, url: string } | null, user: { __typename?: 'UserType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, username: string } }> } };
+
 
 export const CreateNoteDocument = gql`
     mutation CreateNote($data: CreateNoteInput!) {
@@ -144,3 +153,79 @@ export type ClientProfilesQueryHookResult = ReturnType<typeof useClientProfilesQ
 export type ClientProfilesLazyQueryHookResult = ReturnType<typeof useClientProfilesLazyQuery>;
 export type ClientProfilesSuspenseQueryHookResult = ReturnType<typeof useClientProfilesSuspenseQuery>;
 export type ClientProfilesQueryResult = Apollo.QueryResult<ClientProfilesQuery, ClientProfilesQueryVariables>;
+export const ClientProfilesPaginatedDocument = gql`
+    query ClientProfilesPaginated($filters: ClientProfileFilter, $pagination: OffsetPaginationInput, $order: ClientProfileOrder) {
+  clientProfilesPaginated(
+    filters: $filters
+    pagination: $pagination
+    order: $order
+  ) {
+    totalCount
+    pageInfo {
+      limit
+      offset
+    }
+    results {
+      id
+      age
+      dateOfBirth
+      heightInInches
+      mailingAddress
+      nickname
+      residenceAddress
+      hmisProfiles {
+        id
+        agency
+        hmisId
+      }
+      profilePhoto {
+        name
+        url
+      }
+      user {
+        id
+        email
+        firstName
+        lastName
+        username
+      }
+      displayCaseManager
+    }
+  }
+}
+    `;
+
+/**
+ * __useClientProfilesPaginatedQuery__
+ *
+ * To run a query within a React component, call `useClientProfilesPaginatedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useClientProfilesPaginatedQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useClientProfilesPaginatedQuery({
+ *   variables: {
+ *      filters: // value for 'filters'
+ *      pagination: // value for 'pagination'
+ *      order: // value for 'order'
+ *   },
+ * });
+ */
+export function useClientProfilesPaginatedQuery(baseOptions?: Apollo.QueryHookOptions<ClientProfilesPaginatedQuery, ClientProfilesPaginatedQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ClientProfilesPaginatedQuery, ClientProfilesPaginatedQueryVariables>(ClientProfilesPaginatedDocument, options);
+      }
+export function useClientProfilesPaginatedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ClientProfilesPaginatedQuery, ClientProfilesPaginatedQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ClientProfilesPaginatedQuery, ClientProfilesPaginatedQueryVariables>(ClientProfilesPaginatedDocument, options);
+        }
+export function useClientProfilesPaginatedSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<ClientProfilesPaginatedQuery, ClientProfilesPaginatedQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<ClientProfilesPaginatedQuery, ClientProfilesPaginatedQueryVariables>(ClientProfilesPaginatedDocument, options);
+        }
+export type ClientProfilesPaginatedQueryHookResult = ReturnType<typeof useClientProfilesPaginatedQuery>;
+export type ClientProfilesPaginatedLazyQueryHookResult = ReturnType<typeof useClientProfilesPaginatedLazyQuery>;
+export type ClientProfilesPaginatedSuspenseQueryHookResult = ReturnType<typeof useClientProfilesPaginatedSuspenseQuery>;
+export type ClientProfilesPaginatedQueryResult = Apollo.QueryResult<ClientProfilesPaginatedQuery, ClientProfilesPaginatedQueryVariables>;

--- a/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
@@ -113,7 +113,9 @@ export default function Clients({ Logo }: { Logo: ElementType }) {
   };
 
   useEffect(() => {
-    if (!data || !('clientProfilesPaginated' in data)) return;
+    if (!data || !('clientProfilesPaginated' in data)) {
+      return;
+    }
     const { results, totalCount } = data.clientProfilesPaginated;
     setTotalCount(totalCount);
 

--- a/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
@@ -11,6 +11,7 @@ import { debounce } from '@monorepo/expo/shared/utils';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { ElementType, useEffect, useMemo, useState } from 'react';
 import { FlatList, View } from 'react-native';
+import { uniqueBy } from 'remeda';
 import { Ordering } from '../../apollo';
 import { useSnackbar } from '../../hooks';
 import { ClientCard, ClientCardModal, Header } from '../../ui-components';
@@ -19,7 +20,6 @@ import {
   useClientProfilesPaginatedQuery,
   useCreateNoteMutation,
 } from './__generated__/Clients.generated';
-
 type TClientProfile =
   ClientProfilesPaginatedQuery['clientProfilesPaginated']['results'];
 
@@ -122,17 +122,9 @@ export default function Clients({ Logo }: { Logo: ElementType }) {
     if (offset === 0) {
       setClients(results);
     } else {
-      setClients((prevClients) => {
-        // Merge new results with previous ones
-        const combined = [...prevClients, ...results];
-
-        // Use a Map to track unique clients by id
-        const clientMap = new Map<string, (typeof combined)[number]>();
-        for (const client of combined) {
-          clientMap.set(client.id, client);
-        }
-        return Array.from(clientMap.values());
-      });
+      setClients((prevClients) =>
+        uniqueBy([...prevClients, ...results], (client) => client.id)
+      );
     }
 
     setHasMore(offset + paginationLimit < totalCount);

--- a/libs/expo/betterangels/src/lib/screens/Home/ActiveClients.graphql
+++ b/libs/expo/betterangels/src/lib/screens/Home/ActiveClients.graphql
@@ -63,3 +63,47 @@ query ClientProfiles(
     }
   }
 }
+
+query ActiveClientProfilesPaginated(
+  $filters: ClientProfileFilter
+  $pagination: OffsetPaginationInput
+  $order: ClientProfileOrder
+) {
+  clientProfilesPaginated(
+    filters: $filters
+    pagination: $pagination
+    order: $order
+  ) {
+    totalCount
+    pageInfo {
+      limit
+      offset
+    }
+    results {
+      id
+      age
+      dateOfBirth
+      heightInInches
+      mailingAddress
+      nickname
+      residenceAddress
+      hmisProfiles {
+        id
+        agency
+        hmisId
+      }
+      profilePhoto {
+        name
+        url
+      }
+      user {
+        id
+        email
+        firstName
+        lastName
+        username
+      }
+      displayCaseManager # TODO: This shouldn't be here. Temporary fix while we figure out type generation.
+    }
+  }
+}

--- a/libs/expo/betterangels/src/lib/screens/Home/__generated__/ActiveClients.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/Home/__generated__/ActiveClients.generated.ts
@@ -19,6 +19,15 @@ export type ClientProfilesQueryVariables = Types.Exact<{
 
 export type ClientProfilesQuery = { __typename?: 'Query', clientProfiles: Array<{ __typename?: 'ClientProfileType', id: string, age?: number | null, dateOfBirth?: any | null, heightInInches?: number | null, mailingAddress?: string | null, nickname?: string | null, residenceAddress?: string | null, displayCaseManager: string, hmisProfiles?: Array<{ __typename?: 'HmisProfileType', id: string, agency: Types.HmisAgencyEnum, hmisId: string }> | null, profilePhoto?: { __typename?: 'DjangoImageType', name: string, url: string } | null, user: { __typename?: 'UserType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, username: string } }> };
 
+export type ActiveClientProfilesPaginatedQueryVariables = Types.Exact<{
+  filters?: Types.InputMaybe<Types.ClientProfileFilter>;
+  pagination?: Types.InputMaybe<Types.OffsetPaginationInput>;
+  order?: Types.InputMaybe<Types.ClientProfileOrder>;
+}>;
+
+
+export type ActiveClientProfilesPaginatedQuery = { __typename?: 'Query', clientProfilesPaginated: { __typename?: 'ClientProfileTypeOffsetPaginated', totalCount: number, pageInfo: { __typename?: 'OffsetPaginationInfo', limit?: number | null, offset: number }, results: Array<{ __typename?: 'ClientProfileType', id: string, age?: number | null, dateOfBirth?: any | null, heightInInches?: number | null, mailingAddress?: string | null, nickname?: string | null, residenceAddress?: string | null, displayCaseManager: string, hmisProfiles?: Array<{ __typename?: 'HmisProfileType', id: string, agency: Types.HmisAgencyEnum, hmisId: string }> | null, profilePhoto?: { __typename?: 'DjangoImageType', name: string, url: string } | null, user: { __typename?: 'UserType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, username: string } }> } };
+
 
 export const CreateNoteDocument = gql`
     mutation CreateNote($data: CreateNoteInput!) {
@@ -144,3 +153,79 @@ export type ClientProfilesQueryHookResult = ReturnType<typeof useClientProfilesQ
 export type ClientProfilesLazyQueryHookResult = ReturnType<typeof useClientProfilesLazyQuery>;
 export type ClientProfilesSuspenseQueryHookResult = ReturnType<typeof useClientProfilesSuspenseQuery>;
 export type ClientProfilesQueryResult = Apollo.QueryResult<ClientProfilesQuery, ClientProfilesQueryVariables>;
+export const ActiveClientProfilesPaginatedDocument = gql`
+    query ActiveClientProfilesPaginated($filters: ClientProfileFilter, $pagination: OffsetPaginationInput, $order: ClientProfileOrder) {
+  clientProfilesPaginated(
+    filters: $filters
+    pagination: $pagination
+    order: $order
+  ) {
+    totalCount
+    pageInfo {
+      limit
+      offset
+    }
+    results {
+      id
+      age
+      dateOfBirth
+      heightInInches
+      mailingAddress
+      nickname
+      residenceAddress
+      hmisProfiles {
+        id
+        agency
+        hmisId
+      }
+      profilePhoto {
+        name
+        url
+      }
+      user {
+        id
+        email
+        firstName
+        lastName
+        username
+      }
+      displayCaseManager
+    }
+  }
+}
+    `;
+
+/**
+ * __useActiveClientProfilesPaginatedQuery__
+ *
+ * To run a query within a React component, call `useActiveClientProfilesPaginatedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useActiveClientProfilesPaginatedQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useActiveClientProfilesPaginatedQuery({
+ *   variables: {
+ *      filters: // value for 'filters'
+ *      pagination: // value for 'pagination'
+ *      order: // value for 'order'
+ *   },
+ * });
+ */
+export function useActiveClientProfilesPaginatedQuery(baseOptions?: Apollo.QueryHookOptions<ActiveClientProfilesPaginatedQuery, ActiveClientProfilesPaginatedQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ActiveClientProfilesPaginatedQuery, ActiveClientProfilesPaginatedQueryVariables>(ActiveClientProfilesPaginatedDocument, options);
+      }
+export function useActiveClientProfilesPaginatedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ActiveClientProfilesPaginatedQuery, ActiveClientProfilesPaginatedQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ActiveClientProfilesPaginatedQuery, ActiveClientProfilesPaginatedQueryVariables>(ActiveClientProfilesPaginatedDocument, options);
+        }
+export function useActiveClientProfilesPaginatedSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<ActiveClientProfilesPaginatedQuery, ActiveClientProfilesPaginatedQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<ActiveClientProfilesPaginatedQuery, ActiveClientProfilesPaginatedQueryVariables>(ActiveClientProfilesPaginatedDocument, options);
+        }
+export type ActiveClientProfilesPaginatedQueryHookResult = ReturnType<typeof useActiveClientProfilesPaginatedQuery>;
+export type ActiveClientProfilesPaginatedLazyQueryHookResult = ReturnType<typeof useActiveClientProfilesPaginatedLazyQuery>;
+export type ActiveClientProfilesPaginatedSuspenseQueryHookResult = ReturnType<typeof useActiveClientProfilesPaginatedSuspenseQuery>;
+export type ActiveClientProfilesPaginatedQueryResult = Apollo.QueryResult<ActiveClientProfilesPaginatedQuery, ActiveClientProfilesPaginatedQueryVariables>;

--- a/libs/expo/betterangels/src/lib/screens/Home/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Home/index.tsx
@@ -9,6 +9,7 @@ import {
 import { useRouter } from 'expo-router';
 import { ElementType, useEffect, useState } from 'react';
 import { FlatList, View } from 'react-native';
+import { uniqueBy } from 'remeda';
 
 import { UserAddOutlineIcon } from '@monorepo/expo/shared/icons';
 import { ClientCard, ClientCardModal, Header } from '../../ui-components';
@@ -63,17 +64,9 @@ export default function Home({ Logo }: { Logo: ElementType }) {
     if (offset === 0) {
       setClients(results);
     } else {
-      setClients((prevClients) => {
-        // Merge new results with previous ones
-        const combined = [...prevClients, ...results];
-
-        // Use a Map to track unique clients by id
-        const clientMap = new Map<string, (typeof combined)[number]>();
-        for (const client of combined) {
-          clientMap.set(client.id, client);
-        }
-        return Array.from(clientMap.values());
-      });
+      setClients((prevClients) =>
+        uniqueBy([...prevClients, ...results], (client) => client.id)
+      );
     }
 
     setHasMore(offset + paginationLimit < totalCount);

--- a/libs/expo/betterangels/src/lib/screens/Home/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Home/index.tsx
@@ -54,7 +54,9 @@ export default function Home({ Logo }: { Logo: ElementType }) {
   };
 
   useEffect(() => {
-    if (!data || !('clientProfilesPaginated' in data)) return;
+    if (!data || !('clientProfilesPaginated' in data)) {
+      return;
+    }
     const { results, totalCount } = data.clientProfilesPaginated;
     setTotalCount(totalCount);
 

--- a/libs/expo/betterangels/src/lib/screens/Home/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Home/index.tsx
@@ -13,32 +13,33 @@ import { FlatList, View } from 'react-native';
 import { UserAddOutlineIcon } from '@monorepo/expo/shared/icons';
 import { ClientCard, ClientCardModal, Header } from '../../ui-components';
 import {
-  ClientProfilesQuery,
-  useClientProfilesQuery,
+  ActiveClientProfilesPaginatedQuery,
+  useActiveClientProfilesPaginatedQuery,
 } from './__generated__/ActiveClients.generated';
 
 const paginationLimit = 20;
+type TClientProfile =
+  ActiveClientProfilesPaginatedQuery['clientProfilesPaginated']['results'];
 
 export default function Home({ Logo }: { Logo: ElementType }) {
-  const [currentClient, setCurrentClient] =
-    useState<ClientProfilesQuery['clientProfiles'][number]>();
+  const router = useRouter();
+  const [currentClient, setCurrentClient] = useState<TClientProfile[number]>();
   const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
   const [offset, setOffset] = useState<number>(0);
   const [hasMore, setHasMore] = useState<boolean>(true);
-  const [clients, setClients] = useState<ClientProfilesQuery['clientProfiles']>(
-    []
-  );
-  const { data, loading } = useClientProfilesQuery({
+  const [totalCount, setTotalCount] = useState<number>(0);
+
+  const [clients, setClients] = useState<TClientProfile>([]);
+  const { data, loading } = useActiveClientProfilesPaginatedQuery({
     variables: {
       filters: { isActive: true },
-      pagination: { limit: paginationLimit + 1, offset: offset },
+      pagination: { limit: paginationLimit, offset: offset },
     },
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-first',
   });
-  const router = useRouter();
 
-  function loadMoreClients() {
+  async function loadMoreClients() {
     if (hasMore && !loading) {
       setOffset((prevOffset) => prevOffset + paginationLimit);
     }
@@ -53,85 +54,63 @@ export default function Home({ Logo }: { Logo: ElementType }) {
   };
 
   useEffect(() => {
-    if (!data || !('clientProfiles' in data)) return;
-
-    const clientsToShow = data.clientProfiles.slice(0, paginationLimit);
-    const isMoreAvailable = data.clientProfiles.length > clientsToShow.length;
+    if (!data || !('clientProfilesPaginated' in data)) return;
+    const { results, totalCount } = data.clientProfilesPaginated;
+    setTotalCount(totalCount);
 
     if (offset === 0) {
-      setClients(clientsToShow);
+      setClients(results);
     } else {
-      setClients((prevClients) => [...prevClients, ...clientsToShow]);
+      setClients((prevClients) => {
+        // Merge new results with previous ones
+        const combined = [...prevClients, ...results];
+
+        // Use a Map to track unique clients by id
+        const clientMap = new Map<string, (typeof combined)[number]>();
+        for (const client of combined) {
+          clientMap.set(client.id, client);
+        }
+        return Array.from(clientMap.values());
+      });
     }
 
-    setHasMore(isMoreAvailable);
+    setHasMore(offset + paginationLimit < totalCount);
   }, [data, offset]);
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={{ flex: 1, backgroundColor: Colors.NEUTRAL_EXTRA_LIGHT }}>
       <Header title="Home" Logo={Logo} />
-
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginTop: Spacings.xs,
+          paddingHorizontal: Spacings.sm,
+          backgroundColor: Colors.NEUTRAL_EXTRA_LIGHT,
+        }}
+      >
+        <TextMedium size="sm">
+          Displaying {clients.length} of {totalCount} Active Clients
+        </TextMedium>
+        <TextButton
+          accessibilityHint="goes to all clients list"
+          color={Colors.PRIMARY}
+          fontSize="sm"
+          regular={true}
+          title="All Clients"
+          onPress={() => router.navigate('/clients')}
+        />
+      </View>
       <FlatList
         style={{
           flex: 1,
           backgroundColor: Colors.NEUTRAL_EXTRA_LIGHT,
           paddingBottom: 80,
-          paddingTop: Spacings.sm,
+          marginTop: Spacings.xs,
           paddingHorizontal: Spacings.sm,
         }}
         data={clients}
-        ListHeaderComponent={
-          <>
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                marginBottom: Spacings.sm,
-              }}
-            >
-              <TextMedium size="lg">Active Clients</TextMedium>
-              <TextButton
-                accessibilityHint="goes to all active clients list"
-                color={Colors.PRIMARY}
-                fontSize="sm"
-                regular={true}
-                title="All Clients"
-                onPress={() => router.navigate('/clients')}
-              />
-            </View>
-            {!loading && clients.length < 1 && (
-              <View
-                style={{
-                  flexGrow: 1,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  paddingVertical: Spacings.xl,
-                }}
-              >
-                <View
-                  style={{
-                    height: 90,
-                    width: 90,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    borderRadius: Radiuses.xxxl,
-                    backgroundColor: Colors.PRIMARY_EXTRA_LIGHT,
-                    marginBottom: Spacings.md,
-                  }}
-                >
-                  <UserAddOutlineIcon size="2xl" color={Colors.PRIMARY} />
-                </View>
-                <TextBold mb="xs" size="sm">
-                  No Active Clients
-                </TextBold>
-                <TextRegular size="sm">
-                  Try adding a client or an interaction.
-                </TextRegular>
-              </View>
-            )}
-          </>
-        }
         renderItem={({ item: clientProfile }) =>
           clients ? (
             <ClientCard
@@ -148,6 +127,38 @@ export default function Home({ Logo }: { Logo: ElementType }) {
         keyExtractor={(clientProfile) => clientProfile.id}
         onEndReached={loadMoreClients}
         onEndReachedThreshold={0.05}
+        ListHeaderComponent={
+          !loading && clients.length < 1 ? (
+            <View
+              style={{
+                flexGrow: 1,
+                alignItems: 'center',
+                justifyContent: 'center',
+                paddingVertical: Spacings.xl,
+              }}
+            >
+              <View
+                style={{
+                  height: 90,
+                  width: 90,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRadius: Radiuses.xxxl,
+                  backgroundColor: Colors.PRIMARY_EXTRA_LIGHT,
+                  marginBottom: Spacings.md,
+                }}
+              >
+                <UserAddOutlineIcon size="2xl" color={Colors.PRIMARY} />
+              </View>
+              <TextBold mb="xs" size="sm">
+                No Active Clients
+              </TextBold>
+              <TextRegular size="sm">
+                Try adding a client or an interaction.
+              </TextRegular>
+            </View>
+          ) : null
+        }
         ListFooterComponent={renderFooter}
       />
       {currentClient && (


### PR DESCRIPTION
DEV-1155, DEV-1486

- use paginated query on client screens
- display current and total counts in header
- dedupe client cards (thanks @vecchp)
- revert #1058

replaces #1050 because the commit history got out of hand there

## Summary by Sourcery

This pull request introduces pagination to the client lists on the Home and Clients screens to improve performance. It also displays the current and total counts in the header and deduplicates client cards.

New Features:
- Implements pagination for client lists on both the Home and Clients screens, improving performance and user experience.
- Displays the current number of clients and the total number of clients in the header of both the Home and Clients screens.

Bug Fixes:
- Addresses a bug where client cards were not being properly deduplicated when loading more clients.

Enhancements:
- Replaces the `ClientProfilesQuery` with `ClientProfilesPaginatedQuery` to fetch client data in paginated form.
- Improves the loading of client data by implementing client-side deduplication.