### PR TITLE
fix clientcard display details (DEV-1689)

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/NoteCard/NoteCardClient.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteCard/NoteCardClient.tsx
@@ -12,7 +12,7 @@ interface INoteCardClientProps {
 
 export default function NoteCardClient(props: INoteCardClientProps) {
   const { clientProfile, createdBy, isOnInteractionsPage, isSubmitted } = props;
-  const displayDetails = isOnInteractionsPage ? createdBy : clientProfile;
+  const displayDetails = isOnInteractionsPage ? clientProfile : createdBy;
 
   return (
     <View

--- a/libs/expo/betterangels/src/lib/ui-components/NoteCard/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteCard/index.tsx
@@ -15,7 +15,7 @@ export default function NoteCard(props: INoteCardProps) {
   const pathname = usePathname();
   const router = useRouter();
 
-  const isInteractionsPage = pathname === '/interactions';
+  const isOnInteractionsPage = pathname === '/interactions';
 
   return (
     <Pressable
@@ -35,7 +35,7 @@ export default function NoteCard(props: INoteCardProps) {
     >
       <NoteCardHeader purpose={note.purpose} interactedAt={note.interactedAt} />
       <NoteCardClient
-        isOnInteractionsPage={isInteractionsPage}
+        isOnInteractionsPage={isOnInteractionsPage}
         createdBy={note.createdBy}
         clientProfile={note.clientProfile}
         isSubmitted={note.isSubmitted}


### PR DESCRIPTION
DEV-1689

#1183 typo swapped whose info gets displayed in the ClientCard

## Summary by Sourcery

Fix the display of client details in the NoteCard component by correcting the logic for showing client or created by information

Bug Fixes:
- Corrected the display logic in NoteCardClient to show the correct profile details based on the page context

Enhancements:
- Improved variable naming for clarity by renaming 'isInteractionsPage' to 'isOnInteractionsPage'