### PR TITLE
add interaction by pressing client card (DEV-1093)

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/ClientCard.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientCard.tsx
@@ -9,7 +9,6 @@ import {
   Avatar,
   IconButton,
   TextBold,
-  TextButton,
   TextRegular,
   formatDateStatic,
 } from '@monorepo/expo/shared/ui-components';
@@ -144,14 +143,7 @@ export default function ClientCard(props: IClientCardProps) {
         )}
       </View>
       <View style={{ justifyContent: 'center', position: 'relative' }}>
-        {select === 'true' ? (
-          <TextButton
-            fontSize="sm"
-            title={'Select'}
-            onPress={onPress}
-            accessibilityHint={`Add a interaction for client ${client.firstName} ${client.lastName}`}
-          />
-        ) : (
+        {select === 'false' && (
           <IconButton
             onPress={onPress}
             variant="transparent"

--- a/libs/expo/betterangels/src/lib/ui-components/ClientCard.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientCard.tsx
@@ -20,9 +20,7 @@ import { ClientProfilesQuery } from '../screens/Clients/__generated__/Clients.ge
 
 type TSpacing = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 interface IClientCardProps {
-  client:
-    | ClientProfilesQuery['clientProfiles']['results'][number]
-    | undefined;
+  client: ClientProfilesQuery['clientProfiles']['results'][number] | undefined;
   progress?: DimensionValue;
   mb?: TSpacing;
   mt?: TSpacing;
@@ -74,13 +72,16 @@ export default function ClientCard(props: IClientCardProps) {
   return (
     <Pressable
       accessibilityRole="button"
-      onPress={() =>
-        router.navigate({
-          pathname: `/client/${client.id}`,
-          params: {
-            arrivedFrom,
-          },
-        })
+      onPress={
+        select === 'true'
+          ? onPress
+          : () =>
+              router.navigate({
+                pathname: `/client/${client.id}`,
+                params: {
+                  arrivedFrom,
+                },
+              })
       }
       style={({ pressed }) => [
         styles.container,


### PR DESCRIPTION
DEV-1093

## Summary by Sourcery

Add interaction capability by pressing the client card and refactor the onPress logic to conditionally navigate or trigger an event based on the 'select' prop.

New Features:
- Add interaction capability by pressing the client card.

Enhancements:
- Refactor the onPress logic to conditionally navigate or trigger an onPress event based on the 'select' prop.