### PR TITLE
Remove title from frontend in favor of purpose (DEV-1001)

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.37',
+    version: '1.0.38',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.48',
+      buildNumber: '1.0.49',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -73,7 +73,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 47,
+      versionCode: 48,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/mutations.generated.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/mutations.generated.ts
@@ -18,14 +18,14 @@ export type UpdateNoteMutationVariables = Types.Exact<{
 }>;
 
 
-export type UpdateNoteMutation = { __typename?: 'Mutation', updateNote: { __typename?: 'NoteType', id: string, title?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo' } };
+export type UpdateNoteMutation = { __typename?: 'Mutation', updateNote: { __typename?: 'NoteType', id: string, purpose?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo' } };
 
 export type RevertNoteMutationVariables = Types.Exact<{
   data: Types.RevertNoteInput;
 }>;
 
 
-export type RevertNoteMutation = { __typename?: 'Mutation', revertNote: { __typename?: 'NoteType', id: string, title?: string | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, createdAt: any, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, client?: { __typename?: 'UserType', id: string } | null, createdBy: { __typename?: 'UserType', id: string } } | { __typename?: 'OperationInfo' } };
+export type RevertNoteMutation = { __typename?: 'Mutation', revertNote: { __typename?: 'NoteType', id: string, purpose?: string | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, createdAt: any, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, client?: { __typename?: 'UserType', id: string } | null, createdBy: { __typename?: 'UserType', id: string } } | { __typename?: 'OperationInfo' } };
 
 export type DeleteNoteMutationVariables = Types.Exact<{
   data: Types.DeleteDjangoObjectInput;
@@ -178,7 +178,7 @@ export const UpdateNoteDocument = gql`
   updateNote(data: $data) {
     ... on NoteType {
       id
-      title
+      purpose
       publicDetails
       client {
         id
@@ -228,7 +228,7 @@ export const RevertNoteDocument = gql`
   revertNote(data: $data) {
     ... on NoteType {
       id
-      title
+      purpose
       location {
         address {
           id

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -1103,6 +1103,7 @@ export type NoteFilter = {
   DISTINCT?: InputMaybe<Scalars['Boolean']['input']>;
   NOT?: InputMaybe<NoteFilter>;
   OR?: InputMaybe<NoteFilter>;
+  authors?: InputMaybe<Array<Scalars['ID']['input']>>;
   client?: InputMaybe<Scalars['ID']['input']>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
   isSubmitted?: InputMaybe<Scalars['Boolean']['input']>;

--- a/libs/expo/betterangels/src/lib/apollo/graphql/mutations.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/mutations.ts
@@ -31,7 +31,7 @@ export const UPDATE_NOTE = gql`
     updateNote(data: $data) {
       ... on NoteType {
         id
-        title
+        purpose
         publicDetails
         client {
           id
@@ -55,7 +55,7 @@ export const REVERT_NOTE = gql`
     revertNote(data: $data) {
       ... on NoteType {
         id
-        title
+        purpose
         location {
           address {
             id

--- a/libs/expo/betterangels/src/lib/screens/Client/Client.graphql
+++ b/libs/expo/betterangels/src/lib/screens/Client/Client.graphql
@@ -158,7 +158,7 @@ mutation CreateNote($data: CreateNoteInput!) {
 
     ... on NoteType {
       id
-      title
+      purpose
       publicDetails
       client {
         id

--- a/libs/expo/betterangels/src/lib/screens/Client/__generated__/Client.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/__generated__/Client.generated.ts
@@ -29,7 +29,7 @@ export type CreateNoteMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateNoteMutation = { __typename?: 'Mutation', createNote: { __typename?: 'NoteType', id: string, title?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } };
+export type CreateNoteMutation = { __typename?: 'Mutation', createNote: { __typename?: 'NoteType', id: string, purpose?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } };
 
 
 export const ClientProfileDocument = gql`
@@ -279,7 +279,7 @@ export const CreateNoteDocument = gql`
     }
     ... on NoteType {
       id
-      title
+      purpose
       publicDetails
       client {
         id

--- a/libs/expo/betterangels/src/lib/screens/Clients/Clients.graphql
+++ b/libs/expo/betterangels/src/lib/screens/Clients/Clients.graphql
@@ -10,7 +10,7 @@ mutation CreateNote($data: CreateNoteInput!) {
 
     ... on NoteType {
       id
-      title
+      purpose
       publicDetails
       client {
         id

--- a/libs/expo/betterangels/src/lib/screens/Clients/__generated__/Clients.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/Clients/__generated__/Clients.generated.ts
@@ -8,7 +8,7 @@ export type CreateNoteMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateNoteMutation = { __typename?: 'Mutation', createNote: { __typename?: 'NoteType', id: string, title?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } };
+export type CreateNoteMutation = { __typename?: 'Mutation', createNote: { __typename?: 'NoteType', id: string, purpose?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } };
 
 export type ClientProfilesQueryVariables = Types.Exact<{
   filters?: Types.InputMaybe<Types.ClientProfileFilter>;
@@ -41,7 +41,7 @@ export const CreateNoteDocument = gql`
     }
     ... on NoteType {
       id
-      title
+      purpose
       publicDetails
       client {
         id

--- a/libs/expo/betterangels/src/lib/screens/Home/ActiveClients.graphql
+++ b/libs/expo/betterangels/src/lib/screens/Home/ActiveClients.graphql
@@ -10,7 +10,7 @@ mutation CreateNote($data: CreateNoteInput!) {
 
     ... on NoteType {
       id
-      title
+      purpose
       publicDetails
       client {
         id

--- a/libs/expo/betterangels/src/lib/screens/Home/__generated__/ActiveClients.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/Home/__generated__/ActiveClients.generated.ts
@@ -8,7 +8,7 @@ export type CreateNoteMutationVariables = Types.Exact<{
 }>;
 
 
-export type CreateNoteMutation = { __typename?: 'Mutation', createNote: { __typename?: 'NoteType', id: string, title?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } };
+export type CreateNoteMutation = { __typename?: 'Mutation', createNote: { __typename?: 'NoteType', id: string, purpose?: string | null, publicDetails: string, createdAt: any, client?: { __typename?: 'UserType', id: string, username: string, firstName?: string | null, lastName?: string | null, email?: string | null } | null, createdBy: { __typename?: 'UserType', id: string, username: string, email?: string | null } } | { __typename?: 'OperationInfo', messages: Array<{ __typename?: 'OperationMessage', kind: Types.OperationMessageKind, field?: string | null, message: string }> } };
 
 export type ClientProfilesQueryVariables = Types.Exact<{
   filters?: Types.InputMaybe<Types.ClientProfileFilter>;
@@ -41,7 +41,7 @@ export const CreateNoteDocument = gql`
     }
     ... on NoteType {
       id
-      title
+      purpose
       publicDetails
       client {
         id

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -1103,6 +1103,7 @@ export type NoteFilter = {
   DISTINCT?: InputMaybe<Scalars['Boolean']['input']>;
   NOT?: InputMaybe<NoteFilter>;
   OR?: InputMaybe<NoteFilter>;
+  authors?: InputMaybe<Array<Scalars['ID']['input']>>;
   client?: InputMaybe<Scalars['ID']['input']>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
   isSubmitted?: InputMaybe<Scalars['Boolean']['input']>;


### PR DESCRIPTION
DEV-1001
## Summary by Sourcery

Replaced the 'title' field with 'purpose' in the note creation and update process. Also, the app version and build numbers have been incremented.

Enhancements:
- Replaced the 'title' field with 'purpose' in the note creation and update process to better reflect the intended use of the field.

Build:
- Incremented the app version and build numbers for both iOS and Android platforms.

## Summary by Sourcery

Replaced the 'title' field with 'purpose' in the note creation and update process. Also, the app version and build numbers have been incremented.

Enhancements:
- Replaced the 'title' field with 'purpose' in the note creation and update process to better reflect the intended use of the field.

Build:
- Incremented the app version and build numbers for both iOS and Android platforms.