### PR TITLE
fix name validation fn and add regression test (DEV-1546)

### DIFF
--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -224,7 +224,7 @@ def validate_client_profile_data(data: dict) -> None:
         user = User.objects.filter(client_profile__id=data["id"]).first()
 
     if user_data := data.get("user"):
-        errors += validate_client_name(user_data, user_data.get("nickname"), user)
+        errors += validate_client_name(user_data, data.get("nickname"), user)
         errors += validate_user_email(user_data.get("email"), user)
 
     if data.get("california_id"):

--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -1,7 +1,5 @@
-from typing import Optional
 from unittest.mock import ANY
 
-import strawberry
 from accounts.models import User
 from clients.enums import (
     AdaAccommodationEnum,
@@ -26,7 +24,6 @@ from clients.tests.utils import ClientProfileGraphQLBaseTestCase
 from common.models import Attachment
 from deepdiff import DeepDiff
 from django.test import override_settings
-from unittest_parametrize import parametrize
 
 
 class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
@@ -332,7 +329,7 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
 
     def test_client_profile_mutation_client_name_validation(self) -> None:
         variables = {
-            "user": {"id": self.client_profile_1["user"]["id"]},
+            "user": {},
             "nickname": "Mikey",
         }
 

--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -1,5 +1,7 @@
+from typing import Optional
 from unittest.mock import ANY
 
+import strawberry
 from accounts.models import User
 from clients.enums import (
     AdaAccommodationEnum,
@@ -24,6 +26,7 @@ from clients.tests.utils import ClientProfileGraphQLBaseTestCase
 from common.models import Attachment
 from deepdiff import DeepDiff
 from django.test import override_settings
+from unittest_parametrize import parametrize
 
 
 class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
@@ -326,6 +329,66 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
         ]
 
         self.assertCountEqual(create_response["errors"][0]["extensions"]["errors"], expected_create_error_messages)
+
+    @parametrize(
+        "first_name, middle_name, last_name, nickname, operation, should_return_error",
+        [
+            (strawberry.UNSET, strawberry.UNSET, strawberry.UNSET, "nick", "create", False),
+            (strawberry.UNSET, strawberry.UNSET, strawberry.UNSET, strawberry.UNSET, "create", True),
+            (None, None, None, None, "create", True),
+            (" ", " ", " ", " ", "create", True),
+            ("", None, " ", strawberry.UNSET, "create", True),
+            (strawberry.UNSET, strawberry.UNSET, strawberry.UNSET, strawberry.UNSET, "update", False),
+            (None, None, None, None, "update", True),
+            (" ", " ", " ", " ", "update", True),
+            ("", None, " ", strawberry.UNSET, "update", False),
+        ],
+    )
+    def test_client_profile_mutation_client_name_validation(
+        self,
+        first_name: Optional[str],
+        middle_name: Optional[str],
+        last_name: Optional[str],
+        nickname: Optional[str],
+        operation: str,
+        should_return_error: bool,
+    ) -> None:
+        user = {
+            "id": self.client_profile_1["user"]["id"],
+            "firstName": first_name,
+            "lastName": last_name,
+            "middleName": middle_name,
+        }
+        variables: dict = {
+            "id": self.client_profile_1["id"],
+            "user": user,
+            "nickname": nickname,
+        }
+
+        # Can't pass strawberry.UNSET to the mutation, so we remove the "unset" fields
+        if first_name is strawberry.UNSET:
+            variables["user"].pop("firstName")
+        if last_name is strawberry.UNSET:
+            variables["user"].pop("lastName")
+        if middle_name is strawberry.UNSET:
+            variables["user"].pop("middleName")
+        if nickname is strawberry.UNSET:
+            variables.pop("nickname")
+
+        if operation == "create":
+            variables.pop("id")
+            variables["user"].pop("id")
+            response = self._create_client_profile_fixture(variables)
+        else:
+            response = self._update_client_profile_fixture(variables)
+
+        if should_return_error:
+            self.assertEqual(len(response["errors"]), 1)
+            self.assertEqual(
+                response["errors"][0]["extensions"]["errors"][0]["errorCode"], ErrorCodeEnum.NAME_NOT_PROVIDED.name
+            )
+        else:
+            self.assertIsNone(response.get("errors"))
 
     def test_update_client_profile_mutation_related_objects(self) -> None:
         """Verifies that updating a client profile's doesn't affect other client profiles."""


### PR DESCRIPTION
DEV-1546

`validate_client_name` was being called with the wrong arg. Wasn't caught earlier because the function was unit tested directly. Fixed the function call and added an integration test.

## Summary by Sourcery

Fixes a bug in the `validate_client_name` function call and adds a regression test to prevent future occurrences.

Bug Fixes:
- Fixes an issue where `validate_client_name` was being called with the wrong argument, leading to incorrect validation of client names.

Tests:
- Adds a regression test to verify the correct behavior of client name validation in both create and update operations.