### PR TITLE
DEV-770 | Create atlantis app in the monorepo

### DIFF
--- a/apps/atlantis/.env
+++ b/apps/atlantis/.env
@@ -1,0 +1,7 @@
+# Specifies the versions of the tools to be installed
+ATLANTIS=0.29.0
+TERRAFORM=1.8.3
+TERRAGRUNT=0.67.9
+TERRAGRUNT_ATLANTIS_CONFIG=1.18.0
+ATLANTIS_USER=atlantis
+APP_NAME=atlantis-terragrunt

--- a/apps/atlantis/Dockerfile
+++ b/apps/atlantis/Dockerfile
@@ -1,0 +1,45 @@
+ARG ATLANTIS
+ARG TERRAFORM
+ARG TERRAGRUNT
+ARG TERRAGRUNT_ATLANTIS_CONFIG
+ARG ATLANTIS_USER
+
+FROM ghcr.io/runatlantis/atlantis:$ATLANTIS
+
+USER root
+
+RUN apk add --no-cache \
+    bash \
+    git \
+    openssh \
+    curl \
+    jq \
+    yq \
+    aws-cli \
+    python3 \
+    py3-pip \
+    unzip
+
+# Install Terraform
+RUN set -ex \
+    && mkdir -p "/usr/local/bin/terraform/versions/${TERRAFORM}" \
+    && cd "/usr/local/bin/terraform/versions/${TERRAFORM}"
+RUN set -ex \
+    && curl -sSL -o /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM}/terraform_${TERRAFORM}_linux_amd64.zip" \
+    && unzip /tmp/terraform.zip -d "/usr/local/bin/terraform/versions/${TERRAFORM}" \
+    && rm -f /tmp/terraform.zip \
+    && ln -s "/usr/local/bin/terraform/versions/${TERRAFORM}/terraform" /usr/local/bin/terraform \
+    && terraform --version
+
+# Install Terragrunt
+RUN curl -LO https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT}/terragrunt_linux_amd64 && \
+    chmod +x terragrunt_linux_amd64 && \
+    mv terragrunt_linux_amd64 /usr/local/bin/terragrunt \
+    && terragrunt --version
+
+# Install Terragrunt Atlantis Config
+RUN cd /usr/local/bin \
+    && curl -sSL -o https://github.com/transcend-io/terragrunt-atlantis-config/releases/download/v${TERRAGRUNT_ATLANTIS_CONFIG}/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64 -o /usr/local/bin/terragrunt-atlantis-config \
+    && chmod +x terragrunt-atlantis-config
+
+USER §ATLANTIS_USER

--- a/apps/atlantis/project.json
+++ b/apps/atlantis/project.json
@@ -1,0 +1,36 @@
+{
+  "name": "atlantis",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/atlantis",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx-tools/nx-container:build",
+      "options": {
+        "platforms": ["linux/amd64"],
+        "context": "apps/atlantis",
+        "file": "apps/atlantis/Dockerfile",
+        "build-args": [
+          "ATLANTIS",
+          "TERRAFORM",
+          "TERRAGRUNT",
+          "TERRAGRUNT_ATLANTIS_CONFIG",
+          "ATLANTIS_USER"
+        ],
+        "push": true,
+        "cache-from": [
+          "type=registry,ref=${ECR_REGISTRY}/${APP_NAME}:buildcache-${BRANCH_NAME}",
+          "type=registry,ref=${ECR_REGISTRY}/${APP_NAME}:buildcache-main"
+        ],
+        "cache-to": [
+          "type=registry,ref=${ECR_REGISTRY}/${APP_NAME}:buildcache-${BRANCH_NAME},image-manifest=true,mode=max"
+        ],
+        "metadata": {
+          "images": ["${ECR_REGISTRY}/${APP_NAME}"],
+          "tags": ["${DOCKER_TAG}"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary by Sourcery

This pull request creates an Atlantis application within the monorepo. It includes a Dockerfile for building the Atlantis image with Terraform and Terragrunt, and a project.json file for defining the build process.

Build:
- Adds a Dockerfile to build the Atlantis image, including Terraform and Terragrunt.
- Adds a project.json file to define the build process for the Atlantis application.