### PR TITLE
Case Manager Not Showing Up (DEV-1687)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Clients/Clients.graphql
+++ b/libs/expo/betterangels/src/lib/screens/Clients/Clients.graphql
@@ -60,7 +60,6 @@ query ClientProfiles(
         name
         url
       }
-      displayCaseManager # TODO: This shouldn't be here. Temporary fix while we figure out type generation.
     }
   }
 }

--- a/libs/expo/betterangels/src/lib/screens/Clients/__generated__/Clients.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/Clients/__generated__/Clients.generated.ts
@@ -105,7 +105,6 @@ export const ClientProfilesDocument = gql`
         name
         url
       }
-      displayCaseManager
     }
   }
 }


### PR DESCRIPTION
[DEV-1687](https://betterangels.atlassian.net/browse/DEV-1687)

The issue was that the case manager's name was not being saved on the client's page once you exited the page. I removed a field from a GraphQL query that was overwriting the case manager in the centralized Apollo Client cache, which solved the problem.