### PR TITLE
hide location button if permission denied (DEV-1761)

### DIFF
--- a/apps/shelter-web/src/app/shared/components/map/controls/currentLocationBtn.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/controls/currentLocationBtn.tsx
@@ -7,12 +7,12 @@ import { ControlBtnWrapper } from './controlBtnWrapper';
 
 type TProps = {
   className?: string;
-  onLocationSucccess?: (location: TLatLng) => void;
+  onLocationSuccess?: (location: TLatLng) => void;
   onError?: (location: TLocationError) => void;
 };
 
 export function CurrentLocationBtn(props: TProps) {
-  const { className = '', onError, onLocationSucccess } = props;
+  const { className = '', onError, onLocationSuccess } = props;
 
   const map = useMap();
 
@@ -21,7 +21,7 @@ export function CurrentLocationBtn(props: TProps) {
   }
 
   function onLocationChange(location: TLatLng) {
-    onLocationSucccess && onLocationSucccess(location);
+    onLocationSuccess && onLocationSuccess(location);
   }
 
   function onLocationError(error: TLocationError) {

--- a/apps/shelter-web/src/app/shared/components/map/map.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/map.tsx
@@ -118,9 +118,14 @@ export function Map(props: TMap) {
 
   useEffect(() => {
     let permissionStatus: PermissionStatus;
+    const permissionQuery = navigator.permissoms;
 
-    navigator.permissions
-      ?.query({ name: 'geolocation' as PermissionName })
+    if (!permissionQuery) {
+      return;
+    }
+
+    permissionQuery
+      .query({ name: 'geolocation' as PermissionName })
       .then((result) => {
         setGeolocationPermission(result.state);
         permissionStatus = result;

--- a/apps/shelter-web/src/app/shared/components/map/map.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/map.tsx
@@ -138,7 +138,8 @@ export function Map(props: TMap) {
   }, []);
 
   useEffect(() => {
-    if (!map || geolocationPermission !== 'granted') return;
+    if (!map || !navigator.geolocation || geolocationPermission !== 'granted')
+      return;
 
     navigator.geolocation.getCurrentPosition(
       (position) => {

--- a/apps/shelter-web/src/app/shared/components/map/map.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/map.tsx
@@ -188,7 +188,7 @@ export function Map(props: TMap) {
           {locationAllowed && (
             <CurrentLocationBtn
               className="mt-5"
-              onLocationSucccess={handleCenterToUserLocation}
+              onLocationSuccess={handleCenterToUserLocation}
             />
           )}
         </div>

--- a/apps/shelter-web/src/app/shared/components/map/map.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/map.tsx
@@ -118,7 +118,7 @@ export function Map(props: TMap) {
 
   useEffect(() => {
     let permissionStatus: PermissionStatus;
-    const permissionQuery = navigator.permissoms;
+    const permissionQuery = navigator.permissions;
 
     if (!permissionQuery) {
       return;

--- a/apps/shelter-web/src/app/shared/components/map/map.tsx
+++ b/apps/shelter-web/src/app/shared/components/map/map.tsx
@@ -125,13 +125,11 @@ export function Map(props: TMap) {
         setGeolocationPermission(result.state);
         permissionStatus = result;
 
-        // Track changes
         result.onchange = () => {
           setGeolocationPermission(result.state);
         };
       });
 
-    // Cleanup on unmount
     return () => {
       if (permissionStatus) {
         permissionStatus.onchange = null;


### PR DESCRIPTION
DEV-1761

## Summary by Sourcery

Improve geolocation handling by hiding the current location button when location permission is denied

Bug Fixes:
- Add handling for geolocation permission denial by checking permission state before showing location button

Enhancements:
- Implement permission check for geolocation to provide better user experience
- Add dynamic visibility for current location button based on location permissions