### PR TITLE
render physical description and ada accommodation on demographic card (DEV-1677)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/DemographicInfoCard.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/DemographicInfoCard.tsx
@@ -39,6 +39,7 @@ export function DemographicInfoCard(props: TProps) {
   });
 
   const adaAccommodationDisplay = (adaAccommodation || [])
+    .filter((key) => !!key)
     .map((key) => enumDisplayAdaAccommodationEnum[key])
     .join(', ');
 

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/DemographicInfoCard.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile_V2/ClientProfileCards/DemographicInfoCard.tsx
@@ -1,5 +1,6 @@
 import { getFormattedLength } from '@monorepo/expo/shared/ui-components';
 import {
+  enumDisplayAdaAccommodationEnum,
   enumDisplayEyeColor,
   enumDisplayHairColor,
   enumDisplayRace,
@@ -26,6 +27,8 @@ export function DemographicInfoCard(props: TProps) {
     heightInInches,
     placeOfBirth,
     race,
+    physicalDescription,
+    adaAccommodation,
   } = clientProfile || {};
 
   const formattedHeight = getFormattedLength({
@@ -34,6 +37,10 @@ export function DemographicInfoCard(props: TProps) {
     outputUnit: 'inches',
     format: 'feet-inches-symbol',
   });
+
+  const adaAccommodationDisplay = (adaAccommodation || [])
+    .map((key) => enumDisplayAdaAccommodationEnum[key])
+    .join(', ');
 
   const content: TClientProfileCardItem[] = [
     {
@@ -63,6 +70,14 @@ export function DemographicInfoCard(props: TProps) {
     {
       header: ['Hair Color'],
       rows: [[hairColor && enumDisplayHairColor[hairColor]]],
+    },
+    {
+      header: ['Physical Description'],
+      rows: [[physicalDescription]],
+    },
+    {
+      header: ['ADA Accommodation'],
+      rows: [[adaAccommodationDisplay]],
     },
   ];
 


### PR DESCRIPTION
### [CPR - Demographic Info View] Physical Description and ADA fields are missing
https://betterangels.atlassian.net/browse/DEV-1677

## Summary by Sourcery

Add display of physical description and ADA accommodation to the client's demographic information card.

New Features:
- Display the client's physical description.
- Display the client's ADA accommodations.