### PR TITLE
add HmisProfiles and HouseholdMember cards (DEV-1199)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/EmptyState.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/EmptyState.tsx
@@ -1,0 +1,21 @@
+import { ViewStyle } from 'react-native';
+import {
+  ClientProfileCard,
+  TClientProfileCardItem,
+} from '../../../../../ui-components';
+
+type TProps = {
+  style?: ViewStyle;
+};
+
+export function EmptyState(props: TProps) {
+  const { style } = props;
+
+  const emptyField: TClientProfileCardItem[] = [
+    {
+      rows: [[]],
+    },
+  ];
+
+  return <ClientProfileCard style={style} title="HMIS ID" items={emptyField} />;
+}

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/HmisProfileCard.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/HmisProfileCard.tsx
@@ -1,0 +1,38 @@
+import { View, ViewStyle } from 'react-native';
+import { enumDisplayHmisAgency } from '../../../../../static';
+import {
+  ClientProfileCard,
+  TClientProfileCardItem,
+} from '../../../../../ui-components';
+import { TClientProfileHmisProfile } from '../../types';
+
+type TProps = {
+  hmisProfile?: TClientProfileHmisProfile;
+  style?: ViewStyle;
+};
+
+export function HmisProfileCard(props: TProps) {
+  const { hmisProfile, style } = props;
+
+  if (!hmisProfile) {
+    return null;
+  }
+
+  const { hmisId, agency } = hmisProfile;
+
+  const content: TClientProfileCardItem[] = [
+    {
+      header: ['HMIS ID'],
+      rows: [[hmisId]],
+    },
+  ];
+
+  return (
+    <View style={style}>
+      <ClientProfileCard
+        title={enumDisplayHmisAgency[agency]}
+        items={content}
+      />
+    </View>
+  );
+}

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/HmisProfilesCard.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/HmisProfilesCard.tsx
@@ -1,0 +1,30 @@
+import { ClientProfileCardContainer } from '../../../../../ui-components';
+import { TClientProfile } from '../../types';
+import { EmptyState } from './EmptyState';
+import { HmisProfileCard } from './HmisProfileCard';
+
+type TProps = {
+  clientProfile?: TClientProfile;
+};
+
+export function HmisProfilesCard(props: TProps) {
+  const { clientProfile } = props;
+
+  const { hmisProfiles } = clientProfile || {};
+
+  if (!hmisProfiles?.length) {
+    return (
+      <ClientProfileCardContainer>
+        <EmptyState />
+      </ClientProfileCardContainer>
+    );
+  }
+
+  return (
+    <ClientProfileCardContainer>
+      {hmisProfiles.map((hmisProfile, idx) => {
+        return <HmisProfileCard key={idx} hmisProfile={hmisProfile} />;
+      })}
+    </ClientProfileCardContainer>
+  );
+}

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/index.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HmisProfilesCard/index.ts
@@ -1,0 +1,1 @@
+export { HmisProfilesCard } from './HmisProfilesCard';

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/EmptyState.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/EmptyState.tsx
@@ -1,0 +1,23 @@
+import { ViewStyle } from 'react-native';
+import {
+  ClientProfileCard,
+  TClientProfileCardItem,
+} from '../../../../../ui-components';
+
+type TProps = {
+  style?: ViewStyle;
+};
+
+export function EmptyState(props: TProps) {
+  const { style } = props;
+
+  const content: TClientProfileCardItem[] = [
+    {
+      rows: [[]],
+    },
+  ];
+
+  return (
+    <ClientProfileCard style={style} title="Household Member" items={content} />
+  );
+}

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/HouseholdMemberCard.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/HouseholdMemberCard.tsx
@@ -1,0 +1,55 @@
+import { parseDate } from '@monorepo/expo/shared/ui-components';
+import { View, ViewStyle } from 'react-native';
+import { clientHouseholdMemberEnumDisplay } from '../../../../../static';
+import {
+  ClientProfileCard,
+  TClientProfileCardItem,
+} from '../../../../../ui-components';
+import { TClientProfileHouseholdMemeber } from '../../types';
+
+type TProps = {
+  member?: TClientProfileHouseholdMemeber;
+  style?: ViewStyle;
+};
+
+export function HouseholdMemberCard(props: TProps) {
+  const { member, style } = props;
+
+  if (!member) {
+    return null;
+  }
+
+  const { name, displayGender, dateOfBirth, relationshipToClient } = member;
+
+  const formattedDob = parseDate({
+    date: dateOfBirth,
+    inputFormat: 'yyyy-MM-dd',
+  });
+
+  const content: TClientProfileCardItem[] = [
+    {
+      header: ['Name'],
+      rows: [[name]],
+    },
+    {
+      header: ['Gender'],
+      rows: [[displayGender]],
+    },
+    {
+      header: ['Date of Birth'],
+      rows: [[formattedDob]],
+    },
+  ];
+
+  return (
+    <View style={style}>
+      <ClientProfileCard
+        title={
+          relationshipToClient &&
+          clientHouseholdMemberEnumDisplay[relationshipToClient]
+        }
+        items={content}
+      />
+    </View>
+  );
+}

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/HouseholdMembersCard.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/HouseholdMembersCard.tsx
@@ -1,0 +1,30 @@
+import { ClientProfileCardContainer } from '../../../../../ui-components';
+import { TClientProfile } from '../../types';
+import { EmptyState } from './EmptyState';
+import { HouseholdMemberCard } from './HouseholdMemberCard';
+
+type TProps = {
+  clientProfile?: TClientProfile;
+};
+
+export function HouseholdMembersCard(props: TProps) {
+  const { clientProfile } = props;
+
+  const { householdMembers } = clientProfile || {};
+
+  if (!householdMembers?.length) {
+    return (
+      <ClientProfileCardContainer>
+        <EmptyState />
+      </ClientProfileCardContainer>
+    );
+  }
+
+  return (
+    <ClientProfileCardContainer>
+      {householdMembers.map((member, idx) => {
+        return <HouseholdMemberCard key={idx} member={member} />;
+      })}
+    </ClientProfileCardContainer>
+  );
+}

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/index.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/HouseholdMembersCard/index.ts
@@ -1,0 +1,1 @@
+export { HouseholdMembersCard } from './HouseholdMembersCard';

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/index.tsx
@@ -7,6 +7,8 @@ import { CardAccordion } from './ClientProfileCards/CardAccordion';
 import { ContactInfoCard } from './ClientProfileCards/ContactInfoCard';
 import { DemographicInfoCard } from './ClientProfileCards/DemographicInfoCard';
 import { FullNameCard } from './ClientProfileCards/FullNameCard';
+import { HmisProfilesCard } from './ClientProfileCards/HmisProfilesCard';
+import { HouseholdMembersCard } from './ClientProfileCards/HouseholdMembersCard';
 import { ImportantNotesCard } from './ClientProfileCards/ImportantNotesCard';
 import { PersonalInfoCard } from './ClientProfileCards/PersonalInfoCard';
 import { RelevantContactsCard } from './ClientProfileCards/RelevantContactsCard';
@@ -83,6 +85,22 @@ export default function ClientProfileView(props: ProfileProps) {
           setExpandedTitle={setExpandedTitle}
         >
           <RelevantContactsCard clientProfile={clientProfile} />
+        </CardAccordion>
+
+        <CardAccordion
+          section={ClientProfileCardEnum.Household}
+          expandedTitle={expandedTitle}
+          setExpandedTitle={setExpandedTitle}
+        >
+          <HouseholdMembersCard clientProfile={clientProfile} />
+        </CardAccordion>
+
+        <CardAccordion
+          section={ClientProfileCardEnum.HmisIds}
+          expandedTitle={expandedTitle}
+          setExpandedTitle={setExpandedTitle}
+        >
+          <HmisProfilesCard clientProfile={clientProfile} />
         </CardAccordion>
       </View>
     </MainScrollContainer>


### PR DESCRIPTION
CPR: HmisProfiles and HouseholdMember cards
https://betterangels.atlassian.net/browse/DEV-1199

Note: PR opened against `DEV-1199/relevant-contacts` branch - PR #1105 

## Summary by Sourcery

Adds two new cards to the ClientProfileView: HmisProfilesCard and HouseholdMembersCard. These cards display HMIS profiles and household members associated with a client profile.

New Features:
- Adds HmisProfilesCard to display HMIS profiles associated with a client profile.
- Adds HouseholdMembersCard to display household members associated with a client profile.