### PR TITLE
update pronoun labels (DEV-1744, DEV-1707)

### DIFF
--- a/apps/betterangels-backend/clients/enums.py
+++ b/apps/betterangels-backend/clients/enums.py
@@ -127,9 +127,9 @@ class PreferredCommunicationEnum(models.TextChoices):
 
 
 class PronounEnum(models.TextChoices):
-    HE_HIM_HIS = "he_him_his", _("He/Him/His")
-    SHE_HER_HERS = "she_her_hers", _("She/Her/Hers")
-    THEY_THEM_THEIRS = "they_them_theirs", _("They/Them/Theirs")
+    HE_HIM_HIS = "he_him_his", _("He/Him")
+    SHE_HER_HERS = "she_her_hers", _("She/Her")
+    THEY_THEM_THEIRS = "they_them_theirs", _("They/Them")
     OTHER = "other", _("Other")
 
 

--- a/apps/betterangels-backend/clients/tests/test_models.py
+++ b/apps/betterangels-backend/clients/tests/test_models.py
@@ -12,7 +12,7 @@ class ClientProfileModelTestCase(TestCase):
 
         client_profile.pronouns = PronounEnum.HE_HIM_HIS
         client_profile.save()
-        self.assertEqual(client_profile.display_pronouns, "He/Him/His")
+        self.assertEqual(client_profile.display_pronouns, "He/Him")
 
         client_profile.pronouns = PronounEnum.OTHER
         client_profile.pronouns_other = "she/her/their"

--- a/apps/betterangels-backend/clients/tests/test_mutations.py
+++ b/apps/betterangels-backend/clients/tests/test_mutations.py
@@ -123,7 +123,7 @@ class ClientProfileMutationTestCase(ClientProfileGraphQLBaseTestCase):
             "dateOfBirth": self.date_of_birth.strftime("%Y-%m-%d"),
             "displayCaseManager": "Not Assigned",
             "displayGender": "genderqueer",
-            "displayPronouns": "She/Her/Hers",
+            "displayPronouns": "She/Her",
             "hmisProfiles": expected_hmis_profiles,
             "householdMembers": expected_household_members,
             "phoneNumbers": expected_phone_numbers,

--- a/apps/betterangels-backend/clients/tests/test_queries.py
+++ b/apps/betterangels-backend/clients/tests/test_queries.py
@@ -79,7 +79,7 @@ class ClientProfileQueryTestCase(ClientProfileGraphQLBaseTestCase):
             "dateOfBirth": self.date_of_birth.strftime("%Y-%m-%d"),
             "displayCaseManager": self.client_profile_1_contact_2["name"],
             "displayGender": "Male",
-            "displayPronouns": "He/Him/His",
+            "displayPronouns": "He/Him",
             "docReadyDocuments": [self.client_profile_1_document_1, self.client_profile_1_document_2],
             "email": "todd@pblivin.com",
             "eyeColor": EyeColorEnum.BROWN.name,

--- a/libs/expo/betterangels/src/lib/static/enumDisplayMapping.ts
+++ b/libs/expo/betterangels/src/lib/static/enumDisplayMapping.ts
@@ -70,9 +70,9 @@ export const enumDisplayGender: { [key in GenderEnum]: string } = {
 };
 
 export const enumDisplayPronoun: { [key in PronounEnum]: string } = {
-  [PronounEnum.HeHimHis]: 'He/Him/His',
-  [PronounEnum.SheHerHers]: 'She/Her/Hers',
-  [PronounEnum.TheyThemTheirs]: 'They/Them/Theirs',
+  [PronounEnum.HeHimHis]: 'He/Him',
+  [PronounEnum.SheHerHers]: 'She/Her',
+  [PronounEnum.TheyThemTheirs]: 'They/Them',
   [PronounEnum.Other]: 'Other',
 };
 


### PR DESCRIPTION
DEV-1744, DEV-1707

## Summary by Sourcery

Update pronoun labels to remove possessive pronouns from display text

Enhancements:
- Simplified pronoun display labels by removing possessive pronouns (e.g., 'His', 'Hers', 'Theirs')

Tests:
- Updated test cases to reflect the new pronoun display format