### PR TITLE
Added Wilmington option for City

### DIFF
--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -181,6 +181,7 @@ enum CityChoices {
   WESTLAKE_VILLAGE
   WEST_LOS_ANGELES
   WHITTIER
+  WILMINGTON
 }
 
 type CityType {

--- a/apps/betterangels-backend/shelters/enums.py
+++ b/apps/betterangels-backend/shelters/enums.py
@@ -239,6 +239,7 @@ class CityChoices(models.TextChoices):
     WESTLAKE_VILLAGE = "westlake_village", _("Westlake Village")
     WEST_LOS_ANGELES = "west_los_angeles", _("West Los Angeles")
     WHITTIER = "whittier", _("Whittier")
+    WILMINGTON = "wilmington", _("Wilmington")
 
 
 @strawberry.enum


### PR DESCRIPTION
Added Wilmington option to the CityChoices, as per [SDB-38](https://betterangels.atlassian.net/browse/SDB-38).

## Summary by Sourcery

New Features:
- Expanded the list of available cities by adding Wilmington to the CityChoices enum in both GraphQL schema and Python enums

[SDB-38]: https://betterangels.atlassian.net/browse/SDB-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ