### PR TITLE
fix interaction filters & add tests (DEV-1693)

### DIFF
--- a/apps/betterangels-backend/notes/tests/test_queries.py
+++ b/apps/betterangels-backend/notes/tests/test_queries.py
@@ -369,6 +369,7 @@ class NoteQueryTestCase(NoteGraphQLBaseTestCase):
     @parametrize(
         ("teams, expected_results_count, returned_note_labels, expected_query_count"),
         [
+            ([], 3, ["note", "note_2", "note_3"], 4),
             ([SelahTeamEnum.WDI_ON_SITE.name, SelahTeamEnum.SLCC_ON_SITE.name], 2, ["note_2", "note_3"], 4),
             ([SelahTeamEnum.SLCC_ON_SITE.name], 1, ["note_3"], 4),
             ([SelahTeamEnum.WDI_ON_SITE.name, "invalid team"], 0, [], 1),

--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -158,7 +158,7 @@ class NoteFilter:
     def authors(
         self, queryset: QuerySet, info: Info, value: Optional[List[ID]], prefix: str
     ) -> Tuple[QuerySet[models.Note], Q]:
-        if value in [None, []]:
+        if not value:
             return queryset, Q()
 
         return queryset.filter(created_by__in=value), Q()
@@ -191,7 +191,7 @@ class NoteFilter:
     def teams(
         self, queryset: QuerySet, value: Optional[List[SelahTeamEnum]], prefix: str
     ) -> Tuple[QuerySet[models.Note], Q]:
-        if value in [None, []]:
+        if not value:
             return queryset, Q()
 
         return queryset.filter(team__in=value), Q()

--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -191,7 +191,7 @@ class NoteFilter:
     def teams(
         self, queryset: QuerySet, value: Optional[List[SelahTeamEnum]], prefix: str
     ) -> Tuple[QuerySet[models.Note], Q]:
-        if value is None:
+        if value is None or value == []:
             return queryset, Q()
 
         return queryset.filter(team__in=value), Q()

--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -158,7 +158,7 @@ class NoteFilter:
     def authors(
         self, queryset: QuerySet, info: Info, value: Optional[List[ID]], prefix: str
     ) -> Tuple[QuerySet[models.Note], Q]:
-        if value is None:
+        if value in [None, []]:
             return queryset, Q()
 
         return queryset.filter(created_by__in=value), Q()
@@ -191,7 +191,7 @@ class NoteFilter:
     def teams(
         self, queryset: QuerySet, value: Optional[List[SelahTeamEnum]], prefix: str
     ) -> Tuple[QuerySet[models.Note], Q]:
-        if value is None or value == []:
+        if value in [None, []]:
             return queryset, Q()
 
         return queryset.filter(team__in=value), Q()


### PR DESCRIPTION
DEV-1693

old bug. caught while testing fe for release, [here](https://github.com/BetterAngelsLA/monorepo/pull/1203#discussion_r2033912346)

## Summary by Sourcery

Fix interaction filters for notes query to handle empty filter lists correctly

Bug Fixes:
- Modify filter logic to correctly handle empty lists for authors and teams filters in notes query, ensuring all notes are returned when no specific filter is applied

Tests:
- Add comprehensive test cases for notes query filters, including scenarios with empty author and team filter lists