### PR TITLE
add duplicate and invalid cali id error codes (DEV-1161)

### DIFF
--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Dict, List, Optional, cast
 
 import phonenumber_field
@@ -106,6 +107,13 @@ def _validate_user_name(user_data: dict, nickname: str, user: Optional[User] = N
 
 def _validate_california_id(california_id: str) -> list[dict[str, Any]]:
     errors = []
+
+    california_id_pattern = r"^[A-Z]\d{7}$"
+    if not re.search(california_id_pattern, california_id):
+        errors.append(_build_error("californiaId", None, ErrorMessageEnum.INVALID_CA_ID.name))
+
+        # early return so we don't query for invalid ids
+        return errors
 
     if ClientProfile.objects.filter(california_id=california_id).exists():
         errors.append(_build_error("californiaId", None, ErrorMessageEnum.CA_ID_IN_USE.name))

--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -104,6 +104,15 @@ def _validate_user_name(user_data: dict, nickname: str, user: Optional[User] = N
     return errors
 
 
+def _validate_california_id(california_id: str) -> list[dict[str, Any]]:
+    errors = []
+
+    if ClientProfile.objects.filter(california_id=california_id).exists():
+        errors.append(_build_error("californiaId", None, ErrorMessageEnum.CA_ID_IN_USE.name))
+
+    return errors
+
+
 def _validate_phone_numbers(phone_numbers: list[dict[str, Any]]) -> list[dict[str, Any]]:
     errors = []
 
@@ -157,6 +166,9 @@ def _validate_client_profile_data(data: dict) -> None:
 
         errors += _validate_user_name(data["user"], data["nickname"], user)
         errors += _validate_user_email(data["user"], user)
+
+    if data["california_id"] is not strawberry.UNSET:
+        errors += _validate_california_id(data["california_id"])
 
     if data["contacts"] is not strawberry.UNSET:
         errors += _validate_contacts(data["contacts"])

--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -108,14 +108,14 @@ def _validate_user_name(user_data: dict, nickname: str, user: Optional[User] = N
 def _validate_california_id(california_id: str) -> list[dict[str, Any]]:
     errors = []
 
-    california_id_pattern = r"^[A-Z]\d{7}$"
+    california_id_pattern = r"^[a-zA-Z]\d{7}$"
     if not re.search(california_id_pattern, california_id):
         errors.append(_build_error("californiaId", None, ErrorMessageEnum.INVALID_CA_ID.name))
 
         # early return so we don't query for invalid ids
         return errors
 
-    if ClientProfile.objects.filter(california_id=california_id).exists():
+    if ClientProfile.objects.filter(california_id__iexact=california_id).exists():
         errors.append(_build_error("californiaId", None, ErrorMessageEnum.CA_ID_IN_USE.name))
 
     return errors

--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -319,6 +319,8 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
         variables.pop("id")
         variables["user"].pop("id")
 
+        variables["californiaId"] = "invalid_id"
+
         response = self._create_client_profile_fixture(variables)
         validation_errors = response["errors"][0]
         error_messages = validation_errors["extensions"]["errors"]
@@ -333,7 +335,7 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
         self.assertEqual(error_messages[1]["errorCode"], ErrorMessageEnum.EMAIL_IN_USE.name)
         self.assertEqual(error_messages[2]["field"], "californiaId")
         self.assertEqual(error_messages[2]["location"], None)
-        self.assertEqual(error_messages[2]["errorCode"], ErrorMessageEnum.CA_ID_IN_USE.name)
+        self.assertEqual(error_messages[2]["errorCode"], ErrorMessageEnum.INVALID_CA_ID.name)
         self.assertEqual(error_messages[3]["field"], "contacts")
         self.assertEqual(error_messages[3]["location"], "0__phoneNumber")
         self.assertEqual(error_messages[3]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)

--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -283,6 +283,7 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
 
         variables = {
             "id": self.client_profile_2["id"],
+            "californiaId": self.client_profile_1["californiaId"],
             "contacts": [contact],
             "hmisProfiles": [hmis_profile],
             "nickname": "",
@@ -295,22 +296,25 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
         error_messages = validation_errors["extensions"]["errors"]
 
         self.assertEqual(validation_errors["message"], "Validation Errors")
-        self.assertEqual(len(error_messages), 5)
+        self.assertEqual(len(error_messages), 6)
         self.assertEqual(error_messages[0]["field"], "nickname")
         self.assertIsNone(error_messages[0]["location"])
         self.assertEqual(error_messages[0]["errorCode"], ErrorMessageEnum.NO_NAME_PROVIDED.name)
         self.assertEqual(error_messages[1]["field"], "user")
         self.assertEqual(error_messages[1]["location"], "email")
         self.assertEqual(error_messages[1]["errorCode"], ErrorMessageEnum.EMAIL_IN_USE.name)
-        self.assertEqual(error_messages[2]["field"], "contacts")
-        self.assertEqual(error_messages[2]["location"], "0__phoneNumber")
-        self.assertEqual(error_messages[2]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
-        self.assertEqual(error_messages[3]["field"], "hmisProfiles")
-        self.assertEqual(error_messages[3]["location"], "0__hmisId")
-        self.assertEqual(error_messages[3]["errorCode"], ErrorMessageEnum.HMIS_ID_IN_USE.name)
-        self.assertEqual(error_messages[4]["field"], "phoneNumbers")
-        self.assertEqual(error_messages[4]["location"], "0__number")
-        self.assertEqual(error_messages[4]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
+        self.assertEqual(error_messages[2]["field"], "californiaId")
+        self.assertEqual(error_messages[2]["location"], None)
+        self.assertEqual(error_messages[2]["errorCode"], ErrorMessageEnum.CA_ID_IN_USE.name)
+        self.assertEqual(error_messages[3]["field"], "contacts")
+        self.assertEqual(error_messages[3]["location"], "0__phoneNumber")
+        self.assertEqual(error_messages[3]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
+        self.assertEqual(error_messages[4]["field"], "hmisProfiles")
+        self.assertEqual(error_messages[4]["location"], "0__hmisId")
+        self.assertEqual(error_messages[4]["errorCode"], ErrorMessageEnum.HMIS_ID_IN_USE.name)
+        self.assertEqual(error_messages[5]["field"], "phoneNumbers")
+        self.assertEqual(error_messages[5]["location"], "0__number")
+        self.assertEqual(error_messages[5]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
 
         variables.pop("id")
         variables["user"].pop("id")
@@ -320,22 +324,25 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
         error_messages = validation_errors["extensions"]["errors"]
 
         self.assertEqual(validation_errors["message"], "Validation Errors")
-        self.assertEqual(len(error_messages), 5)
+        self.assertEqual(len(error_messages), 6)
         self.assertEqual(error_messages[0]["field"], "nickname")
         self.assertIsNone(error_messages[0]["location"])
         self.assertEqual(error_messages[0]["errorCode"], ErrorMessageEnum.NO_NAME_PROVIDED.name)
         self.assertEqual(error_messages[1]["field"], "user")
         self.assertEqual(error_messages[1]["location"], "email")
         self.assertEqual(error_messages[1]["errorCode"], ErrorMessageEnum.EMAIL_IN_USE.name)
-        self.assertEqual(error_messages[2]["field"], "contacts")
-        self.assertEqual(error_messages[2]["location"], "0__phoneNumber")
-        self.assertEqual(error_messages[2]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
-        self.assertEqual(error_messages[3]["field"], "hmisProfiles")
-        self.assertEqual(error_messages[3]["location"], "0__hmisId")
-        self.assertEqual(error_messages[3]["errorCode"], ErrorMessageEnum.HMIS_ID_IN_USE.name)
-        self.assertEqual(error_messages[4]["field"], "phoneNumbers")
-        self.assertEqual(error_messages[4]["location"], "0__number")
-        self.assertEqual(error_messages[4]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
+        self.assertEqual(error_messages[2]["field"], "californiaId")
+        self.assertEqual(error_messages[2]["location"], None)
+        self.assertEqual(error_messages[2]["errorCode"], ErrorMessageEnum.CA_ID_IN_USE.name)
+        self.assertEqual(error_messages[3]["field"], "contacts")
+        self.assertEqual(error_messages[3]["location"], "0__phoneNumber")
+        self.assertEqual(error_messages[3]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
+        self.assertEqual(error_messages[4]["field"], "hmisProfiles")
+        self.assertEqual(error_messages[4]["location"], "0__hmisId")
+        self.assertEqual(error_messages[4]["errorCode"], ErrorMessageEnum.HMIS_ID_IN_USE.name)
+        self.assertEqual(error_messages[5]["field"], "phoneNumbers")
+        self.assertEqual(error_messages[5]["location"], "0__number")
+        self.assertEqual(error_messages[5]["errorCode"], ErrorMessageEnum.INVALID_PHONE_NUMBER.name)
 
     def test_update_client_profile_mutation_related_objects(self) -> None:
         """Verifies that updating a client profile's doesn't affect other client profiles."""

--- a/apps/betterangels-backend/common/enums.py
+++ b/apps/betterangels-backend/common/enums.py
@@ -11,6 +11,7 @@ class AttachmentType(models.TextChoices):
 
 
 class ErrorMessageEnum(models.TextChoices):
+    CA_ID_IN_USE = "ca_id_in_us", _("California ID is already in use")
     EMAIL_IN_USE = "email_in_use", _("Email is already in use")
     HMIS_ID_IN_USE = "hmis_id_in_use", _("HMIS ID is already in use")
     INVALID_PHONE_NUMBER = "invalid_phone_number", _("Invalid phone number")

--- a/apps/betterangels-backend/common/enums.py
+++ b/apps/betterangels-backend/common/enums.py
@@ -14,5 +14,6 @@ class ErrorMessageEnum(models.TextChoices):
     CA_ID_IN_USE = "ca_id_in_us", _("California ID is already in use")
     EMAIL_IN_USE = "email_in_use", _("Email is already in use")
     HMIS_ID_IN_USE = "hmis_id_in_use", _("HMIS ID is already in use")
+    INVALID_CA_ID = "invalid_ca_id", _("Invalid California ID")
     INVALID_PHONE_NUMBER = "invalid_phone_number", _("Invalid phone number")
     NO_NAME_PROVIDED = "no_name_provided", _("No name provided")


### PR DESCRIPTION
DEV-1161 (ok, not really, but we're already here)

## Summary by Sourcery

Tests:
- Added a test case to verify that an error is raised when a duplicate California ID is used.