### PR TITLE
render dateOfBirth as absolute date without tz adjustments (DEV-1571)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Profile/HouseholdMembers.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Profile/HouseholdMembers.tsx
@@ -5,8 +5,8 @@ import {
   TextBold,
   TextMedium,
   TextRegular,
+  parseDate,
 } from '@monorepo/expo/shared/ui-components';
-import { format } from 'date-fns';
 import { View } from 'react-native';
 import { RelationshipTypeEnum } from '../../../apollo';
 import { clientHouseholdMemberEnumDisplay } from '../../../static/enumDisplayMapping';
@@ -59,9 +59,11 @@ export default function HouseholdMembers(props: IProfileSectionProps) {
               },
               {
                 label: 'Date of Birth',
-                value: householdMember.dateOfBirth
-                  ? format(new Date(householdMember.dateOfBirth), 'MM/dd/yyyy')
-                  : '',
+                value: parseDate({
+                  date: householdMember.dateOfBirth,
+                  inputFormat: 'yyyy-MM-dd',
+                  outputFormat: 'MM/dd/yyyy',
+                }),
               },
             ];
             return (

--- a/libs/expo/betterangels/src/lib/screens/Client/Profile/PersonalInfo.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Profile/PersonalInfo.tsx
@@ -4,10 +4,10 @@ import {
   CardWrapper,
   TextBold,
   TextRegular,
+  parseDate,
 } from '@monorepo/expo/shared/ui-components';
 import { StyleSheet, View } from 'react-native';
 
-import { format } from 'date-fns';
 import {
   enumDisplayHmisAgency,
   enumDisplayLanguage,
@@ -44,9 +44,11 @@ export default function PersonalInfo(props: IProfileSectionProps) {
     .join(' ')
     .trim();
 
-  const formattedDob = client?.clientProfile.dateOfBirth
-    ? format(new Date(client?.clientProfile.dateOfBirth), 'MM/dd/yyyy')
-    : null;
+  const formattedDob = parseDate({
+    date: client?.clientProfile.dateOfBirth,
+    inputFormat: 'yyyy-MM-dd',
+    outputFormat: 'MM/dd/yyyy',
+  });
   const clientAge = client?.clientProfile.age;
   const displayDob =
     formattedDob && clientAge ? `${formattedDob} (${clientAge})` : null;

--- a/libs/expo/betterangels/src/lib/ui-components/ClientCard.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientCard.tsx
@@ -11,8 +11,8 @@ import {
   TextBold,
   TextButton,
   TextRegular,
+  parseDate,
 } from '@monorepo/expo/shared/ui-components';
-import { format } from 'date-fns';
 import { useRouter } from 'expo-router';
 import { DimensionValue, Pressable, StyleSheet, View } from 'react-native';
 import { HmisProfileType, Maybe } from '../apollo';
@@ -111,8 +111,12 @@ export default function ClientCard(props: IClientCardProps) {
             <UserOutlineIcon mr="xxs" size="sm" color={Colors.NEUTRAL_DARK} />
             {!!client.dateOfBirth && (
               <TextRegular size="xs">
-                {format(new Date(client.dateOfBirth), 'MM/dd/yyyy')} (
-                {client.age})
+                {parseDate({
+                  date: client.dateOfBirth,
+                  inputFormat: 'yyyy-MM-dd',
+                  outputFormat: 'MM/dd/yyyy',
+                })}{' '}
+                ({client.age})
               </TextRegular>
             )}
             {!!client.dateOfBirth && !!client.heightInInches && (

--- a/libs/expo/shared/ui-components/src/lib/Date/DateLocal.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Date/DateLocal.tsx
@@ -1,0 +1,23 @@
+import { Text, TextStyle } from 'react-native';
+import { formatDateLocal } from './formatDateLocal';
+
+type TProps = {
+  date?: string | number | Date | null;
+  format?: string;
+  style?: TextStyle;
+};
+
+export function DateLocal(props: TProps) {
+  const { date, format, style } = props;
+
+  const formattedDate = formatDateLocal({
+    date,
+    format,
+  });
+
+  if (!formattedDate) {
+    return null;
+  }
+
+  return <Text style={style}>{formattedDate}</Text>;
+}

--- a/libs/expo/shared/ui-components/src/lib/Date/formatDateLocal.ts
+++ b/libs/expo/shared/ui-components/src/lib/Date/formatDateLocal.ts
@@ -1,0 +1,24 @@
+import { format as fnsFormat } from 'date-fns';
+
+const DEFAULT_FORMAT = 'MM/dd/yyyy';
+
+interface TFormattedLength {
+  date?: string | number | Date | null;
+  format?: string;
+}
+
+export function formatDateLocal(props: TFormattedLength) {
+  const { date, format = DEFAULT_FORMAT } = props;
+
+  if (!date) {
+    return '';
+  }
+
+  try {
+    return fnsFormat(date, format);
+  } catch (e) {
+    console.error(`formatDateLocal: failed to format date: ${date}: ${e}`);
+
+    return '';
+  }
+}

--- a/libs/expo/shared/ui-components/src/lib/Date/index.ts
+++ b/libs/expo/shared/ui-components/src/lib/Date/index.ts
@@ -1,0 +1,3 @@
+export { DateLocal } from './DateLocal';
+export { formatDateLocal } from './formatDateLocal';
+export { parseDate } from './parseDate';

--- a/libs/expo/shared/ui-components/src/lib/Date/parseDate.ts
+++ b/libs/expo/shared/ui-components/src/lib/Date/parseDate.ts
@@ -1,0 +1,29 @@
+import { format, parse } from 'date-fns';
+
+const DEFAULT_OUTPUT_FORMAT = 'MM/dd/yyyy';
+
+interface TFormattedLength {
+  date: string;
+  inputFormat: string;
+  outputFormat?: string;
+}
+
+export function parseDate(props: TFormattedLength): string {
+  const { date, inputFormat, outputFormat = DEFAULT_OUTPUT_FORMAT } = props;
+
+  if (!date) {
+    return '';
+  }
+
+  try {
+    const parsed = parse(date, inputFormat, new Date());
+
+    return format(parsed, outputFormat);
+  } catch {
+    console.error(
+      `parseDate: failed to parse date: [${date}] with inputFormat [${inputFormat}]`
+    );
+
+    return '';
+  }
+}

--- a/libs/expo/shared/ui-components/src/lib/index.ts
+++ b/libs/expo/shared/ui-components/src/lib/index.ts
@@ -17,6 +17,7 @@ export { default as CloseButton } from './CloseButton';
 export { BaseContainer } from './Container';
 export { default as Copy } from './Copy';
 export { DataTable, TDataTable, TDataTableItem } from './DataTable';
+export { DateLocal, formatDateLocal, parseDate } from './Date';
 export { default as DatePicker } from './DatePicker';
 export { default as DeleteModal } from './DeleteModal';
 export { default as EventCard } from './EventCard';


### PR DESCRIPTION
**Date of Birth is a day off - timezone issue**
https://betterangels.atlassian.net/browse/DEV-1571

* update DOB in
  * HouseHold members view
  * PersonalInfo view
  * ClientCard


* adds component and helpers:
  * DateLocal (adjust for local TZ)
  * formatDateLocal (adjust for local TZ)
  * parseDate (parses date w/o TZ adjustment)

## Summary by Sourcery

Fixes a timezone issue that was causing the date of birth to be displayed incorrectly by introducing a new `parseDate` function to parse dates without timezone adjustments. It also introduces `DateLocal` and `formatDateLocal` to adjust for local timezones.

New Features:
- Introduces `parseDate` to parse dates without timezone adjustments.
- Introduces `DateLocal` and `formatDateLocal` to adjust for local timezones.

Bug Fixes:
- Fixes a timezone issue where the date of birth was off by one day.