### PR TITLE
Fix Shelter Apollo Codegen (DEV-1111)

### DIFF
--- a/libs/expo/betterangels/codegen.ts
+++ b/libs/expo/betterangels/codegen.ts
@@ -6,19 +6,9 @@ const config: CodegenConfig = {
   documents: [
     'src/**/*.{graphql,ts,tsx}',
     '!src/**/__generated__/**/*.{graphql,ts,tsx}',
-    '../../react/shelter/src/**/*.{graphql,ts,tsx}',
-    '!../../react/shelter/src/**/__generated__/**/*.{graphql,ts,tsx}',
   ],
   generates: {
     'src/lib/apollo/graphql/__generated__/types.ts': {
-      plugins: ['typescript'],
-      config: {
-        scalars: {
-          NonBlankString: 'string',
-        },
-      },
-    },
-    '../../react/shelter/src/lib/apollo/graphql/__generated__/types.ts': {
       plugins: ['typescript'],
       config: {
         scalars: {

--- a/libs/expo/betterangels/project.json
+++ b/libs/expo/betterangels/project.json
@@ -4,6 +4,12 @@
   "sourceRoot": "libs/expo/betterangels/src",
   "projectType": "library",
   "tags": [],
+  "namedInputs": {
+    "default": [
+      "{projectRoot}/**/*",
+      "{workspaceRoot}/apps/betterangels-backend/schema.graphql"
+    ]
+  },
   "targets": {
     "generate-graphql-types": {
       "executor": "nx:run-commands",

--- a/libs/react/shelter/codegen.ts
+++ b/libs/react/shelter/codegen.ts
@@ -1,0 +1,30 @@
+import type { CodegenConfig } from '@graphql-codegen/cli';
+
+const config: CodegenConfig = {
+  overwrite: true,
+  schema: '../../../apps/betterangels-backend/schema.graphql',
+  documents: [
+    'src/**/*.{graphql,ts,tsx}',
+    '!src/**/__generated__/**/*.{graphql,ts,tsx}',
+  ],
+  generates: {
+    'src/lib/apollo/graphql/__generated__/types.ts': {
+      plugins: ['typescript'],
+      config: {
+        scalars: {
+          NonBlankString: 'string',
+        },
+      },
+    },
+    'src/': {
+      preset: 'near-operation-file',
+      plugins: ['typescript-operations', 'typescript-react-apollo'],
+      presetConfig: {
+        baseTypesPath: 'lib/apollo/graphql/__generated__/types.ts',
+        folder: '__generated__',
+      },
+    },
+  },
+};
+
+export default config;

--- a/libs/react/shelter/project.json
+++ b/libs/react/shelter/project.json
@@ -20,21 +20,6 @@
       "outputs": [
         "{workspaceRoot}/libs/react/shelter/src/lib/**/__generated__/"
       ]
-    },
-    "lint": {
-      "executor": "@nx/eslint:lint",
-      "outputs": ["{options.outputFile}"]
-    },
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "libs/react/shelter",
-        "commands": [
-          {
-            "command": "tsc --noEmit -p tsconfig.lib.json"
-          }
-        ]
-      }
     }
   }
 }

--- a/libs/react/shelter/project.json
+++ b/libs/react/shelter/project.json
@@ -4,5 +4,37 @@
   "sourceRoot": "libs/react/shelter/src",
   "projectType": "library",
   "tags": [],
-  "targets": {}
+  "namedInputs": {
+    "default": [
+      "{projectRoot}/**/*",
+      "{workspaceRoot}/apps/betterangels-backend/schema.graphql"
+    ]
+  },
+  "targets": {
+    "generate-graphql-types": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "libs/react/shelter",
+        "command": "graphql-codegen --config codegen.ts"
+      },
+      "outputs": [
+        "{workspaceRoot}/libs/react/shelter/src/lib/**/__generated__/"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "libs/react/shelter",
+        "commands": [
+          {
+            "command": "tsc --noEmit -p tsconfig.lib.json"
+          }
+        ]
+      }
+    }
+  }
 }

--- a/libs/react/shelter/src/lib/pages/shelter/__generated__/shelter.generated.ts
+++ b/libs/react/shelter/src/lib/pages/shelter/__generated__/shelter.generated.ts
@@ -1,4 +1,4 @@
-import * as Types from '../../../../../../../expo/betterangels/src/lib/apollo/graphql/__generated__/types';
+import * as Types from '../../../apollo/graphql/__generated__/types';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';

--- a/libs/react/shelter/src/lib/pages/shelters/__generated__/shelters.generated.ts
+++ b/libs/react/shelter/src/lib/pages/shelters/__generated__/shelters.generated.ts
@@ -1,4 +1,4 @@
-import * as Types from '../../../../../../../expo/betterangels/src/lib/apollo/graphql/__generated__/types';
+import * as Types from '../../../apollo/graphql/__generated__/types';
 
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';


### PR DESCRIPTION
DEV-1111

might also fix DEV-694

Do not cross projects to generate apollo code.



## Summary by Sourcery

Refactor GraphQL code generation configuration for the Shelter library

Enhancements:
- Consolidate GraphQL code generation by creating a dedicated codegen configuration for the Shelter library

Build:
- Add generate-graphql-types target to project.json for the Shelter library
- Add named inputs to project configurations to include GraphQL schema

Chores:
- Remove GraphQL document references from Expo Betterangels codegen configuration