### PR TITLE
don't set associated_with on doc mutation (DEV-1681)

### DIFF
--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -671,7 +671,6 @@ class Mutation:
                 content_type=content_type,
                 object_id=client_profile.id,
                 uploaded_by=user,
-                associated_with=client_profile.user,
             )
 
             permissions = [

--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -648,7 +648,7 @@ class ClientDocumentMutationTestCase(ClientProfileGraphQLBaseTestCase):
         file_content = b"Test client document content"
         file_name = "test_client_document.txt"
 
-        expected_query_count = 17
+        expected_query_count = 16
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._create_client_document_fixture(
                 self.client_profile_1["id"],


### PR DESCRIPTION
DEV-1681

## Summary by Sourcery

Remove unnecessary association of document with user during client document creation

Bug Fixes:
- Prevent unnecessary setting of 'associated_with' field when creating a client document

Tests:
- Adjusted test case to reflect reduced query count after removing unnecessary user association