### PR TITLE
Use Input with Picker and DateField (DEV-1774)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/ClientProfileForm/PersonalInfoForm/PersonalInfoForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/ClientProfileForm/PersonalInfoForm/PersonalInfoForm.tsx
@@ -2,7 +2,7 @@ import { Regex } from '@monorepo/expo/shared/static';
 import {
   ActionModal,
   ControlledInput,
-  DatePicker,
+  DatePicker_V2 as DatePicker,
   Form,
   SingleSelect,
 } from '@monorepo/expo/shared/ui-components';
@@ -168,16 +168,13 @@ export function PersonalInfoForm() {
 
       <Form.Field title="Date of Birth">
         <DatePicker
-          disabled
           maxDate={new Date()}
-          pattern={Regex.date}
           mode="date"
           format="MM/dd/yyyy"
           placeholder="Enter Date of Birth"
           minDate={new Date('1900-01-01')}
-          mt="xs"
           value={dateOfBirth}
-          setValue={(date) => setValue('dateOfBirth', date)}
+          onChange={(date) => setValue('dateOfBirth', date)}
         />
       </Form.Field>
 

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HmisProfileForm/HmisProfileForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HmisProfileForm/HmisProfileForm.tsx
@@ -171,6 +171,7 @@ export function HmisProfileForm(props: TProps) {
             rules={{ required: 'Type of HMIS ID is required' }}
             render={({ field }) => (
               <SingleSelect
+                required={true}
                 disabled={isLoading}
                 label="Type of HMIS ID"
                 placeholder="Select type of HMIS ID"
@@ -186,6 +187,7 @@ export function HmisProfileForm(props: TProps) {
 
           <ControlledInput
             control={control}
+            required={true}
             disabled={isLoading}
             label={'HMIS ID'}
             name={'hmisId'}

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HouseholdMemberForm/HouseholdMemberForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HouseholdMemberForm/HouseholdMemberForm.tsx
@@ -169,7 +169,7 @@ export function HouseholdMemberForm(props: TProps) {
           <Controller
             name="gender"
             control={control}
-            render={({ field }) => (
+            render={({ field: { value, onChange } }) => (
               <SingleSelect
                 disabled={isLoading}
                 label="Gender"
@@ -177,8 +177,8 @@ export function HouseholdMemberForm(props: TProps) {
                 items={Object.entries(enumDisplayGender).map(
                   ([value, displayValue]) => ({ value, displayValue })
                 )}
-                selectedValue={field.value}
-                onChange={(value) => field.onChange(value)}
+                selectedValue={value}
+                onChange={(value) => onChange(value)}
                 error={errors.gender?.message}
               />
             )}

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HouseholdMemberForm/HouseholdMemberForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms-V2/relatedClientProfileModel/forms/HouseholdMemberForm/HouseholdMemberForm.tsx
@@ -1,4 +1,3 @@
-import { Regex } from '@monorepo/expo/shared/static';
 import {
   ControlledInput,
   DatePicker_V2 as DatePicker,
@@ -192,14 +191,13 @@ export function HouseholdMemberForm(props: TProps) {
                 label="Date of Birth"
                 disabled={isLoading}
                 maxDate={new Date()}
-                pattern={Regex.date}
                 mode="date"
                 format="MM/dd/yyyy"
                 placeholder="Enter date of birth"
                 minDate={new Date('1900-01-01')}
-                mt="xs"
                 value={value}
                 onChange={onChange}
+                error={errors.dateOfBirth?.message}
               />
             )}
           />

--- a/libs/expo/shared/static/src/lib/index.ts
+++ b/libs/expo/shared/static/src/lib/index.ts
@@ -1,6 +1,11 @@
 export { Colors } from './colors';
 export { FontSizes } from './fontSizes';
-export { TMarginProps, getMarginStyles } from './margins';
+export {
+  TMarginProps,
+  getMarginStyles,
+  marginPropKeys,
+  omitMarginProps,
+} from './margins';
 export { MimeTypes, TMimeType } from './mimeTypes';
 export { Radiuses, TRadius, TRadiusKey } from './radiuses';
 export { Regex } from './regex';

--- a/libs/expo/shared/static/src/lib/margins.ts
+++ b/libs/expo/shared/static/src/lib/margins.ts
@@ -21,14 +21,14 @@ const marginMap: Record<keyof TMarginProps, string> = {
 
 export const marginPropKeys = Object.keys(marginMap) as (keyof TMarginProps)[];
 
-export function omitMarginProps<T extends Record<string, any>>(props: T) {
-  const cloneProps: Record<string, any> = { ...props };
+export function omitMarginProps<T extends Record<string, unknown>>(props: T) {
+  const clone = { ...props };
 
   for (const key of marginPropKeys) {
-    delete cloneProps[key];
+    delete clone[key];
   }
 
-  return cloneProps as Omit<T, keyof TMarginProps>;
+  return clone as Omit<T, keyof TMarginProps>;
 }
 
 export const getMarginStyles = (props: TMarginProps) => {

--- a/libs/expo/shared/static/src/lib/margins.ts
+++ b/libs/expo/shared/static/src/lib/margins.ts
@@ -19,7 +19,17 @@ const marginMap: Record<keyof TMarginProps, string> = {
   mx: 'marginHorizontal',
 };
 
-const marginMapKeys = Object.keys(marginMap);
+export const marginPropKeys = Object.keys(marginMap) as (keyof TMarginProps)[];
+
+export function omitMarginProps<T extends Record<string, any>>(props: T) {
+  const cloneProps: Record<string, any> = { ...props };
+
+  for (const key of marginPropKeys) {
+    delete cloneProps[key];
+  }
+
+  return cloneProps as Omit<T, keyof TMarginProps>;
+}
 
 export const getMarginStyles = (props: TMarginProps) => {
   if (!props) {
@@ -28,8 +38,8 @@ export const getMarginStyles = (props: TMarginProps) => {
 
   const styles: Record<string, number> = {};
 
-  for (const key of marginMapKeys) {
-    const marginProp = props[key as keyof TMarginProps];
+  for (const key of marginPropKeys) {
+    const marginProp = props[key];
 
     if (!marginProp) {
       continue;

--- a/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
@@ -5,6 +5,7 @@ import {
   Spacings,
   TMarginProps,
   getMarginStyles,
+  omitMarginProps,
 } from '@monorepo/expo/shared/static';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { format as dateFnsFormat } from 'date-fns';
@@ -41,18 +42,17 @@ export function DatePicker(props: IDatePickerProps) {
     label,
     onChange,
     error,
-    required,
-    disabled,
     style,
     minDate,
     maxDate,
     mode,
-    placeholder,
     format = 'MM/dd/yyyy',
     value,
     ...rest
   } = props;
   const [pickerVisible, setPickerVisible] = useState(false);
+
+  const nonMarginOtherProps = omitMarginProps(rest);
 
   return (
     <View
@@ -66,9 +66,6 @@ export function DatePicker(props: IDatePickerProps) {
     >
       <Input
         asSelect
-        disabled={disabled}
-        required={required}
-        placeholder={placeholder}
         value={value ? dateFnsFormat(value, format) : undefined}
         label={label}
         error={!!error}
@@ -83,7 +80,7 @@ export function DatePicker(props: IDatePickerProps) {
           accessibilityLabel: 'date selector',
           accessibilityHint: `opens date selector for ${label || 'date field'}`,
         }}
-        {...rest}
+        {...nonMarginOtherProps}
       />
       {pickerVisible && (
         <View style={{ marginTop: Spacings.xs }}>

--- a/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/DatePicker_V2/DatePicker.tsx
@@ -1,7 +1,6 @@
 import { CalendarLineIcon, ClockIcon } from '@monorepo/expo/shared/icons';
 import {
   Colors,
-  FontSizes,
   Radiuses,
   Spacings,
   TMarginProps,
@@ -10,43 +9,30 @@ import {
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { format as dateFnsFormat } from 'date-fns';
 import { useState } from 'react';
-import { RegisterOptions } from 'react-hook-form';
 import {
   Keyboard,
   Platform,
-  Pressable,
   StyleProp,
   StyleSheet,
-  Text,
-  TextInput,
   View,
   ViewStyle,
 } from 'react-native';
 import Button from '../Button';
-
-type TRules = Omit<
-  RegisterOptions,
-  'disabled' | 'valueAsNumber' | 'valueAsDate' | 'setValueAs'
->;
+import Input from '../Input_V2';
 
 interface IDatePickerProps extends TMarginProps {
-  label?: string;
   mode: 'date' | 'time';
-  height?: 40 | 56 | 200;
+  onChange: (date: Date) => void;
+  style?: StyleProp<ViewStyle>;
+  label?: string;
   placeholder?: string;
   required?: boolean;
-  pattern?: RegExp;
   disabled?: boolean;
-  error?: boolean;
-  rules?: TRules;
+  error?: string;
   format: string;
-  componentStyle?: StyleProp<ViewStyle>;
   onBlur?: () => void;
   minDate?: Date;
   maxDate?: Date;
-  pickerMode?: 'countdown' | 'date' | 'time' | 'datetime';
-  onChange: (date: Date) => void;
-  initialDate?: Date;
   value?: Date | null;
 }
 
@@ -57,78 +43,48 @@ export function DatePicker(props: IDatePickerProps) {
     error,
     required,
     disabled,
-    componentStyle,
-    height = 56,
+    style,
     minDate,
     maxDate,
     mode,
     placeholder,
     format = 'MM/dd/yyyy',
-    pattern,
-    initialDate,
     value,
     ...rest
   } = props;
-
   const [pickerVisible, setPickerVisible] = useState(false);
 
   return (
     <View
       style={[
-        styles.inputContainer,
-        componentStyle,
+        styles.container,
         {
           ...getMarginStyles(props),
         },
+        style,
       ]}
     >
-      {label && (
-        <View style={styles.label}>
-          <Text style={styles.labelText}>{label}</Text>
-          {required && <Text style={styles.required}>*</Text>}
-        </View>
-      )}
-
-      <View
-        style={[
-          styles.input,
-          {
-            borderColor: error ? 'red' : Colors.NEUTRAL_LIGHT,
-          },
-        ]}
-      >
-        <TextInput
-          placeholder={placeholder}
-          maxLength={18}
-          style={[
-            styles.textInput,
-            {
-              height,
-              ...Platform.select({
-                web: {
-                  outline: 'none',
-                },
-              }),
-            },
-          ]}
-          value={value ? dateFnsFormat(value, format) : undefined}
-          editable={!disabled}
-          {...rest}
-        />
-        <Pressable
-          accessible
-          accessibilityRole="button"
-          accessibilityLabel="open date picker"
-          accessibilityHint="Opens the date picker to select a date"
-          onPress={() => {
-            setPickerVisible(true);
-            Keyboard.dismiss();
-          }}
-          style={styles.icon}
-        >
-          <FieldIcon mode={mode} />
-        </Pressable>
-      </View>
+      <Input
+        asSelect
+        disabled={disabled}
+        required={required}
+        placeholder={placeholder}
+        value={value ? dateFnsFormat(value, format) : undefined}
+        label={label}
+        error={!!error}
+        errorMessage={error}
+        onFocus={() => {
+          setPickerVisible(!pickerVisible);
+          Keyboard.dismiss();
+        }}
+        slotRight={{
+          focusableInput: true,
+          component: <FieldIcon mode={mode} />,
+          accessibilityLabel: 'date selector',
+          accessibilityHint: `opens date selector for ${label || 'date field'}`,
+        }}
+        {...rest}
+      />
       {pickerVisible && (
         <View style={{ marginTop: Spacings.xs }}>
           <DateTimePicker
@@ -181,52 +137,12 @@ function FieldIcon({ mode }: { mode: 'date' | 'time' }) {
 }
 
 const styles = StyleSheet.create({
-  inputContainer: {
-    position: 'relative',
+  container: {
     width: '100%',
-  },
-  input: {
-    position: 'relative',
-    fontFamily: 'Poppins-Regular',
-    backgroundColor: Colors.WHITE,
-    borderWidth: 1,
-    borderRadius: Radiuses.xs,
-    justifyContent: 'center',
-  },
-  textInput: {
-    color: Colors.PRIMARY_EXTRA_DARK,
-    paddingLeft: Spacings.sm,
-    paddingRight: 38,
-    fontFamily: 'Poppins-Regular',
-    fontSize: FontSizes.md.fontSize,
   },
   dateTimePicker: {
     backgroundColor: Colors.WHITE,
     borderRadius: Radiuses.xs,
     overflow: 'hidden',
-  },
-  label: {
-    flexDirection: 'row',
-    marginBottom: Spacings.xs,
-  },
-  labelText: {
-    fontSize: FontSizes.sm.fontSize,
-    lineHeight: FontSizes.sm.lineHeight,
-    color: Colors.PRIMARY_EXTRA_DARK,
-    fontFamily: 'Poppins-Regular',
-  },
-  required: {
-    marginLeft: 2,
-    color: 'red',
-  },
-  icon: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    width: '100%',
-    height: '100%',
-    alignItems: 'flex-end',
-    justifyContent: 'center',
-    paddingRight: Spacings.sm,
   },
 });

--- a/libs/expo/shared/ui-components/src/lib/Input_V2/Input.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Input_V2/Input.tsx
@@ -1,15 +1,15 @@
-import { PlusIcon } from '@monorepo/expo/shared/icons';
+import { ChevronLeftIcon } from '@monorepo/expo/shared/icons';
 import {
   Colors,
   FontSizes,
   Radiuses,
   Spacings,
-  TSpacing,
+  TMarginProps,
+  getMarginStyles,
 } from '@monorepo/expo/shared/static';
-import { ReactNode } from 'react';
+import { useRef } from 'react';
 import {
   Platform,
-  Pressable,
   StyleProp,
   StyleSheet,
   TextInput,
@@ -19,24 +19,28 @@ import {
 } from 'react-native';
 import FormFieldError from '../FormFieldError';
 import FormFieldLabel from '../FormFieldLabel';
+import { InputClearIcon } from './InputClearIcon';
+import { InputSlot, TInputSlot } from './InputSlot';
 
-export interface IInputProps extends TextInputProps {
+export interface IInputProps extends TMarginProps, TextInputProps {
   label?: string;
   required?: boolean;
   disabled?: boolean;
   error?: boolean;
   errorMessage?: string;
-  componentStyle?: StyleProp<ViewStyle>;
-  mb?: TSpacing;
-  mt?: TSpacing;
-  my?: TSpacing;
-  mx?: TSpacing;
-  ml?: TSpacing;
-  mr?: TSpacing;
-  icon?: ReactNode;
-  onDelete?: () => void;
+  style?: StyleProp<ViewStyle>;
+  inputStyle?: StyleProp<ViewStyle>;
   borderRadius?: number;
+  onDelete?: () => void;
+  slotLeft?: TInputSlot;
+  slotRight?: TInputSlot;
+  asPicker?: boolean;
 }
+
+const defaultAsPickerProps: TextInputProps = {
+  showSoftInputOnFocus: false,
+  caretHidden: true,
+};
 
 export function Input(props: IInputProps) {
   const {
@@ -44,36 +48,29 @@ export function Input(props: IInputProps) {
     error,
     required,
     disabled,
-    componentStyle,
-    mb,
-    mt,
-    my,
-    mx,
-    ml,
-    mr,
-    icon,
+    style,
+    inputStyle,
     value,
     onDelete,
+    slotLeft,
+    slotRight,
     autoCorrect = false,
     autoCapitalize = 'none',
     borderRadius = Radiuses.xs,
     errorMessage,
-    style,
+    asPicker,
     ...rest
   } = props;
+  const inputRef = useRef<TextInput>(null);
+  const asPickerProps = asPicker ? defaultAsPickerProps : {};
 
   return (
     <View
       style={[
-        styles.inputContainer,
-        componentStyle,
+        styles.container,
+        style,
         {
-          marginBottom: mb && Spacings[mb],
-          marginTop: mt && Spacings[mt],
-          marginLeft: ml && Spacings[ml],
-          marginRight: mr && Spacings[mr],
-          marginHorizontal: mx && Spacings[mx],
-          marginVertical: my && Spacings[my],
+          ...getMarginStyles(props),
         },
       ]}
     >
@@ -82,21 +79,29 @@ export function Input(props: IInputProps) {
         style={[
           styles.input,
           {
-            paddingLeft: icon ? Spacings.sm : 0,
-            borderColor: error ? Colors.ERROR : Colors.NEUTRAL_LIGHT,
+            // borderColor: error ? Colors.ERROR : Colors.NEUTRAL_LIGHT,
+            borderColor: 'green',
             borderRadius,
           },
         ]}
       >
-        {icon}
+        {slotLeft && (
+          <InputSlot
+            placement="left"
+            disabled={disabled}
+            inputRef={inputRef}
+            {...slotLeft}
+          />
+        )}
+
         <TextInput
+          ref={inputRef}
           style={[
             {
               color: disabled
                 ? Colors.NEUTRAL_LIGHT
                 : Colors.PRIMARY_EXTRA_DARK,
-              paddingLeft: icon ? Spacings.xs : Spacings.sm,
-              paddingRight: onDelete ? 38 : Spacings.sm,
+              paddingHorizontal: Spacings.sm,
               flex: 1,
               fontFamily: 'Poppins-Regular',
               fontSize: FontSizes.md.fontSize,
@@ -108,39 +113,59 @@ export function Input(props: IInputProps) {
                 },
               }),
             },
-            style,
+            inputStyle,
           ]}
           editable={!disabled}
           autoCorrect={autoCorrect}
           autoCapitalize={autoCapitalize}
+          {...asPickerProps}
           {...rest}
           value={value}
         />
+
         {value && onDelete && (
-          <Pressable
+          <InputSlot
+            placement="right"
             disabled={disabled}
-            accessible
-            accessibilityRole="button"
-            accessibilityLabel="delete icon"
-            accessibilityHint="deletes input's value"
             onPress={onDelete}
-            style={[{ opacity: disabled ? 0.5 : 1 }, styles.pressable]}
-          >
-            <View style={styles.icon}>
-              <PlusIcon size="xs" rotate="45deg" />
-            </View>
-          </Pressable>
+            accessibilityLabel="clear input"
+            accessibilityHint={`clear value for ${label || 'input'}`}
+            component={<InputClearIcon />}
+          />
+        )}
+
+        {asPicker && (
+          <InputSlot
+            placement="right"
+            inputRef={inputRef}
+            focusableInput={true}
+            disabled={disabled}
+            component={<ChevronLeftIcon size="sm" rotate={'-90deg'} />}
+            accessibilityLabel={`selector for ${label || 'input'}`}
+            accessibilityHint={`opens selector for ${label || 'input'}`}
+          />
+        )}
+
+        {slotRight && (
+          <InputSlot
+            placement="right"
+            disabled={disabled}
+            inputRef={inputRef}
+            {...slotRight}
+          />
         )}
       </View>
+
       {errorMessage && <FormFieldError message={errorMessage} />}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  inputContainer: {
+  container: {
     position: 'relative',
     width: '100%',
+    display: 'flex',
   },
   input: {
     position: 'relative',
@@ -163,22 +188,5 @@ const styles = StyleSheet.create({
   required: {
     marginLeft: 2,
     color: 'red',
-  },
-  pressable: {
-    position: 'absolute',
-    top: 12,
-    right: Spacings.xs,
-    height: Spacings.lg,
-    width: Spacings.lg,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  icon: {
-    height: Spacings.sm,
-    width: Spacings.sm,
-    backgroundColor: Colors.NEUTRAL_LIGHT,
-    borderRadius: Radiuses.xxxl,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
 });

--- a/libs/expo/shared/ui-components/src/lib/Input_V2/Input.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Input_V2/Input.tsx
@@ -5,6 +5,7 @@ import {
   Spacings,
   TMarginProps,
   getMarginStyles,
+  omitMarginProps,
 } from '@monorepo/expo/shared/static';
 import { useRef } from 'react';
 import {
@@ -60,7 +61,9 @@ export function Input(props: IInputProps) {
     asSelect,
     ...rest
   } = props;
+
   const inputRef = useRef<TextInput>(null);
+  const nonMarginOtherProps = omitMarginProps(rest);
   const asSelectProps = asSelect ? defaultAsSelectProps : {};
 
   return (
@@ -117,7 +120,7 @@ export function Input(props: IInputProps) {
           autoCorrect={autoCorrect}
           autoCapitalize={autoCapitalize}
           {...asSelectProps}
-          {...rest}
+          {...nonMarginOtherProps}
           value={value}
         />
 
@@ -173,6 +176,6 @@ const styles = StyleSheet.create({
   },
   required: {
     marginLeft: 2,
-    color: 'red',
+    color: Colors.ERROR_DARK,
   },
 });

--- a/libs/expo/shared/ui-components/src/lib/Input_V2/Input.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Input_V2/Input.tsx
@@ -1,4 +1,3 @@
-import { ChevronLeftIcon } from '@monorepo/expo/shared/icons';
 import {
   Colors,
   FontSizes,
@@ -34,10 +33,10 @@ export interface IInputProps extends TMarginProps, TextInputProps {
   onDelete?: () => void;
   slotLeft?: TInputSlot;
   slotRight?: TInputSlot;
-  asPicker?: boolean;
+  asSelect?: boolean;
 }
 
-const defaultAsPickerProps: TextInputProps = {
+const defaultAsSelectProps: TextInputProps = {
   showSoftInputOnFocus: false,
   caretHidden: true,
 };
@@ -58,11 +57,11 @@ export function Input(props: IInputProps) {
     autoCapitalize = 'none',
     borderRadius = Radiuses.xs,
     errorMessage,
-    asPicker,
+    asSelect,
     ...rest
   } = props;
   const inputRef = useRef<TextInput>(null);
-  const asPickerProps = asPicker ? defaultAsPickerProps : {};
+  const asSelectProps = asSelect ? defaultAsSelectProps : {};
 
   return (
     <View
@@ -79,8 +78,7 @@ export function Input(props: IInputProps) {
         style={[
           styles.input,
           {
-            // borderColor: error ? Colors.ERROR : Colors.NEUTRAL_LIGHT,
-            borderColor: 'green',
+            borderColor: error ? Colors.ERROR : Colors.NEUTRAL_LIGHT,
             borderRadius,
           },
         ]}
@@ -118,7 +116,7 @@ export function Input(props: IInputProps) {
           editable={!disabled}
           autoCorrect={autoCorrect}
           autoCapitalize={autoCapitalize}
-          {...asPickerProps}
+          {...asSelectProps}
           {...rest}
           value={value}
         />
@@ -131,18 +129,6 @@ export function Input(props: IInputProps) {
             accessibilityLabel="clear input"
             accessibilityHint={`clear value for ${label || 'input'}`}
             component={<InputClearIcon />}
-          />
-        )}
-
-        {asPicker && (
-          <InputSlot
-            placement="right"
-            inputRef={inputRef}
-            focusableInput={true}
-            disabled={disabled}
-            component={<ChevronLeftIcon size="sm" rotate={'-90deg'} />}
-            accessibilityLabel={`selector for ${label || 'input'}`}
-            accessibilityHint={`opens selector for ${label || 'input'}`}
           />
         )}
 

--- a/libs/expo/shared/ui-components/src/lib/Input_V2/InputClearIcon.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Input_V2/InputClearIcon.tsx
@@ -1,0 +1,22 @@
+import { PlusIcon } from '@monorepo/expo/shared/icons';
+import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
+import { StyleSheet, View } from 'react-native';
+
+export function InputClearIcon() {
+  return (
+    <View style={styles.container}>
+      <PlusIcon size="xs" rotate="45deg" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: Spacings.sm,
+    width: Spacings.sm,
+    backgroundColor: Colors.NEUTRAL_LIGHT,
+    borderRadius: Radiuses.xxxl,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/libs/expo/shared/ui-components/src/lib/Input_V2/InputSlot.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Input_V2/InputSlot.tsx
@@ -1,0 +1,95 @@
+import { Spacings } from '@monorepo/expo/shared/static';
+import { ReactNode } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  TextInput,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+export type TInputSlot = {
+  component: ReactNode;
+  style?: ViewStyle;
+  disabledStyle?: ViewStyle;
+  onPress?: () => void;
+  focusableInput?: boolean;
+  accessibilityLabel?: string;
+  accessibilityHint?: string;
+};
+
+interface TProps extends TInputSlot {
+  placement: 'left' | 'right';
+  disabled?: boolean;
+  inputRef?: React.RefObject<TextInput>;
+}
+
+export function InputSlot(props: TProps) {
+  const {
+    style,
+    placement,
+    disabledStyle,
+    onPress,
+    focusableInput,
+    disabled,
+    accessibilityLabel,
+    accessibilityHint,
+    component,
+    inputRef,
+  } = props;
+
+  const disabledStyles = disabledStyle || { opacity: disabled ? 0.5 : 1 };
+  const placementStyles =
+    placement === 'left' ? styles.slotLeft : styles.slotRight;
+
+  const slotStyle = [
+    styles.container,
+    { ...placementStyles },
+    { ...disabledStyles },
+    style,
+  ];
+
+  const handlePress = () => {
+    if (disabled) {
+      return;
+    }
+
+    if (focusableInput) {
+      inputRef?.current?.focus();
+    }
+
+    if (onPress) {
+      onPress();
+    }
+  };
+
+  if (onPress || focusableInput) {
+    return (
+      <Pressable
+        style={slotStyle}
+        onPress={handlePress}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
+      >
+        <View>{component}</View>
+      </Pressable>
+    );
+  }
+
+  return <View style={slotStyle}>{component}</View>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  slotLeft: {
+    paddingLeft: Spacings.sm,
+  },
+  slotRight: {
+    paddingRight: Spacings.sm,
+  },
+});

--- a/libs/expo/shared/ui-components/src/lib/Input_V2/InputSlot.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Input_V2/InputSlot.tsx
@@ -13,7 +13,7 @@ export type TInputSlot = {
   style?: ViewStyle;
   disabledStyle?: ViewStyle;
   onPress?: () => void;
-  focusableInput?: boolean;
+  focusableInput?: boolean; // if true, will trigger focus on inputRef
   accessibilityLabel?: string;
   accessibilityHint?: string;
 };

--- a/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.ios.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.ios.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeftIcon } from '@monorepo/expo/shared/icons';
 import {
   Colors,
   Radiuses,
@@ -81,7 +82,7 @@ export default function Picker(props: IPickerProps) {
         ]}
       >
         <Input
-          asPicker
+          asSelect
           disabled={disabled}
           required={required}
           placeholder={placeholder}
@@ -92,6 +93,12 @@ export default function Picker(props: IPickerProps) {
           onFocus={() => {
             Keyboard.dismiss();
             setIsModalVisible(true);
+          }}
+          slotRight={{
+            focusableInput: true,
+            component: <ChevronLeftIcon size="sm" rotate={'-90deg'} />,
+            accessibilityLabel: `selector for ${label || 'field'}`,
+            accessibilityHint: `opens selector for ${label || 'field'}`,
           }}
         />
       </View>

--- a/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.ios.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.ios.tsx
@@ -1,20 +1,28 @@
-import { ChevronLeftIcon } from '@monorepo/expo/shared/icons';
-import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
+import {
+  Colors,
+  Radiuses,
+  Spacings,
+  getMarginStyles,
+} from '@monorepo/expo/shared/static';
 import { Picker as RNPicker } from '@react-native-picker/picker';
-import { useEffect, useState } from 'react';
-import { Pressable, SafeAreaView, StyleSheet, View } from 'react-native';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Keyboard,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  View,
+} from 'react-native';
 import Modal from 'react-native-modal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import FormFieldLabel from '../FormFieldLabel';
+import Input from '../Input_V2';
 import TextBold from '../TextBold';
-import TextRegular from '../TextRegular';
 import { IPickerProps } from './Picker';
 
 export default function Picker(props: IPickerProps) {
   const {
     onChange,
     error,
-    selectedDisplayValue,
     selectedValue,
     placeholder,
     allowSelectNone,
@@ -23,16 +31,8 @@ export default function Picker(props: IPickerProps) {
     label,
     required,
     disabled,
-    mb,
-    mt,
-    my,
-    mx,
-    mr,
-    ml,
   } = props;
-
   const [localValue, setLocalValue] = useState<string | null>(null);
-
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
 
   useEffect(() => {
@@ -40,6 +40,7 @@ export default function Picker(props: IPickerProps) {
   }, [selectedValue, setLocalValue]);
 
   function onPressDone() {
+    Keyboard.dismiss();
     setIsModalVisible(false);
 
     if (localValue) {
@@ -57,53 +58,42 @@ export default function Picker(props: IPickerProps) {
     onChange(items[0].value);
   }
 
+  const getDisplayValue = useCallback(
+    (value?: string | null) => {
+      const item = items.find((item) => item.value === value);
+
+      return item?.displayValue ?? item?.value;
+    },
+    [items]
+  );
+
   const insets = useSafeAreaInsets();
   const bottomOffset = insets.bottom;
 
   return (
     <>
-      <View>
-        {label && <FormFieldLabel label={label} required={required} />}
-
-        <Pressable
+      <View
+        style={[
+          {
+            borderColor: error ? Colors.ERROR : Colors.NEUTRAL_LIGHT,
+            ...getMarginStyles(props),
+          },
+        ]}
+      >
+        <Input
+          asPicker
           disabled={disabled}
-          onPress={() => setIsModalVisible(true)}
-          style={[
-            styles.selectButton,
-            {
-              borderColor: error ? Colors.ERROR : Colors.NEUTRAL_LIGHT,
-              marginBottom: mb && Spacings[mb],
-              marginTop: mt && Spacings[mt],
-              marginLeft: ml && Spacings[ml],
-              marginRight: mr && Spacings[mr],
-              marginHorizontal: mx && Spacings[mx],
-              marginVertical: my && Spacings[my],
-            },
-          ]}
-          accessibilityRole="button"
-        >
-          <TextRegular
-            color={
-              disabled
-                ? Colors.NEUTRAL_LIGHT
-                : selectedDisplayValue || selectedValue
-                ? Colors.PRIMARY_EXTRA_DARK
-                : Colors.NEUTRAL
-            }
-          >
-            {selectedDisplayValue || selectedValue || placeholder}
-          </TextRegular>
-          <ChevronLeftIcon
-            size="sm"
-            rotate={'-90deg'}
-            color={disabled ? Colors.NEUTRAL_LIGHT : Colors.PRIMARY_EXTRA_DARK}
-          />
-        </Pressable>
-        {error && (
-          <TextRegular size="sm" mt="xxs" color={Colors.ERROR}>
-            {error}
-          </TextRegular>
-        )}
+          required={required}
+          placeholder={placeholder}
+          value={getDisplayValue(localValue)}
+          label={label}
+          error={!!error}
+          errorMessage={error}
+          onFocus={() => {
+            Keyboard.dismiss();
+            setIsModalVisible(true);
+          }}
+        />
       </View>
       <Modal
         style={styles.modal}
@@ -159,16 +149,6 @@ export default function Picker(props: IPickerProps) {
 }
 
 const styles = StyleSheet.create({
-  selectButton: {
-    backgroundColor: Colors.WHITE,
-    height: 56,
-    paddingHorizontal: Spacings.sm,
-    borderWidth: 1,
-    borderRadius: Radiuses.xs,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
   modal: {
     margin: 0,
     flex: 1,

--- a/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.tsx
@@ -2,7 +2,8 @@ import {
   Colors,
   Radiuses,
   Spacings,
-  TSpacing,
+  TMarginProps,
+  getMarginStyles,
 } from '@monorepo/expo/shared/static';
 import { Picker as RNPicker } from '@react-native-picker/picker';
 import { StyleSheet, View } from 'react-native';
@@ -11,24 +12,22 @@ import TextRegular from '../TextRegular';
 
 const NONE_VALUE = '__none__';
 
-export interface IPickerProps {
+export type TPickerItem = {
+  displayValue?: string;
+  value: string;
+};
+
+export interface IPickerProps extends TMarginProps {
   onChange: (value: string | null) => void;
   error?: string;
   selectedValue?: string | null;
-  selectedDisplayValue?: string | null;
   placeholder: string;
-  items: { displayValue?: string; value: string }[];
+  items: TPickerItem[];
   label?: string;
   required?: boolean;
   disabled?: boolean;
   selectNoneLabel?: string;
   allowSelectNone?: boolean;
-  mb?: TSpacing;
-  mt?: TSpacing;
-  my?: TSpacing;
-  mx?: TSpacing;
-  ml?: TSpacing;
-  mr?: TSpacing;
 }
 
 export default function Picker(props: IPickerProps) {
@@ -43,12 +42,6 @@ export default function Picker(props: IPickerProps) {
     required,
     selectNoneLabel,
     allowSelectNone,
-    mb,
-    mt,
-    my,
-    mx,
-    ml,
-    mr,
   } = props;
 
   const noneLabel = selectNoneLabel || placeholder || 'Selece one';
@@ -66,12 +59,7 @@ export default function Picker(props: IPickerProps) {
           styles.pickerContainer,
           {
             borderColor: error ? Colors.ERROR : Colors.NEUTRAL_LIGHT,
-            marginBottom: mb && Spacings[mb],
-            marginTop: mt && Spacings[mt],
-            marginLeft: ml && Spacings[ml],
-            marginRight: mr && Spacings[mr],
-            marginHorizontal: mx && Spacings[mx],
-            marginVertical: my && Spacings[my],
+            ...getMarginStyles(props),
           },
         ]}
       >

--- a/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Picker_V2/Picker.tsx
@@ -88,12 +88,12 @@ export default function Picker(props: IPickerProps) {
             />
           ))}
         </RNPicker>
-        {error && (
-          <TextRegular size="sm" color={Colors.ERROR}>
-            {error}
-          </TextRegular>
-        )}
       </View>
+      {error && (
+        <TextRegular mt="xxs" size="sm" color={Colors.ERROR}>
+          {error}
+        </TextRegular>
+      )}
     </View>
   );
 }

--- a/libs/expo/shared/ui-components/src/lib/SingleSelect/SingleSelect.tsx
+++ b/libs/expo/shared/ui-components/src/lib/SingleSelect/SingleSelect.tsx
@@ -1,16 +1,16 @@
-import { Colors, Spacings, TSpacing } from '@monorepo/expo/shared/static';
+import {
+  Colors,
+  Spacings,
+  TMarginProps,
+  getMarginStyles,
+} from '@monorepo/expo/shared/static';
 import { View } from 'react-native';
+import FormFieldLabel from '../FormFieldLabel';
 import Picker from '../Picker_V2';
 import Radio from '../Radio_V2';
 import TextRegular from '../TextRegular';
 
-interface ISingleSelectProps {
-  mb?: TSpacing;
-  mt?: TSpacing;
-  my?: TSpacing;
-  mx?: TSpacing;
-  ml?: TSpacing;
-  mr?: TSpacing;
+interface ISingleSelectProps extends TMarginProps {
   label?: string;
   placeholder?: string;
   onChange: (value: string | null) => void;
@@ -27,22 +27,15 @@ interface ISingleSelectProps {
 export function SingleSelect(props: ISingleSelectProps) {
   const {
     items,
-    mb,
-    mt,
-    mr,
-    ml,
-    my,
-    mx,
     label,
     onChange,
     required,
     disabled,
     placeholder = '',
     selectedValue,
-    selectNoneLabel,
-    allowSelectNone,
     error,
     maxRadioItems = 3,
+    ...rest
   } = props;
 
   const asSelect = items.length > maxRadioItems;
@@ -59,15 +52,8 @@ export function SingleSelect(props: ISingleSelectProps) {
         onChange={onChange}
         disabled={disabled}
         placeholder={placeholder}
-        selectNoneLabel={selectNoneLabel}
-        allowSelectNone={allowSelectNone}
         items={items}
-        mb={mb}
-        mt={mt}
-        mr={mr}
-        ml={ml}
-        my={my}
-        mx={mx}
+        {...rest}
       />
     );
   }
@@ -75,15 +61,12 @@ export function SingleSelect(props: ISingleSelectProps) {
   return (
     <View
       style={{
-        marginBottom: mb && Spacings[mb],
-        marginTop: mt && Spacings[mt],
-        marginLeft: ml && Spacings[ml],
-        marginRight: mr && Spacings[mr],
-        marginHorizontal: mx && Spacings[mx],
-        marginVertical: my && Spacings[my],
+        ...getMarginStyles(props),
         gap: Spacings.xs,
       }}
     >
+      {label && <FormFieldLabel label={label} required={required} />}
+
       {items.map(({ displayValue, value }) => (
         <Radio
           key={value || displayValue}

--- a/libs/expo/shared/ui-components/src/lib/SingleSelect/SingleSelect.tsx
+++ b/libs/expo/shared/ui-components/src/lib/SingleSelect/SingleSelect.tsx
@@ -15,6 +15,7 @@ interface ISingleSelectProps {
   placeholder?: string;
   onChange: (value: string | null) => void;
   items: { displayValue?: string; value: string }[];
+  required?: boolean;
   disabled?: boolean;
   selectedValue?: string;
   selectNoneLabel?: string;
@@ -34,6 +35,7 @@ export function SingleSelect(props: ISingleSelectProps) {
     mx,
     label,
     onChange,
+    required,
     disabled,
     placeholder = '',
     selectedValue,
@@ -52,8 +54,8 @@ export function SingleSelect(props: ISingleSelectProps) {
       <Picker
         error={error}
         label={label}
+        required={required}
         selectedValue={selectedItem?.value}
-        selectedDisplayValue={selectedItem?.displayValue}
         onChange={onChange}
         disabled={disabled}
         placeholder={placeholder}


### PR DESCRIPTION
### Blur input field after Picker is selected
https://betterangels.atlassian.net/browse/DEV-1774


- `Input_V2` updates
  - add `asSelect` option for input that is meant to be "inactive" (a focusable input used with inputs like Picker etc...)
  -  add left and right `slots` to render content on left/right of the input, with option to focus input on Click
- update `Picker_V2 iOS` to use `Input_V2` to render value
- update `DatePicker_V2` to use `Input_V2` to render value
- update components to use `TMarginProps` with getMarginStyles helper

## Summary by Sourcery

Refactor `DatePicker_V2` and `Picker_V2` (iOS) to use the enhanced `Input_V2` component for a consistent input appearance and improved interaction behavior.

New Features:
- Add `slotLeft` and `slotRight` props to `Input_V2` for rendering components within its borders.
- Add `asSelect` prop to `Input_V2` to configure it for triggering pickers/selects without showing the keyboard.

Bug Fixes:
- Prevent keyboard display when opening `DatePicker_V2` and `Picker_V2` (iOS).

Enhancements:
- Utilize `Input_V2` within `DatePicker_V2`.
- Utilize `Input_V2` within `Picker_V2` (iOS).
- Standardize margin prop handling across UI components using new helpers.
- Update form components to align with revised `DatePicker`, `Picker`, and `SingleSelect` props.

Chores:
- Introduce reusable `InputSlot` and `InputClearIcon` components.
- Add `omitMarginProps` helper function to static styles library.