### PR TITLE
Shelter db multifile upload with django-s3file

### DIFF
--- a/apps/betterangels-backend/betterangels_backend/settings.py
+++ b/apps/betterangels-backend/betterangels_backend/settings.py
@@ -128,6 +128,7 @@ INSTALLED_APPS = [
     "django_select2",
     "import_export",
     "rangefilter",
+    "s3file",
     "strawberry_django",
     "waffle",
     # Our Apps
@@ -153,6 +154,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "pghistory.middleware.HistoryMiddleware",
+    "s3file.middleware.S3FileMiddleware",
     # Our Middleware
     "common.middleware.TimezoneMiddleware",
 ]
@@ -330,6 +332,7 @@ if env("AWS_S3_MEDIA_STORAGE_ENABLED"):
         },
     }
 
+AWS_STORAGE_BUCKET_NAME = ""
 
 ADMIN_RESUMABLE_CHUNKSIZE = 10 * 1024 * 1024
 ADMIN_RESUMABLE_SHOW_THUMB = True

--- a/apps/betterangels-backend/betterangels_backend/settings.py
+++ b/apps/betterangels-backend/betterangels_backend/settings.py
@@ -331,8 +331,11 @@ if env("AWS_S3_MEDIA_STORAGE_ENABLED"):
             "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
         },
     }
-
-AWS_STORAGE_BUCKET_NAME = ""
+else:
+    # Cannot define STORAGES dict the same way with "BACKEND": "<Django's default FileSystemStorage>"
+    # because FileSystemStorage does not take "bucket_name" as argument but django.s3file still needs bucket name defined
+    # therefore we use the following for dev environment
+    AWS_STORAGE_BUCKET_NAME = ""
 
 ADMIN_RESUMABLE_CHUNKSIZE = 10 * 1024 * 1024
 ADMIN_RESUMABLE_SHOW_THUMB = True

--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -408,12 +408,15 @@ class ShelterForm(forms.ModelForm):
     def save(self, commit: bool = True) -> Any:
         instance = super().save(commit=commit)
 
-        for file in self.cleaned_data["interior_photos_multiple"]:
-            instance.interior_photos.create(file=file)
-        for file in self.cleaned_data["exterior_photos_multiple"]:
-            instance.exterior_photos.create(file=file)
-        for file in self.cleaned_data["videos_multiple"]:
-            instance.videos.create(file=file)
+        file_fields = {
+            "interior_photos_multiple": instance.interior_photos,
+            "exterior_photos_multiple": instance.exterior_photos,
+            "videos_multiple": instance.videos,
+        }
+
+        for field_name, manager in file_fields.items():
+            for file in self.cleaned_data.get(field_name, []):
+                manager.create(file=file)
 
         # Only proceed if instance is saved (commit=True) and files are uploaded
         if commit:

--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -439,17 +439,20 @@ class ContactInfoInline(admin.TabularInline):
 
 class ExteriorPhotoInline(admin.TabularInline):
     model = ExteriorPhoto
-    extra = 1
+    extra = 0
+    verbose_name_plural = "Exterior Photos View"
 
 
 class InterPhotoInline(admin.TabularInline):
     model = InteriorPhoto
-    extra = 1
+    extra = 0
+    verbose_name_plural = "Interior Photos View"
 
 
 class VideoInline(admin.TabularInline):
     model = Video
-    extra = 1
+    extra = 0
+    verbose_name_plural = "Videos View"
 
 
 class ShelterResource(resources.ModelResource):

--- a/apps/betterangels-backend/shelters/widgets.py
+++ b/apps/betterangels-backend/shelters/widgets.py
@@ -169,3 +169,21 @@ class TimeRangeField(models.Field):
     ) -> Optional[forms.Field]:
         field = super().formfield(choices_form_class=choices_form_class, form_class=TimeRangeFormField)
         return field
+
+
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data: Any, initial: Any = None) -> Any:
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = [single_file_clean(data, initial)]
+        return result

--- a/apps/betterangels-backend/templates/admin/shelters/change_form.html
+++ b/apps/betterangels-backend/templates/admin/shelters/change_form.html
@@ -11,6 +11,42 @@
         position: absolute;
     }
     </style>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            console.log("HELLO HELLO HELLO HELLO HELLO HELLO HELLO");
+            Array.from(document.getElementsByClassName("s3file")).forEach(element => {
+                const bars = document.createElement('progress');
+                bars.setAttribute('value', 0);
+                bars.setAttribute('max', 100);
+                bars.setAttribute('id', "bar_for" + element.id);
+                element.parentNode.appendChild(bars);
+                element.addEventListener('progress', function (event) {
+                    // event.detail.progress is a value between 0 and 1
+                    console.log(event.detail.progress);
+                    var percent = Math.round(event.detail.progress * 100);
+                    bars.value = percent;
+                });
+            });
+            const bar = document.createElement('progress');
+            bar.setAttribute('value', 0);
+            bar.setAttribute('max', 100);
+            bar.setAttribute('id', "bar_for_save");
+            const form_prog = document.createElement('label');
+            form_prog.setAttribute('for', '_save');
+            form_prog.appendChild(bar);
+            form_prog.style.display = 'none';
+            document.querySelectorAll(".submit-row")[0].appendChild(form_prog);
+            var form = document.getElementsByTagName('form')[1];
+            console.log(form);
+            form.addEventListener('progress', function (event) {
+                // event.detail.progress is a value between 0 and 1
+                form_prog.style.display = 'block';
+                console.log(event.detail.progress);
+                var percent = Math.round(event.detail.progress * 100);
+                bar.value = percent;
+            });
+        });
+    </script>
     {{ block.super }}
 {% endblock %}
 {% block content_title %}

--- a/apps/betterangels-backend/templates/admin/shelters/change_form.html
+++ b/apps/betterangels-backend/templates/admin/shelters/change_form.html
@@ -13,20 +13,6 @@
     </style>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            console.log("HELLO HELLO HELLO HELLO HELLO HELLO HELLO");
-            Array.from(document.getElementsByClassName("s3file")).forEach(element => {
-                const bars = document.createElement('progress');
-                bars.setAttribute('value', 0);
-                bars.setAttribute('max', 100);
-                bars.setAttribute('id', "bar_for" + element.id);
-                element.parentNode.appendChild(bars);
-                element.addEventListener('progress', function (event) {
-                    // event.detail.progress is a value between 0 and 1
-                    console.log(event.detail.progress);
-                    var percent = Math.round(event.detail.progress * 100);
-                    bars.value = percent;
-                });
-            });
             const bar = document.createElement('progress');
             bar.setAttribute('value', 0);
             bar.setAttribute('max', 100);
@@ -37,11 +23,9 @@
             form_prog.style.display = 'none';
             document.querySelectorAll(".submit-row")[0].appendChild(form_prog);
             var form = document.getElementsByTagName('form')[1];
-            console.log(form);
             form.addEventListener('progress', function (event) {
                 // event.detail.progress is a value between 0 and 1
                 form_prog.style.display = 'block';
-                console.log(event.detail.progress);
                 var percent = Math.round(event.detail.progress * 100);
                 bar.value = percent;
             });

--- a/poetry.lock
+++ b/poetry.lock
@@ -1561,6 +1561,26 @@ prevent-xss = ["bleach"]
 test = ["tox (>=2.3)"]
 
 [[package]]
+name = "django-s3file"
+version = "5.5.7"
+description = "A lightweight file uploader input for Django and Amazon S3."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "django_s3file-5.5.7-py3-none-any.whl", hash = "sha256:7746893df64a28bb7c7df2794d4bd7a4932f2d72c5eef6244c1c42ec82b8e60c"},
+    {file = "django_s3file-5.5.7.tar.gz", hash = "sha256:2165e1f7f260f716a9894286a31013e44f393684a8dfde5f15e317ddac77ee9a"},
+]
+
+[package.dependencies]
+boto3 = "*"
+django = ">=2.0"
+django-storages = ">=1.6"
+
+[package.extras]
+test = ["pytest (>=2.7.3)", "pytest-cov", "pytest-django", "selenium"]
+
+[[package]]
 name = "django-select2"
 version = "8.4.0"
 description = "This is a Django_ integration of Select2_."
@@ -4378,4 +4398,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "3.13.2"
-content-hash = "3e60071553280120ca89e7bce70f65fca01ad49f495c782fad627e2d4c2bafba"
+content-hash = "3f79434856d69317da817eb8edcdeeb4aab8017b5b9800c4f4b5c374c2f96abe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ skip_glob = ["*/migrations/*"]
 
 [tool.poetry.dependencies]
 python = "3.13.2"
+django-s3file = "^5.5.7"
 
 [tool.poetry.dependencies.betterangels-backend]
 path = "apps/betterangels-backend"


### PR DESCRIPTION
Implemented multi file upload fields for each of the media upload fields. Used the django ClearableFIleInput widget and corresponding fields to do so instead of AsyncFileField. Removed progress bars from each of the upload fields after having added them to avoid confusion, as I learned that these progress bars would only start upon form submission when file upload begins. Left one progress bar next to save button once form submission happens. [django-s3file](https://github.com/codingjoe/django-s3file) module was added for direct upload to s3 capability. Selected this module in particular as it integrates with django's ClearableFileInput widget directly, and has options for a dummy upload django route while in development environment.

## Summary by Sourcery

Implement multi-file upload functionality for shelter media using django-s3file and ClearableFileInput

New Features:
- Added support for multiple file uploads for interior photos, exterior photos, and videos in the shelter admin interface

Enhancements:
- Replaced single file upload with multi-file upload capability
- Added a form-level progress bar for file uploads
- Integrated django-s3file for direct S3 uploads

Chores:
- Updated admin form to handle multiple file uploads
- Modified inline admin views to remove extra empty fields