### PR TITLE
Add client search and user links to django admin

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -1,9 +1,11 @@
-from typing import Type, cast
+from typing import Optional, Type, cast
 
 from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User as DefaultUser
+from django.urls import reverse
+from django.utils.html import format_html
 from organizations.models import Organization, OrganizationInvitation, OrganizationUser
 
 from .admin_request_mixin import AdminRequestMixin
@@ -83,12 +85,16 @@ class UserAdmin(BaseUserAdmin):
     )
     # Not convinced this is the right type; we cast our custom User as a DefaultUser.
     model = cast(Type[DefaultUser], User)
-    list_display = [
-        "id",
-        "full_name",
-        "email",
-        "is_client",
-    ]
+    list_display = ["id", "full_name", "email", "is_client", "client_id"]
 
     def is_client(self, obj: User) -> bool:
         return hasattr(obj, "client_profile")
+
+    def client_id(self, obj: User) -> Optional[str]:
+        return (
+            format_html(
+                f'<a href="{reverse("admin:clients_clientprofile_change", args=(obj.client_profile.id,))}">{obj.client_profile.id}</a>'
+            )
+            if hasattr(obj, "client_profile")
+            else None
+        )

--- a/apps/betterangels-backend/clients/admin.py
+++ b/apps/betterangels-backend/clients/admin.py
@@ -1,6 +1,8 @@
 from common.models import PhoneNumber
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericTabularInline
+from django.urls import reverse
+from django.utils.html import format_html
 
 from .models import (
     ClientProfile,
@@ -22,16 +24,25 @@ class PhoneNumberInline(GenericTabularInline):
 
 @admin.register(ClientProfile)
 class ClientProfileAdmin(admin.ModelAdmin):
-    list_display = ["name", "id"]
+    list_display = ["name", "id", "user__email", "user_id"]
     inlines = [HmisProfileInline, PhoneNumberInline]
 
     def name(self, obj: ClientProfile) -> str:
         return obj.user.full_name
 
+    def user_id(self, obj: ClientProfile) -> str:
+        return format_html(f'<a href="{reverse("admin:accounts_user_change", args=(obj.user.id,))}">{obj.user.id}</a>')
+
+    search_fields = (
+        "nickname",
+        "user__email",
+        "user__first_name",
+        "user__last_name",
+        "user__middle_name",
+    )
+
 
 # Data Import
-
-
 @admin.register(ClientProfileDataImport)
 class ClientProfileDataImportAdmin(admin.ModelAdmin):
     list_display = ("id", "imported_at", "source_file", "imported_by", "record_counts")


### PR DESCRIPTION
## Summary by Sourcery

Enhance Django admin interface for users and clients by adding search functionality to client profiles and linking users to their client profiles and vice versa.

Enhancements:
- Add search functionality to client profiles based on nickname, user email, first name, last name, and middle name.
- Add links in the user admin to the client profile and in the client profile admin to the user.