### PR TITLE
bump updatePrompt no repeat to 24 hrs and remove crash btn (DEV-1584)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/AppSettings/AboutApp/UpdatesDebugInfo.tsx
+++ b/libs/expo/betterangels/src/lib/screens/AppSettings/AboutApp/UpdatesDebugInfo.tsx
@@ -1,6 +1,5 @@
 import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
 import {
-  Button,
   ExpandableContainer,
   TextBold,
   TextRegular,
@@ -44,17 +43,8 @@ export function UpdatesDebugInfo() {
     fetchUpdate();
   }, []);
 
-  // TOOD: remove after testing ErrorCrashView via ErrorBoundary in _layout.
-  // Using state as click handler errors will not bubble up to ErrorBoundary.
-  const [shouldCrash, setShouldCrash] = useState(false);
   const [lastDismissedTs, setLastDismissedTs] = useState('');
   const [lastUpdatedTs, setLastUpdatedTs] = useState('');
-
-  useEffect(() => {
-    if (shouldCrash) {
-      throw new Error('Fake app crash');
-    }
-  }, [shouldCrash]);
 
   useEffect(() => {
     async function updateFromStorage() {
@@ -101,16 +91,6 @@ export function UpdatesDebugInfo() {
           </TextRegular>
         </View>
       </ExpandableContainer>
-
-      {/* TODO: remove after testing Crash Error screen */}
-      <View style={{ marginTop: 24 }}>
-        <Button
-          variant="negative"
-          title="Crash App"
-          onPress={() => setShouldCrash(true)}
-          accessibilityHint="crashes app."
-        />
-      </View>
     </View>
   );
 }

--- a/libs/expo/betterangels/src/lib/ui-components/AppUpdatePrompt/constants.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/AppUpdatePrompt/constants.ts
@@ -1,12 +1,10 @@
-import { minutesToMilliseconds } from 'date-fns';
+import { hoursToMilliseconds, minutesToMilliseconds } from 'date-fns';
 
 // Extra safety check to avoid any rate limiting.
-// TODO: increase threshold after testing
 export const MIN_UPDATE_CHECK_INTERVAL_MS = minutesToMilliseconds(1);
 
 // Interval to prevent showing update prompt for a period after user dismisses it.
-// TODO: increase threshold after testing
-export const DO_NOT_REPEAT_INTERVAL_MS = minutesToMilliseconds(5);
+export const DO_NOT_REPEAT_INTERVAL_MS = hoursToMilliseconds(24);
 
 // storage keys
 export const UPDATE_DISMISSED_TS_KEY = 'updateDismissedTsKey';


### PR DESCRIPTION
## Summary by Sourcery

Modify update prompt behavior and remove debug crash functionality

Enhancements:
- Extend the update prompt suppression interval from 5 minutes to 24 hours to reduce frequent update notifications

Chores:
- Remove debug crash button and related crash simulation code from UpdatesDebugInfo screen