### PR TITLE
Add lint target to `shelter-web` (DEV-1675)

### DIFF
--- a/apps/shelter-web/project.json
+++ b/apps/shelter-web/project.json
@@ -45,6 +45,10 @@
       },
       "dependsOn": ["build"]
     },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
     "post-pr-preview": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/shelter-web/src/app/app.spec.tsx
+++ b/apps/shelter-web/src/app/app.spec.tsx
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom';
 import { GET_SHELTERS_QUERY } from './shared/clients/apollo/queries/getShelters';
 
+// Temporary suppression to allow incremental cleanup without regressions.
+// ⚠️ If you're modifying this file, please remove this ignore and fix the issue.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mocks = [
   {
     request: {

--- a/apps/shelter-web/src/app/pages/home/home.tsx
+++ b/apps/shelter-web/src/app/pages/home/home.tsx
@@ -16,9 +16,14 @@ import { ShelterSearch } from '../../shared/components/shelters/shelterSearch';
 import { ModalAnimationEnum } from '../../shared/modal/modal';
 
 export function Home() {
+  // Temporary suppression to allow incremental cleanup without regressions.
+  // ⚠️ If you're modifying this file, please remove these ignores and fix the issues.
+  /* eslint-disable @typescript-eslint/no-unused-vars, no-console */
   const [_location, setLocation] = useAtom(locationAtom);
-  const [shelters] = useAtom(sheltersAtom);
   const [_modal, setModal] = useAtom(modalAtom);
+  /* eslint-enable @typescript-eslint/no-unused-vars, no-console */
+
+  const [shelters] = useAtom(sheltersAtom);
   const [shelterMarkers, setShelterMarkers] = useState<TMarker[]>([]);
   const [defaultCenter, setDefaultCenter] = useState<TLatLng>();
 

--- a/apps/shelter-web/src/app/shared/components/map/controls/zoomButton.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/controls/zoomButton.tsx
@@ -13,7 +13,10 @@ type TProps = {
 export function ZoomButton(props: TProps) {
   const { zoomBy, icon, className, onClick } = props;
 
-  let zoomIcon = icon || getIcon(zoomBy);
+  // Temporary suppression to allow incremental cleanup without regressions.
+  // ⚠️ If you're modifying this file, please remove this ignore and fix the issue.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const zoomIcon = icon || getIcon(zoomBy);
 
   const map = useMap();
 

--- a/apps/shelter-web/src/app/shared/components/map/controls/zoomControls.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/controls/zoomControls.tsx
@@ -8,6 +8,9 @@ type TProps = {
 };
 
 export function ZoomControls(props: TProps) {
+  // Temporary suppression to allow incremental cleanup without regressions.
+  // ⚠️ If you're modifying this file, please remove this ignore and fix the issue.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { className = '', zoomBy = 1 } = props;
 
   const map = useMap();

--- a/apps/shelter-web/src/app/shared/components/shelters/shelterSearch.tsx
+++ b/apps/shelter-web/src/app/shared/components/shelters/shelterSearch.tsx
@@ -15,6 +15,9 @@ import { ShelterFilters } from '../shelterFilter/shelterFilters';
 import { SheltersDisplay, TShelterPropertyFilters } from './sheltersDisplay';
 
 export function ShelterSearch() {
+  // Temporary suppression to allow incremental cleanup without regressions.
+  // ⚠️ If you're modifying this file, please remove this ignore and fix the issue.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_modal, setModal] = useAtom(modalAtom);
   const [location, setLocation] = useAtom(locationAtom);
   const [queryFilters, setQueryFilters] = useState<TShelterPropertyFilters>();

--- a/apps/shelter-web/src/app/shared/components/shelters/sheltersDisplay.tsx
+++ b/apps/shelter-web/src/app/shared/components/shelters/sheltersDisplay.tsx
@@ -46,6 +46,9 @@ export function SheltersDisplay(props: TProps) {
 
   const [getShelters, { loading, data, error }] = useViewSheltersLazyQuery();
 
+  // Temporary suppression to allow incremental cleanup without regressions.
+  // ⚠️ If you're modifying this file, please remove this ignore and fix the issue.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_sheltersData, setSheltersData] = useAtom(sheltersAtom);
 
   useEffect(() => {

--- a/apps/shelter-web/src/app/shared/modal/modal.tsx
+++ b/apps/shelter-web/src/app/shared/modal/modal.tsx
@@ -35,6 +35,9 @@ export function Modal(props: IModal): ReactElement | null {
     onClose,
   } = props;
 
+  // Temporary suppression to allow incremental cleanup without regressions.
+  // ⚠️ If you're modifying this file, please remove this ignore and fix the issue.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_modal, setModal] = useAtom(modalAtom);
 
   function onModalClose(): void {

--- a/apps/shelter-web/src/app/shared/modal/modalMask.tsx
+++ b/apps/shelter-web/src/app/shared/modal/modalMask.tsx
@@ -12,6 +12,9 @@ interface IProps extends PropsWithChildren {
 export function ModalMask(props: IProps) {
   const { className, closeOnMaskClick = false, children } = props;
 
+  // Temporary suppression to allow incremental cleanup without regressions.
+  // ⚠️ If you're modifying this file, please remove this ignore and fix the issue.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_modal, setModal] = useAtom(modalAtom);
 
   const parentCss: string = [


### PR DESCRIPTION
DEV-1675: Adds linting to the shelter-web project.

This configuration prevents new linting errors from being introduced, while suppressing existing issues.
Each suppressed file includes a comment instructing developers to resolve the issue the next time the file is modified.

## Summary by Sourcery

Add ESLint configuration and temporary lint suppressions to shelter-web project

New Features:
- Added a lint target to the shelter-web project configuration

Enhancements:
- Added temporary ESLint suppressions across multiple components to allow incremental code cleanup

CI:
- Integrated ESLint linting into the project's build process