### PR TITLE
view pdf via expo-web-browser (DEV-1116)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/FileScreenComponent/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/FileScreenComponent/index.tsx
@@ -3,7 +3,6 @@ import {
   BaseModal,
   ImageViewer,
   Loading,
-  PdfViewer,
   TextBold,
   TextRegular,
 } from '@monorepo/expo/shared/ui-components';
@@ -14,7 +13,11 @@ import { StyleSheet, View } from 'react-native';
 import { AttachmentType } from '../../apollo';
 import { MimeTypes } from '../../static';
 import { enumDisplayDocumentType } from '../../static/enumDisplayMapping';
-import { FileThumbnail, MainContainer } from '../../ui-components';
+import {
+  FileThumbnail,
+  MainContainer,
+  WebBrowserLink,
+} from '../../ui-components';
 import { useClientDocumentQuery } from './__generated__/Document.generated';
 import { fileDisplaySizeMap } from './fileDisplaySizeMap';
 
@@ -85,18 +88,14 @@ export default function FileScreenComponent(props: TFileScreenComponent) {
           )}
 
           {isPdf && (
-            <FileThumbnail
-              uri={file.url}
-              mimeType={mimeType}
-              thumbnailSize={fileDisplaySizeMap[namespace]}
-              accessibilityHint="view pdf file"
-              onPress={() =>
-                setFileView({
-                  content: <PdfViewer url={file.url} />,
-                  title: originalFilename || '',
-                })
-              }
-            />
+            <WebBrowserLink href={file.url} accessibilityHint="view pdf file">
+              <FileThumbnail
+                uri={file.url}
+                mimeType={mimeType}
+                thumbnailSize={fileDisplaySizeMap[namespace]}
+                accessibilityHint="view pdf file"
+              />
+            </WebBrowserLink>
           )}
 
           {!isImage && !isPdf && (


### PR DESCRIPTION
https://betterangels.atlassian.net/browse/DEV-1116

- switches to rendering PDF in `WebBrowser` (from 'expo-web-browser')
  - `react-native-pdf` does not work fully with expo (not technically supported) and breaks in android.
  - `react-native-webview` has similar issues for Android, where a loaded pdf would probably need to be shown in an iframe. It's good for rendering html in webview, but not files via url
  - other pdf solutions have questionable support
  - Expo Go seems to be a limitation
  - the browser solution seems the most stable
    - the android experience is still sub-optimal due to android ux

## Summary by Sourcery

Enhancements:
- Replaced the PDF viewer component with a link that opens the PDF in the Expo web browser, improving stability across platforms.