### PR TITLE
add DatePicker_V2 for CPR household form (DEV-1194)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HouseholdMemberForm/HouseholdMemberForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HouseholdMemberForm/HouseholdMemberForm.tsx
@@ -1,7 +1,7 @@
 import { Regex } from '@monorepo/expo/shared/static';
 import {
   ControlledInput,
-  DatePicker,
+  DatePicker_V2 as DatePicker,
   Form,
   SingleSelect,
   TextRegular,
@@ -187,19 +187,19 @@ export function HouseholdMemberForm(props: TProps) {
           <Controller
             name="dateOfBirth"
             control={control}
-            render={({ field }) => (
+            render={({ field: { value, onChange } }) => (
               <DatePicker
-                label="Date of birth"
+                label="Date of Birth"
                 disabled={isLoading}
                 maxDate={new Date()}
                 pattern={Regex.date}
                 mode="date"
                 format="MM/dd/yyyy"
-                placeholder="Enter date of Birth"
+                placeholder="Enter date of birth"
                 minDate={new Date('1900-01-01')}
                 mt="xs"
-                value={field.value}
-                setValue={(date) => setValue('dateOfBirth', date)}
+                value={value}
+                onChange={onChange}
               />
             )}
           />

--- a/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
@@ -1,0 +1,231 @@
+import { CalendarLineIcon, ClockIcon } from '@monorepo/expo/shared/icons';
+import {
+  Colors,
+  FontSizes,
+  Radiuses,
+  Spacings,
+  TMarginProps,
+  getMarginStyles,
+} from '@monorepo/expo/shared/static';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { format as dateFnsFormat } from 'date-fns';
+import { useState } from 'react';
+import { RegisterOptions } from 'react-hook-form';
+import {
+  Keyboard,
+  Platform,
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  ViewStyle,
+} from 'react-native';
+import Button from '../Button';
+
+type TRules = Omit<
+  RegisterOptions,
+  'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'
+>;
+
+interface IDatePickerProps extends TMarginProps {
+  label?: string;
+  mode: 'date' | 'time';
+  height?: 40 | 56 | 200;
+  placeholder?: string;
+  required?: boolean;
+  pattern?: RegExp;
+  disabled?: boolean;
+  error?: boolean;
+  rules?: TRules;
+  format: string;
+  componentStyle?: StyleProp<ViewStyle>;
+  onBlur?: () => void;
+  minDate?: Date;
+  maxDate?: Date;
+  pickerMode?: 'countdown' | 'date' | 'time' | 'datetime';
+  onChange: (date: Date) => void;
+  initialDate?: Date;
+  value?: Date | null;
+}
+
+export function DatePicker(props: IDatePickerProps) {
+  const {
+    label,
+    onChange,
+    error,
+    required,
+    disabled,
+    componentStyle,
+    height = 56,
+    minDate,
+    maxDate,
+    mode,
+    placeholder,
+    format = 'MM/dd/yyyy',
+    pattern,
+    initialDate,
+    value,
+    ...rest
+  } = props;
+
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  return (
+    <View
+      style={[
+        styles.inputContainer,
+        componentStyle,
+        {
+          ...getMarginStyles(props),
+        },
+      ]}
+    >
+      {label && (
+        <View style={styles.label}>
+          <Text style={styles.labelText}>{label}</Text>
+          {required && <Text style={styles.required}>*</Text>}
+        </View>
+      )}
+
+      <View
+        style={[
+          styles.input,
+          {
+            borderColor: error ? 'red' : Colors.NEUTRAL_LIGHT,
+          },
+        ]}
+      >
+        <TextInput
+          placeholder={placeholder}
+          maxLength={18}
+          style={[
+            styles.textInput,
+            {
+              height,
+              ...Platform.select({
+                web: {
+                  outline: 'none',
+                },
+              }),
+            },
+          ]}
+          value={value ? dateFnsFormat(value, format) : undefined}
+          editable={!disabled}
+          {...rest}
+        />
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="open date picker"
+          accessibilityHint="Opens the date picker to select a date"
+          onPress={() => {
+            setPickerVisible(true);
+            Keyboard.dismiss();
+          }}
+          style={styles.icon}
+        >
+          <FieldIcon mode={mode} />
+        </Pressable>
+      </View>
+      {pickerVisible && (
+        <View style={{ marginTop: Spacings.xs }}>
+          <DateTimePicker
+            locale={'en_US'}
+            onChange={(event, date) => {
+              if (event.type === 'dismissed' || !date) {
+                return setPickerVisible(false);
+              }
+
+              onChange(date);
+
+              Platform.OS !== 'ios' && setPickerVisible(false);
+            }}
+            style={styles.dateTimePicker}
+            display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+            mode={mode}
+            minimumDate={minDate}
+            maximumDate={maxDate}
+            value={value || new Date()}
+          />
+          {Platform.OS === 'ios' && (
+            <View style={{ marginTop: Spacings.xs }}>
+              <Button
+                style={{ alignSelf: 'flex-end' }}
+                variant="primary"
+                size="sm"
+                height="sm"
+                accessibilityHint="save date"
+                onPress={() => {
+                  setPickerVisible(false);
+                }}
+                title="Done"
+              />
+            </View>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+function FieldIcon({ mode }: { mode: 'date' | 'time' }) {
+  if (mode === 'time') {
+    return <ClockIcon color={Colors.PRIMARY_EXTRA_DARK} size="md" />;
+  }
+
+  return <CalendarLineIcon color={Colors.PRIMARY_EXTRA_DARK} size="md" />;
+}
+
+const styles = StyleSheet.create({
+  inputContainer: {
+    position: 'relative',
+    width: '100%',
+  },
+  input: {
+    position: 'relative',
+    fontFamily: 'Poppins-Regular',
+    backgroundColor: Colors.WHITE,
+    borderWidth: 1,
+    borderRadius: Radiuses.xs,
+    justifyContent: 'center',
+  },
+  textInput: {
+    color: Colors.PRIMARY_EXTRA_DARK,
+    paddingLeft: Spacings.sm,
+    paddingRight: 38,
+    fontFamily: 'Poppins-Regular',
+    fontSize: FontSizes.md.fontSize,
+    borderColor: 'red',
+  },
+  dateTimePicker: {
+    backgroundColor: Colors.WHITE,
+    borderRadius: Radiuses.xs,
+    overflow: 'hidden',
+  },
+  label: {
+    flexDirection: 'row',
+    marginBottom: Spacings.xs,
+  },
+  labelText: {
+    fontSize: FontSizes.sm.fontSize,
+    lineHeight: FontSizes.sm.lineHeight,
+    color: Colors.PRIMARY_EXTRA_DARK,
+    fontFamily: 'Poppins-Regular',
+  },
+  required: {
+    marginLeft: 2,
+    color: 'red',
+  },
+  icon: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: '100%',
+    height: '100%',
+    alignItems: 'flex-end',
+    justifyContent: 'center',
+    paddingRight: Spacings.sm,
+  },
+});

--- a/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
@@ -140,7 +140,9 @@ export function DatePicker(props: IDatePickerProps) {
 
               onChange(date);
 
-              Platform.OS !== 'ios' && setPickerVisible(false);
+              if (Platform.OS !== 'ios') {
+                setPickerVisible(false);
+              }
             }}
             style={styles.dateTimePicker}
             display={Platform.OS === 'ios' ? 'spinner' : 'default'}
@@ -197,7 +199,6 @@ const styles = StyleSheet.create({
     paddingRight: 38,
     fontFamily: 'Poppins-Regular',
     fontSize: FontSizes.md.fontSize,
-    borderColor: 'red',
   },
   dateTimePicker: {
     backgroundColor: Colors.WHITE,

--- a/libs/expo/shared/ui-components/src/lib/DatePicker_V2/index.ts
+++ b/libs/expo/shared/ui-components/src/lib/DatePicker_V2/index.ts
@@ -1,0 +1,1 @@
+export { DatePicker as default } from './DatePicker';

--- a/libs/expo/shared/ui-components/src/lib/index.ts
+++ b/libs/expo/shared/ui-components/src/lib/index.ts
@@ -25,6 +25,7 @@ export {
   parseToDate,
 } from './Date';
 export { default as DatePicker } from './DatePicker';
+export { default as DatePicker_V2 } from './DatePicker_V2';
 export { default as DeleteModal } from './DeleteModal';
 export { default as Divider } from './Divider';
 export { default as EditButton } from './EditButton';
@@ -40,13 +41,14 @@ export { default as IconButton } from './IconButton';
 export { default as ImageViewer } from './ImageViewer';
 export { default as Input } from './Input';
 export { default as Input_V2 } from './Input_V2';
+// DatePicker
 export { default as KeyboardAwareScrollView } from './KeyboardAwareScrollView';
 export {
+  Length,
+  TLengthUnit,
   feetInchesToInches,
   getFormattedLength,
   inchesToFeetInches,
-  Length,
-  TLengthUnit,
 } from './Length';
 export { default as Loading } from './Loading';
 export { default as LoadingView } from './LoadingView';
@@ -71,10 +73,10 @@ export { default as Snackbar } from './Snackbar';
 export { SocialMediaIcon, TSocialMediaType } from './SocialMediaIcon';
 export { default as StatusBadge } from './StatusBadge';
 export { default as Tag } from './Tag';
-export { default as Textarea } from './Textarea';
 export { default as TextBold } from './TextBold';
 export { default as TextButton } from './TextButton';
 export { default as TextMedium } from './TextMedium';
 export { default as TextOrNode } from './TextOrNode';
 export { default as TextRegular } from './TextRegular';
+export { default as Textarea } from './Textarea';
 export * from './types';


### PR DESCRIPTION
### Add DatePicker_V2
https://betterangels.atlassian.net/browse/DEV-1194

* adds DatePicker_V2 to work with `onChange` instead of `setValue`
  * Implements only in CPR Household form
  * If accepted, can implemented elsewhere in other forms during cleanup after CPR launch. The DatePicker will probably change anyway later to have the iOS version render a picker in a modal at bottom of screen, like other pickers.

## Summary by Sourcery

Implement a new DatePicker_V2 component with improved onChange handling for the CPR Household form

New Features:
- Introduce a new DatePicker_V2 component that uses onChange instead of setValue for form interactions

Enhancements:
- Refactor DatePicker implementation to support more flexible form integration
- Improve date picker interaction with better keyboard and platform-specific handling

Chores:
- Update component exports to include the new DatePicker_V2