### PR TITLE
update ExpandableContainer to manage state internally or externally (DEV-1775)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ExpandableProfileContainer.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ExpandableProfileContainer.tsx
@@ -33,7 +33,7 @@ export function ExpandableProfileContainer(props: TProps) {
   );
 
   return (
-    <ExpandableContainer isOpen={isOpen} header={header}>
+    <ExpandableContainer controlled isOpen={isOpen} header={header}>
       {children}
     </ExpandableContainer>
   );


### PR DESCRIPTION
### Update ExpandableContainer to work as controlled or not controlled component
https://betterangels.atlassian.net/browse/DEV-1775

## Summary by Sourcery

Allow the `ExpandableContainer` component to manage its expanded state internally or be controlled externally via props.

Enhancements:
- Add support for both controlled (via `isOpen` and `onToggle` props) and uncontrolled (via `defaultOpen` prop and internal state) modes.
- Rename the `onClick` prop to `onToggle`.