### PR TITLE
add ffAppUpdatePrompt feature flag (DEV-1584)

### DIFF
--- a/libs/expo/betterangels/src/lib/hooks/featureFlag/useFeatureFlagActive.tsx
+++ b/libs/expo/betterangels/src/lib/hooks/featureFlag/useFeatureFlagActive.tsx
@@ -1,6 +1,5 @@
 import { useContext } from 'react';
-import { TFeatureFlagValue } from '../../providers/featureControls/constants';
-import { FeatureControlContext } from '../../providers/featureControls/featureControlContext';
+import { FeatureControlContext, TFeatureFlagValue } from '../../providers';
 
 export default function useFeatureFlagActive(
   flagName: TFeatureFlagValue

--- a/libs/expo/betterangels/src/lib/providers/featureControls/constants.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/constants.ts
@@ -1,7 +1,5 @@
 export const FeatureFlags = {
   PROFILE_REDESIGN_FF: 'ffClientProfileRedesign',
   CLIENT_DEDUPE_FF: 'ffClientDedupe',
+  APP_UPDATE_PROMPT_FF: 'ffAppUpdatePrompt',
 } as const;
-
-export type TFeatureFlagKey = keyof typeof FeatureFlags;
-export type TFeatureFlagValue = (typeof FeatureFlags)[TFeatureFlagKey];

--- a/libs/expo/betterangels/src/lib/providers/featureControls/featureControlContext.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/featureControlContext.ts
@@ -1,6 +1,6 @@
-import { createContext, useContext } from 'react';
+import { createContext } from 'react';
 import { useGetFeatureControlsQuery } from './__generated__/featureControls.generated';
-import { FeatureControlGroups } from './interfaces';
+import { FeatureControlGroups } from './types';
 
 export interface TFeatureControlContext extends FeatureControlGroups {
   clearFeatureFlags: () => void;
@@ -10,13 +10,3 @@ export interface TFeatureControlContext extends FeatureControlGroups {
 export const FeatureControlContext = createContext<
   TFeatureControlContext | undefined
 >(undefined);
-
-export const useFeatureControls = (): TFeatureControlContext => {
-  const context = useContext(FeatureControlContext);
-  if (context === undefined) {
-    throw new Error(
-      'useFeatureControls must be used within a FeatureControlProvider'
-    );
-  }
-  return context;
-};

--- a/libs/expo/betterangels/src/lib/providers/featureControls/featureControlProvider.tsx
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/featureControlProvider.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useGetFeatureControlsQuery } from './__generated__/featureControls.generated';
 import { FeatureControlContext } from './featureControlContext';
-import { FeatureControlDictionary, FeatureControlGroups } from './interfaces';
+import { FeatureControlDictionary, FeatureControlGroups } from './types';
 
 interface FeatureControlProviderProps {
   children: React.ReactNode;

--- a/libs/expo/betterangels/src/lib/providers/featureControls/index.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/index.ts
@@ -1,0 +1,5 @@
+export * from './constants';
+export { FeatureControlContext } from './featureControlContext';
+export { FeatureControlProvider } from './featureControlProvider';
+export { TFeatureFlagKey, TFeatureFlagValue } from './types';
+export { useFeatureControls } from './useFeatureControls';

--- a/libs/expo/betterangels/src/lib/providers/featureControls/types.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/types.ts
@@ -1,4 +1,8 @@
-// Define a dictionary type for easier access
+import { FeatureFlags } from './constants';
+
+export type TFeatureFlagKey = keyof typeof FeatureFlags;
+export type TFeatureFlagValue = (typeof FeatureFlags)[TFeatureFlagKey];
+
 export interface FeatureControlDictionary {
   [key: string]: { isActive: boolean; lastModified?: string | null };
 }

--- a/libs/expo/betterangels/src/lib/providers/featureControls/useFeatureControls.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/useFeatureControls.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import {
+  FeatureControlContext,
+  TFeatureControlContext,
+} from './featureControlContext';
+
+export const useFeatureControls = (): TFeatureControlContext => {
+  const context = useContext(FeatureControlContext);
+
+  if (context === undefined) {
+    throw new Error(
+      'useFeatureControls must be used within a FeatureControlProvider'
+    );
+  }
+
+  return context;
+};

--- a/libs/expo/betterangels/src/lib/providers/index.ts
+++ b/libs/expo/betterangels/src/lib/providers/index.ts
@@ -1,5 +1,4 @@
-export { useFeatureControls } from './featureControls/featureControlContext';
-export { FeatureControlProvider } from './featureControls/featureControlProvider';
+export * from './featureControls';
 export { default as KeyboardToolbarProvider } from './keyboardToolbar/keyboardToolbarProvider';
 export { default as SnackbarProvider } from './snackbar/SnackbarProvider';
 export { default as UserProvider } from './user/UserProvider';

--- a/libs/expo/betterangels/src/lib/screens/Client/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/index.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react';
 import { Pressable, View } from 'react-native';
 import { useFeatureFlagActive } from '../../hooks';
-import { FeatureFlags } from '../../providers/featureControls/constants';
+import { FeatureFlags } from '../../providers';
 import { ClientProfileSectionEnum } from '../../screenRouting';
 import { MainContainer } from '../../ui-components';
 import ClientHeader from './ClientHeader';

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/ClientProfileForm/PersonalInfoForm/PersonalInfoForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/ClientProfileForm/PersonalInfoForm/PersonalInfoForm.tsx
@@ -19,7 +19,7 @@ import {
   useCaliforniaIdUniqueCheck,
   useFeatureFlagActive,
 } from '../../../../hooks';
-import { FeatureFlags } from '../../../../providers/featureControls/constants';
+import { FeatureFlags } from '../../../../providers';
 import {
   enumDisplayLanguage,
   enumDisplayLivingSituation,

--- a/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
@@ -7,10 +7,9 @@ import {
   TextBold,
 } from '@monorepo/expo/shared/ui-components';
 import { router } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useDeleteCurrentUserMutation } from '../../apollo';
 import { useSignOut, useSnackbar, useUser } from '../../hooks';
-import { useFeatureControls } from '../../providers/featureControls/featureControlContext';
 import InfoCard from './InfoCard';
 
 export default function UserProfile() {
@@ -18,7 +17,6 @@ export default function UserProfile() {
   const { showSnackbar } = useSnackbar();
 
   if (!user) throw new Error('Something went wrong');
-  const featureControls = useFeatureControls();
   const [deleteCurrentUser] = useDeleteCurrentUserMutation();
   const userInfo = [
     { title: 'Email', value: user.email },
@@ -46,9 +44,6 @@ export default function UserProfile() {
       });
     }
   }
-
-  const isSamplFeatureFlagActive =
-    featureControls.flags['SampleFeatureFlag']?.isActive;
 
   return (
     <View style={styles.container}>
@@ -90,11 +85,6 @@ export default function UserProfile() {
           }
         />
       </View>
-      {isSamplFeatureFlagActive && (
-        <Text style={styles.featureText}>
-          The feature "SampleFeatureFlag" is active
-        </Text>
-      )}
     </View>
   );
 }

--- a/libs/expo/betterangels/src/lib/ui-components/MainPlusModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainPlusModal.tsx
@@ -7,7 +7,7 @@ import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { useFeatureFlagActive } from '../hooks';
-import { FeatureFlags } from '../providers/featureControls/constants';
+import { FeatureFlags } from '../providers';
 import MainModal from './MainModal';
 
 interface IMainPlusModalProps {


### PR DESCRIPTION
### Add ffAppUpdatePrompt and consolidate featureControls exports
part of: `Periodic EAS Update Checks & User Prompt`

https://betterangels.atlassian.net/browse/DEV-1584

Note: adding `ffAppUpdatePrompt` feature flag to allow for testing in PROD

* add `ffAppUpdatePrompt` feature flag
* consolidate `featureControls` exports into an `index.ts` file
* remove `SampleFeatureFlag`

## Summary by Sourcery

Refactor feature controls module by consolidating exports and adding a new feature flag for app update prompts

New Features:
- Add a new feature flag `ffAppUpdatePrompt` for periodic EAS update checks and user prompts

Enhancements:
- Consolidate feature controls exports into a centralized index file
- Reorganize feature flag type definitions and imports

Chores:
- Remove `SampleFeatureFlag` from the codebase
- Move `useFeatureControls` hook to a separate file