### PR TITLE
add FeatureFlagControlled component and update featureControls exports (DEV-1584)

### DIFF
--- a/libs/expo/betterangels/src/lib/hooks/featureFlag/useFeatureFlagActive.tsx
+++ b/libs/expo/betterangels/src/lib/hooks/featureFlag/useFeatureFlagActive.tsx
@@ -1,6 +1,5 @@
 import { useContext } from 'react';
-import { TFeatureFlagValue } from '../../providers/featureControls/constants';
-import { FeatureControlContext } from '../../providers/featureControls/featureControlContext';
+import { FeatureControlContext, TFeatureFlagValue } from '../../providers';
 
 export default function useFeatureFlagActive(
   flagName: TFeatureFlagValue

--- a/libs/expo/betterangels/src/lib/providers/featureControls/constants.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/constants.ts
@@ -2,6 +2,3 @@ export const FeatureFlags = {
   PROFILE_REDESIGN_FF: 'ffClientProfileRedesign',
   CLIENT_DEDUPE_FF: 'ffClientDedupe',
 } as const;
-
-export type TFeatureFlagKey = keyof typeof FeatureFlags;
-export type TFeatureFlagValue = (typeof FeatureFlags)[TFeatureFlagKey];

--- a/libs/expo/betterangels/src/lib/providers/featureControls/index.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/index.ts
@@ -1,0 +1,7 @@
+export * from './constants';
+export {
+  FeatureControlContext,
+  useFeatureControls,
+} from './featureControlContext';
+export { FeatureControlProvider } from './featureControlProvider';
+export * from './types';

--- a/libs/expo/betterangels/src/lib/providers/featureControls/types.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/types.ts
@@ -1,0 +1,4 @@
+import { FeatureFlags } from './constants';
+
+export type TFeatureFlagKey = keyof typeof FeatureFlags;
+export type TFeatureFlagValue = (typeof FeatureFlags)[TFeatureFlagKey];

--- a/libs/expo/betterangels/src/lib/providers/index.ts
+++ b/libs/expo/betterangels/src/lib/providers/index.ts
@@ -1,5 +1,4 @@
-export { useFeatureControls } from './featureControls/featureControlContext';
-export { FeatureControlProvider } from './featureControls/featureControlProvider';
+export * from './featureControls';
 export { default as KeyboardToolbarProvider } from './keyboardToolbar/keyboardToolbarProvider';
 export { default as SnackbarProvider } from './snackbar/SnackbarProvider';
 export { default as UserProvider } from './user/UserProvider';

--- a/libs/expo/betterangels/src/lib/screens/Client/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/index.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react';
 import { Pressable, View } from 'react-native';
 import { useFeatureFlagActive } from '../../hooks';
-import { FeatureFlags } from '../../providers/featureControls/constants';
+import { FeatureFlags } from '../../providers';
 import { ClientProfileSectionEnum } from '../../screenRouting';
 import { MainContainer } from '../../ui-components';
 import ClientHeader from './ClientHeader';

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/ClientProfileForm/PersonalInfoForm/PersonalInfoForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/ClientProfileForm/PersonalInfoForm/PersonalInfoForm.tsx
@@ -19,7 +19,7 @@ import {
   useCaliforniaIdUniqueCheck,
   useFeatureFlagActive,
 } from '../../../../hooks';
-import { FeatureFlags } from '../../../../providers/featureControls/constants';
+import { FeatureFlags } from '../../../../providers';
 import {
   enumDisplayLanguage,
   enumDisplayLivingSituation,

--- a/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
@@ -7,10 +7,9 @@ import {
   TextBold,
 } from '@monorepo/expo/shared/ui-components';
 import { router } from 'expo-router';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useDeleteCurrentUserMutation } from '../../apollo';
 import { useSignOut, useSnackbar, useUser } from '../../hooks';
-import { useFeatureControls } from '../../providers';
 import InfoCard from './InfoCard';
 
 export default function UserProfile() {
@@ -18,7 +17,6 @@ export default function UserProfile() {
   const { showSnackbar } = useSnackbar();
 
   if (!user) throw new Error('Something went wrong');
-  const featureControls = useFeatureControls();
   const [deleteCurrentUser] = useDeleteCurrentUserMutation();
   const userInfo = [
     { title: 'Email', value: user.email },
@@ -46,9 +44,6 @@ export default function UserProfile() {
       });
     }
   }
-
-  const isSamplFeatureFlagActive =
-    featureControls.flags['SampleFeatureFlag']?.isActive;
 
   return (
     <View style={styles.container}>
@@ -90,11 +85,6 @@ export default function UserProfile() {
           }
         />
       </View>
-      {isSamplFeatureFlagActive && (
-        <Text style={styles.featureText}>
-          The feature "SampleFeatureFlag" is active
-        </Text>
-      )}
     </View>
   );
 }

--- a/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
@@ -10,7 +10,7 @@ import { router } from 'expo-router';
 import { StyleSheet, Text, View } from 'react-native';
 import { useDeleteCurrentUserMutation } from '../../apollo';
 import { useSignOut, useSnackbar, useUser } from '../../hooks';
-import { useFeatureControls } from '../../providers/featureControls/featureControlContext';
+import { useFeatureControls } from '../../providers';
 import InfoCard from './InfoCard';
 
 export default function UserProfile() {

--- a/libs/expo/betterangels/src/lib/ui-components/FeatureFlagControlled/FeatureFlagControlled.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/FeatureFlagControlled/FeatureFlagControlled.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import { useFeatureFlagActive } from '../../hooks';
+import { TFeatureFlagValue } from '../../providers';
+
+type TProps = {
+  flag: TFeatureFlagValue;
+  children: ReactNode;
+};
+
+export default function FeatureFlagControlled(props: TProps) {
+  const { flag, children } = props;
+
+  const featureActive = useFeatureFlagActive(flag);
+
+  if (!featureActive) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/libs/expo/betterangels/src/lib/ui-components/MainPlusModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainPlusModal.tsx
@@ -7,7 +7,7 @@ import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
 import { Pressable, StyleSheet, View } from 'react-native';
 
 import { useFeatureFlagActive } from '../hooks';
-import { FeatureFlags } from '../providers/featureControls/constants';
+import { FeatureFlags } from '../providers';
 import MainModal from './MainModal';
 
 interface IMainPlusModalProps {

--- a/libs/expo/betterangels/src/lib/ui-components/index.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/index.ts
@@ -12,6 +12,7 @@ export { default as ConsentModal } from './ConsentModal';
 export { default as DateOfBirthPicker } from './DateOfBirthPicker';
 export { default as DocumentModal } from './DocumentModal';
 export { default as EyeColorPicker } from './EyeColorPicker';
+export { default as FeatureFlagControlled } from './FeatureFlagControlled/FeatureFlagControlled';
 export { FileThumbnail } from './FileThumbnail/FileThumbnail';
 export { default as GenderPicker } from './GenderPicker';
 export { default as HairColorPicker } from './HairColorPicker';


### PR DESCRIPTION
### add FeatureFlagControlled component and update featureControls exports 
part of DEV-1584
https://betterangels.atlassian.net/browse/DEV-1584

* adds `FeatureFlagControlled` component
  * renders child components only if flag is active
  * makes it usable in `_layout`, where `FeatureControlContext` is not directly available
  * makes flag controls very explicit in code
* updates `featureControls` exports

**FeatureFlagControlled usage:**

```javascript

<FeatureFlagControlled
   flag={FeatureFlags.APP_UPDATE_PROMPT_FF}
>
   <MyComponent />
</FeatureFlagControlled>
```

## Summary by Sourcery

Refactor and enhance feature flag controls by introducing a new FeatureFlagControlled component and updating feature controls exports

New Features:
- Add FeatureFlagControlled component that conditionally renders child components based on feature flag status

Enhancements:
- Restructure feature controls exports to improve module imports
- Simplify feature flag usage across the application

Chores:
- Reorganize feature controls module structure
- Move type definitions to a separate file