### PR TITLE
Bump Outreach to 1.0.39

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.38',
+    version: '1.0.39',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.49',
+      buildNumber: '1.0.50',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -73,7 +73,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 48,
+      versionCode: 49,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',


### PR DESCRIPTION
## Summary by Sourcery

Bump application version from 1.0.38 to 1.0.39 and increment build numbers for both iOS and Android platforms.

Build:
- Bump application version from 1.0.38 to 1.0.39.
- Increment iOS build number from 1.0.49 to 1.0.50.
- Increment Android versionCode from 48 to 49.