### PR TITLE
add ErrorCrash page with AppUpdatePrompt (DEV-1584)

### DIFF
--- a/apps/betterangels/src/app/_layout.tsx
+++ b/apps/betterangels/src/app/_layout.tsx
@@ -2,6 +2,7 @@ import 'expo-dev-client';
 
 import {
   AppUpdatePrompt,
+  ErrorCrashView,
   FeatureControlProvider,
   FeatureFlagControlled,
   FeatureFlags,
@@ -22,12 +23,17 @@ import { View } from 'react-native';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { apiUrl, demoApiUrl } from '../../config';
 
-export { ErrorBoundary } from 'expo-router';
+import { type ErrorBoundaryProps } from 'expo-router';
 
 export const unstable_settings = {
   // Ensure that reloading on `/modal` keeps a back button present.
   initialRouteName: '(tabs)',
 };
+
+// Render Error page on uncaught error
+export function ErrorBoundary(props: ErrorBoundaryProps) {
+  return <ErrorCrashView {...props} />;
+}
 
 export default function RootLayout() {
   const router = useRouter();

--- a/libs/expo/betterangels/src/lib/ui-components/AppUpdatePrompt/AppUpdatePrompt.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/AppUpdatePrompt/AppUpdatePrompt.tsx
@@ -7,13 +7,19 @@ import { canShowPromptAgain } from './canShowPromptAgain';
 import { checkForUpdate } from './checkForUpdate';
 import { LAST_UPDATE_CHECK_TS_KEY, UPDATE_DISMISSED_TS_KEY } from './constants';
 
-export function AppUpdatePrompt() {
+type TProps = {
+  forceCanShow?: boolean;
+};
+
+export function AppUpdatePrompt(props: TProps) {
+  const { forceCanShow } = props;
+
   const [promptModalVisible, setPromptModalVisible] = useState(false);
   const { appBecameActive } = useAppState();
 
   useEffect(() => {
     const showPrompt = async () => {
-      const canShowAgain = await canShowPromptAgain();
+      const canShowAgain = forceCanShow || (await canShowPromptAgain());
 
       if (!canShowAgain) {
         return;
@@ -26,12 +32,10 @@ export function AppUpdatePrompt() {
       }
     };
 
-    if (!appBecameActive) {
-      return;
+    if (forceCanShow || appBecameActive) {
+      showPrompt();
     }
-
-    showPrompt();
-  }, [appBecameActive]);
+  }, [appBecameActive, forceCanShow]);
 
   async function onAccept() {
     setPromptModalVisible(false);

--- a/libs/expo/betterangels/src/lib/ui-components/ErrorCrashView/ErrorCrashView.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ErrorCrashView/ErrorCrashView.tsx
@@ -1,11 +1,22 @@
 import { Spacings } from '@monorepo/expo/shared/static';
 import { Button, TextBold } from '@monorepo/expo/shared/ui-components';
 import { ErrorBoundaryProps } from 'expo-router';
+import { useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { AppUpdatePrompt } from '../AppUpdatePrompt';
 
 export default function ErrorCrashView(props: ErrorBoundaryProps) {
   const { retry } = props;
+
+  const [hasRetried, setHasRetried] = useState(false);
+
+  const handleRetry = () => {
+    if (!hasRetried) {
+      setHasRetried(true);
+
+      retry();
+    }
+  };
 
   return (
     <View style={styles.container}>
@@ -13,10 +24,9 @@ export default function ErrorCrashView(props: ErrorBoundaryProps) {
         <TextBold size="lg">Sorry, something went wrong.</TextBold>
 
         <Button
-          style={{
-            paddingHorizontal: 60,
-          }}
-          onPress={retry}
+          style={styles.retryButton}
+          onPress={handleRetry}
+          disabled={hasRetried}
           size="full"
           fontSize="sm"
           accessibilityHint="reload the app"
@@ -42,5 +52,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: Spacings.sm,
     alignItems: 'center',
     textAlign: 'center',
+  },
+  retryButton: {
+    paddingHorizontal: 60,
   },
 });

--- a/libs/expo/betterangels/src/lib/ui-components/ErrorCrashView/ErrorCrashView.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ErrorCrashView/ErrorCrashView.tsx
@@ -1,0 +1,48 @@
+import { Spacings } from '@monorepo/expo/shared/static';
+import { Button, TextBold } from '@monorepo/expo/shared/ui-components';
+import { ErrorBoundaryProps } from 'expo-router';
+import { StyleSheet, View } from 'react-native';
+import { AppUpdatePrompt } from '../AppUpdatePrompt';
+
+interface TProps extends ErrorBoundaryProps {}
+
+export default function ErrorCrashView(props: TProps) {
+  const { retry } = props;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.content}>
+        <TextBold size="lg">Sorry, something went wrong.</TextBold>
+
+        <Button
+          style={{
+            paddingHorizontal: 60,
+          }}
+          onPress={retry}
+          size="full"
+          fontSize="sm"
+          accessibilityHint="reload the app"
+          variant="primary"
+          title="Retry"
+        />
+      </View>
+
+      <AppUpdatePrompt forceCanShow={true} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    gap: Spacings.lg,
+    paddingHorizontal: Spacings.sm,
+    alignItems: 'center',
+    textAlign: 'center',
+  },
+});

--- a/libs/expo/betterangels/src/lib/ui-components/ErrorCrashView/ErrorCrashView.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ErrorCrashView/ErrorCrashView.tsx
@@ -4,9 +4,7 @@ import { ErrorBoundaryProps } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
 import { AppUpdatePrompt } from '../AppUpdatePrompt';
 
-interface TProps extends ErrorBoundaryProps {}
-
-export default function ErrorCrashView(props: TProps) {
+export default function ErrorCrashView(props: ErrorBoundaryProps) {
   const { retry } = props;
 
   return (

--- a/libs/expo/betterangels/src/lib/ui-components/FeatureFlagControlled/FeatureFlagControlled.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/FeatureFlagControlled/FeatureFlagControlled.tsx
@@ -16,5 +16,5 @@ export default function FeatureFlagControlled(props: TProps) {
     return null;
   }
 
-  return <>{children}</>;
+  return children;
 }

--- a/libs/expo/betterangels/src/lib/ui-components/index.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/index.ts
@@ -12,6 +12,7 @@ export {
 export { default as ConsentModal } from './ConsentModal';
 export { default as DateOfBirthPicker } from './DateOfBirthPicker';
 export { default as DocumentModal } from './DocumentModal';
+export { default as ErrorCrashView } from './ErrorCrashView/ErrorCrashView';
 export { default as EyeColorPicker } from './EyeColorPicker';
 export { default as FeatureFlagControlled } from './FeatureFlagControlled/FeatureFlagControlled';
 export { FileThumbnail } from './FileThumbnail/FileThumbnail';


### PR DESCRIPTION
### Add ErrorCrash page with AppUpdatePrompt

DEV-1584

* add simple Error page
  * renders on uncaught error in layout
  * includes `retry` button to try reload app
  * incorporates `AppUpdatePrompt`
    * no feature flag check (can't guarantee it's available if app crashes)
    * bypasses all time interval checks, such as last time dismissed etc..
  

<img width="320" alt="Screenshot 2025-04-16 at 10 58 27 AM" src="https://github.com/user-attachments/assets/9d40ea8c-427c-47c6-97c4-bb3d9b67923c" />

## Summary by Sourcery

Implement an ErrorCrash page that renders when an uncaught error occurs in the app, providing a retry mechanism and forcing an app update prompt

New Features:
- Add an ErrorCrashView component that displays when the app encounters an unhandled error
- Implement a retry button to reload the app after a crash

Bug Fixes:
- Ensure app update prompt is shown even during critical error scenarios

Enhancements:
- Modify AppUpdatePrompt to support forced display regardless of normal show conditions
- Create a centralized error handling mechanism for the app layout