### PR TITLE
Push monorepo image after build and test (DEV-1692)

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -85,96 +85,96 @@ jobs:
           sudo setfacl --modify user:1000:rw /var/run/docker.sock
           sudo setfacl -Rm u:1000:rwX,d:u:1000:rwX $HOME/.docker
 
-      # - name: 🔄 Spin up monorepo environment
-      #   run: |
-      #     docker compose up -d
+      - name: 🔄 Spin up monorepo environment
+        run: |
+          docker compose up -d
 
-      # - name: 🧹 Lint
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     yarn nx affected -t lint
-      #     EOF
+      - name: 🧹 Lint
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          yarn nx affected -t lint
+          EOF
 
-      # - name: 🕵️ Check for missing Django migrations
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     yarn nx affected -t check-migrations
-      #     STATUS=$?
-      #     if [ $STATUS -ne 0 ]; then
-      #       echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
-      #       exit 1
-      #     else
-      #       echo "Success: No missing Django migrations!"
-      #     fi
-      #     EOF
+      - name: 🕵️ Check for missing Django migrations
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          yarn nx affected -t check-migrations
+          STATUS=$?
+          if [ $STATUS -ne 0 ]; then
+            echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
+            exit 1
+          else
+            echo "Success: No missing Django migrations!"
+          fi
+          EOF
 
-      # - name: 📝 Make sure GraphQL Schema is up to date
-      #   # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     yarn nx run-many -t validate-graphql-schema
-      #     STATUS=$?
-      #     if [ $STATUS -ne 0 ]; then
-      #       echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx run-many -t generate-graphql-schema' locally and committed the changes."
-      #       exit 1
-      #     else
-      #       echo "Success: The GraphQL schemas match!"
-      #     fi
+      - name: 📝 Make sure GraphQL Schema is up to date
+        # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          yarn nx run-many -t validate-graphql-schema
+          STATUS=$?
+          if [ $STATUS -ne 0 ]; then
+            echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx run-many -t generate-graphql-schema' locally and committed the changes."
+            exit 1
+          else
+            echo "Success: The GraphQL schemas match!"
+          fi
 
-      #     yarn nx run-many -t generate-graphql-types
-      #     TYPE_GEN_STATUS=$?
-      #     git diff --exit-code;
-      #     DIFF_STATUS=$?
-      #     if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
-      #       echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx run-many -t generate-graphql-types' locally and committed the changes."
-      #       exit 1
-      #     else
-      #       echo "Success: The GraphQL types match!"
-      #     fi
-      #     EOF
+          yarn nx run-many -t generate-graphql-types
+          TYPE_GEN_STATUS=$?
+          git diff --exit-code;
+          DIFF_STATUS=$?
+          if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
+            echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx run-many -t generate-graphql-types' locally and committed the changes."
+            exit 1
+          else
+            echo "Success: The GraphQL types match!"
+          fi
+          EOF
 
-      # - name: 🕵🏻‍♂️ GraphQL Inspector
-      #   uses: kamilkisiela/graphql-inspector@master
-      #   # Warning: This now skips schema breaking checks in forked repositories.
-      #   # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
-      #   if: ${{ github.event.pull_request.head.repo.fork == false }}
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     schema: main:apps/betterangels-backend/schema.graphql
-      #     fail-on-breaking: true
-      #     approve-label: graphql-inspector:approved-breaking-change
+      - name: 🕵🏻‍♂️ GraphQL Inspector
+        uses: kamilkisiela/graphql-inspector@master
+        # Warning: This now skips schema breaking checks in forked repositories.
+        # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          schema: main:apps/betterangels-backend/schema.graphql
+          fail-on-breaking: true
+          approve-label: graphql-inspector:approved-breaking-change
 
-      # - name: 🔬 Typecheck
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     yarn nx affected -t typecheck
-      #     EOF
+      - name: 🔬 Typecheck
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          yarn nx affected -t typecheck
+          EOF
 
-      # - name: 🧪 Test
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     # Exclude Betterangels Frontend Given its CI is not setup yet
-      #     yarn nx affected -t test
-      #     EOF
-
-      # - name: 🛠️ Build and Push Artifacts
-      #   if: ${{ env.BRANCH_NAME == 'main' }}
-      #   run: |
-      #     docker compose run better-angels bash <<'EOF'
-      #     # Exclude Betterangels Frontend Given its CI is not setup yet
-      #     yarn nx affected -t build --exclude=^betterangels$,^shelter$
-      #     EOF
-      #   env:
-      #     AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
-      #     INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🧪 Test
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          # Exclude Betterangels Frontend Given its CI is not setup yet
+          yarn nx affected -t test
+          EOF
 
       - name: 🐳 Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
-        # if: ${{ env.BRANCH_NAME == 'main' }}
+        if: ${{ env.BRANCH_NAME == 'main' }}
         with:
           role-to-assume: ${{ env.ASSUMED_ROLE }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
+
+      - name: 🛠️ Build and Push Artifacts
+        if: ${{ env.BRANCH_NAME == 'main' }}
+        run: |
+          docker compose run better-angels bash <<'EOF'
+          # Exclude Betterangels Frontend Given its CI is not setup yet
+          yarn nx affected -t build --exclude=^betterangels$,^shelter$
+          EOF
+        env:
+          AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
+          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐳 Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -165,6 +165,10 @@ jobs:
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: 🐳 Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        if: ${{ env.BRANCH_NAME == 'main' }}
+
       - name: 🛠️ Build and Push Artifacts
         if: ${{ env.BRANCH_NAME == 'main' }}
         run: |
@@ -175,10 +179,6 @@ jobs:
         env:
           AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 🐳 Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-        # if: ${{ env.BRANCH_NAME == 'main' }}
 
       - name: 🏗️ Push Monorepo Docker image
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -68,25 +68,12 @@ jobs:
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: 🐳 Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ env.BRANCH_NAME == 'main' }}
-        with:
-          role-to-assume: ${{ env.ASSUMED_ROLE }}
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: 🐳 Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-        if: ${{ env.BRANCH_NAME == 'main' }}
-
-      # Build and Push Monorepo Image for each commit using GitHub Actions cache
+      # Build Monorepo Image for each commit using GitHub Actions cache
       - name: 🏗️ Build Monorepo Docker image
         uses: docker/build-push-action@v6
         with:
           file: Dockerfile
           load: true
-          push: ${{ env.BRANCH_NAME == 'main' }}
           tags: |
             ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
           cache-from: type=gha
@@ -98,88 +85,104 @@ jobs:
           sudo setfacl --modify user:1000:rw /var/run/docker.sock
           sudo setfacl -Rm u:1000:rwX,d:u:1000:rwX $HOME/.docker
 
-      - name: 🔄 Spin up monorepo environment
-        run: |
-          docker compose up -d
+      # - name: 🔄 Spin up monorepo environment
+      #   run: |
+      #     docker compose up -d
 
-      - name: 🧹 Lint
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          yarn nx affected -t lint
-          EOF
+      # - name: 🧹 Lint
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     yarn nx affected -t lint
+      #     EOF
 
-      - name: 🕵️ Check for missing Django migrations
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          yarn nx affected -t check-migrations
-          STATUS=$?
-          if [ $STATUS -ne 0 ]; then
-            echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
-            exit 1
-          else
-            echo "Success: No missing Django migrations!"
-          fi
-          EOF
+      # - name: 🕵️ Check for missing Django migrations
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     yarn nx affected -t check-migrations
+      #     STATUS=$?
+      #     if [ $STATUS -ne 0 ]; then
+      #       echo "Error: Missing Django migrations! Make sure you have run 'python manage.py makemigrations <app_name>' locally and committed the changes."
+      #       exit 1
+      #     else
+      #       echo "Success: No missing Django migrations!"
+      #     fi
+      #     EOF
 
-      - name: 📝 Make sure GraphQL Schema is up to date
-        # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          yarn nx run-many -t validate-graphql-schema
-          STATUS=$?
-          if [ $STATUS -ne 0 ]; then
-            echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx run-many -t generate-graphql-schema' locally and committed the changes."
-            exit 1
-          else
-            echo "Success: The GraphQL schemas match!"
-          fi
+      # - name: 📝 Make sure GraphQL Schema is up to date
+      #   # TODO: Upon graphql mismatch, a github action could commit the changes and push into the branch
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     yarn nx run-many -t validate-graphql-schema
+      #     STATUS=$?
+      #     if [ $STATUS -ne 0 ]; then
+      #       echo "Error: The GraphQL schemas do not match! Make sure you have run 'yarn nx run-many -t generate-graphql-schema' locally and committed the changes."
+      #       exit 1
+      #     else
+      #       echo "Success: The GraphQL schemas match!"
+      #     fi
 
-          yarn nx run-many -t generate-graphql-types
-          TYPE_GEN_STATUS=$?
-          git diff --exit-code;
-          DIFF_STATUS=$?
-          if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
-            echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx run-many -t generate-graphql-types' locally and committed the changes."
-            exit 1
-          else
-            echo "Success: The GraphQL types match!"
-          fi
-          EOF
+      #     yarn nx run-many -t generate-graphql-types
+      #     TYPE_GEN_STATUS=$?
+      #     git diff --exit-code;
+      #     DIFF_STATUS=$?
+      #     if [ $TYPE_GEN_STATUS -ne 0 ] || [ $DIFF_STATUS -ne 0 ]; then
+      #       echo "Error: The GraphQL types do not match or generation failed! Make sure you have run 'yarn nx run-many -t generate-graphql-types' locally and committed the changes."
+      #       exit 1
+      #     else
+      #       echo "Success: The GraphQL types match!"
+      #     fi
+      #     EOF
 
-      - name: 🕵🏻‍♂️ GraphQL Inspector
-        uses: kamilkisiela/graphql-inspector@master
-        # Warning: This now skips schema breaking checks in forked repositories.
-        # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
-        if: ${{ github.event.pull_request.head.repo.fork == false }}
+      # - name: 🕵🏻‍♂️ GraphQL Inspector
+      #   uses: kamilkisiela/graphql-inspector@master
+      #   # Warning: This now skips schema breaking checks in forked repositories.
+      #   # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
+      #   if: ${{ github.event.pull_request.head.repo.fork == false }}
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     schema: main:apps/betterangels-backend/schema.graphql
+      #     fail-on-breaking: true
+      #     approve-label: graphql-inspector:approved-breaking-change
+
+      # - name: 🔬 Typecheck
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     yarn nx affected -t typecheck
+      #     EOF
+
+      # - name: 🧪 Test
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     # Exclude Betterangels Frontend Given its CI is not setup yet
+      #     yarn nx affected -t test
+      #     EOF
+
+      # - name: 🛠️ Build and Push Artifacts
+      #   if: ${{ env.BRANCH_NAME == 'main' }}
+      #   run: |
+      #     docker compose run better-angels bash <<'EOF'
+      #     # Exclude Betterangels Frontend Given its CI is not setup yet
+      #     yarn nx affected -t build --exclude=^betterangels$,^shelter$
+      #     EOF
+      #   env:
+      #     AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
+      #     INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        # if: ${{ env.BRANCH_NAME == 'main' }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          schema: main:apps/betterangels-backend/schema.graphql
-          fail-on-breaking: true
-          approve-label: graphql-inspector:approved-breaking-change
+          role-to-assume: ${{ env.ASSUMED_ROLE }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ env.AWS_REGION }}
 
-      - name: 🔬 Typecheck
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          yarn nx affected -t typecheck
-          EOF
+      - name: 🐳 Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        # if: ${{ env.BRANCH_NAME == 'main' }}
 
-      - name: 🧪 Test
+      - name: 🏗️ Push Monorepo Docker image
         run: |
-          docker compose run better-angels bash <<'EOF'
-          # Exclude Betterangels Frontend Given its CI is not setup yet
-          yarn nx affected -t test
-          EOF
-
-      - name: 🛠️ Build and Push Artifacts
-        if: ${{ env.BRANCH_NAME == 'main' }}
-        run: |
-          docker compose run better-angels bash <<'EOF'
-          # Exclude Betterangels Frontend Given its CI is not setup yet
-          yarn nx affected -t build --exclude=^betterangels$,^shelter$
-          EOF
-        env:
-          AWS_ACCOUNT_ID: ${{ env.AWS_ACCOUNT_ID }}
-          INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          docker push ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
 
       - name: 🚀 Deploy Changes
         if: ${{ env.BRANCH_NAME == 'main' }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -181,6 +181,7 @@ jobs:
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🏗️ Push Monorepo Docker image
+        if: ${{ env.BRANCH_NAME == 'main' }}
         run: |
           docker push ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
 


### PR DESCRIPTION
## Summary by Sourcery

Modify GitHub Actions workflow to separate Docker image build and push steps

Enhancements:
- Split Docker image build and push operations to improve workflow flexibility

CI:
- Refactor Docker image build workflow to build image first, then push separately on main branch