### PR TITLE
use MainScrollContainer with AboutApp and add debug info

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/AppSettings/AboutApp/AboutApp.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AppSettings/AboutApp/AboutApp.tsx
@@ -3,7 +3,10 @@ import { Divider } from '@monorepo/expo/shared/ui-components';
 import { StyleSheet, View } from 'react-native';
 import { useAppVersion } from '../../../hooks';
 import { FeatureFlags } from '../../../providers';
-import { FeatureFlagControlled, MainContainer } from '../../../ui-components';
+import {
+  FeatureFlagControlled,
+  MainScrollContainer,
+} from '../../../ui-components';
 import { AppDataCard } from './AppDataCard';
 import { UpdatesDebugInfo } from './UpdatesDebugInfo';
 
@@ -11,7 +14,7 @@ export function AboutApp() {
   const { version, runtimeVersionShort } = useAppVersion();
 
   return (
-    <MainContainer pb={0} bg={Colors.NEUTRAL_EXTRA_LIGHT}>
+    <MainScrollContainer pb={0} bg={Colors.NEUTRAL_EXTRA_LIGHT}>
       <View style={styles.pageCard}>
         {version && <AppDataCard label="App Version" value={version} />}
 
@@ -23,7 +26,7 @@ export function AboutApp() {
       <FeatureFlagControlled flag={FeatureFlags.SHOW_DEBUG_INFO_FF}>
         <UpdatesDebugInfo />
       </FeatureFlagControlled>
-    </MainContainer>
+    </MainScrollContainer>
   );
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Update AboutApp screen to use MainScrollContainer and add debug information for app updates

New Features:
- Implement debug information display for app update timestamps

Enhancements:
- Add timestamp display for last update check and update dismissal in the AboutApp screen

Chores:
- Replace MainContainer with MainScrollContainer in AboutApp screen