### PR TITLE
Fix Runtime Version

### DIFF
--- a/libs/expo/betterangels/src/lib/hooks/expoUpdates/useAppVersion.ts
+++ b/libs/expo/betterangels/src/lib/hooks/expoUpdates/useAppVersion.ts
@@ -5,8 +5,8 @@ import * as Updates from 'expo-updates';
 export default function useAppVersion() {
   return {
     version: Constants.expoConfig?.version,
-    runtimeVersion: Constants.manifest2?.runtimeVersion,
-    runtimeVersionShort: Constants.manifest2?.runtimeVersion?.slice(-12),
+    runtimeVersion: Updates.runtimeVersion,
+    runtimeVersionShort: Updates.runtimeVersion?.slice(-12),
     nativeApplicationVersion: Application.nativeApplicationVersion,
     otaUpdateId: Updates.updateId,
     otaUpdateIdShort: Updates.updateId?.slice(-12),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Switch runtimeVersion and its short form to use Updates.runtimeVersion instead of Constants.manifest2