### PR TITLE
fix fe create note mutations (DEV-1690)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Interactions/InteractionsSorting.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Interactions/InteractionsSorting.tsx
@@ -46,7 +46,7 @@ export default function InteractionsSorting(props: IInteractionsSortingProps) {
         variables: {
           data: {
             purpose: `Session with ${firstName || 'Client'}`,
-            client: id,
+            clientProfile: id,
           },
         },
       });

--- a/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
@@ -67,7 +67,7 @@ export default function Clients({ Logo }: { Logo: ElementType }) {
         variables: {
           data: {
             purpose: `Session with ${firstName || 'Client'}`,
-            client: id,
+            clientProfile: id,
           },
         },
       });


### PR DESCRIPTION
DEV-1690

missed a spot in the fe cutover

## Summary by Sourcery

Bug Fixes:
- Fix client note creation by changing the input field from 'client' to 'clientProfile' in mutations