### PR TITLE
Bump version to 1.0.37

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.36',
+    version: '1.0.37',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.47',
+      buildNumber: '1.0.48',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -73,7 +73,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 46,
+      versionCode: 47,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bumped the app version to 1.0.37, iOS build number to 1.0.48, and Android versionCode to 47.