### PR TITLE
interaction note starts empty (DEV-1020)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/PublicNote/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/PublicNote/index.tsx
@@ -27,7 +27,6 @@ export default function PublicNote({ noteId }: { noteId: string }) {
   const [updateNote, { error }] = useUpdateNoteMutation();
   const [autoNote, setAutoNote] = useState<string>('');
   const [publicNote, setPublicNote] = useState<string>('');
-  const [userChange, setUserChange] = useState(false);
 
   const router = useRouter();
   const insets = useSafeAreaInsets();
@@ -57,13 +56,12 @@ export default function PublicNote({ noteId }: { noteId: string }) {
   ).current;
 
   const onChange = (value: string) => {
-    setUserChange(true);
     setPublicNote(value);
     updateNoteFunction(value);
   };
 
   useEffect(() => {
-    if (!data || !('note' in data) || userChange) return;
+    if (!data || !('note' in data)) return;
     const autoNote = generatePublicNote({
       purpose: data.note.purpose,
       moods: data.note.moods,
@@ -72,7 +70,8 @@ export default function PublicNote({ noteId }: { noteId: string }) {
     });
 
     setAutoNote(autoNote);
-  }, [data, userChange]);
+    setPublicNote(data.note.publicDetails);
+  }, [data]);
 
   if (isLoading) {
     return <LoadingView />;
@@ -132,9 +131,12 @@ export default function PublicNote({ noteId }: { noteId: string }) {
           <Button
             onPress={() => {
               if (!publicNote) {
-                return setPublicNote(autoNote);
+                setPublicNote(autoNote);
+                onChange(autoNote);
+              } else {
+                setPublicNote('');
+                onChange('');
               }
-              onChange('');
             }}
             height="xl"
             accessibilityHint="Generates or clears GIRP note"

--- a/libs/expo/betterangels/src/lib/screens/PublicNote/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/PublicNote/index.tsx
@@ -72,12 +72,6 @@ export default function PublicNote({ noteId }: { noteId: string }) {
     });
 
     setAutoNote(autoNote);
-
-    if (data.note.publicDetails) {
-      setPublicNote(data.note.publicDetails);
-    } else {
-      onChange(autoNote);
-    }
   }, [data, userChange]);
 
   if (isLoading) {
@@ -94,22 +88,8 @@ export default function PublicNote({ noteId }: { noteId: string }) {
           }}
         >
           <TextBold size="lg">Write Note</TextBold>
-          {autoNote !== publicNote && (
-            <View
-              style={{
-                padding: Spacings.xs,
-                borderRadius: Radiuses.xs,
-                backgroundColor: Colors.WARNING_EXTRA_LIGHT,
-              }}
-            >
-              <TextRegular size="sm" color={Colors.WARNING_DARK}>
-                You changed the form above. Please review note text for
-                consistency.
-              </TextRegular>
-            </View>
-          )}
           <TextRegular size="md">
-            Use the generated text below to get started. When finished, click
+            Use the generated text below to get started. When finished, tap
             “Save Note.”
           </TextRegular>
 
@@ -123,7 +103,7 @@ export default function PublicNote({ noteId }: { noteId: string }) {
               accessibilityLabel="Note input"
               style={styles.input}
               placeholder={
-                "Describe your interaction or tap 'Regenerate' to automatically create it in GIRP format"
+                'Tap “Generate” to auto-draft a note in GIRP format. When finished, tap “Save Note.”'
               }
             />
           </View>
@@ -151,16 +131,16 @@ export default function PublicNote({ noteId }: { noteId: string }) {
         >
           <Button
             onPress={() => {
-              if (autoNote !== publicNote) {
+              if (!publicNote) {
                 return setPublicNote(autoNote);
               }
               onChange('');
             }}
             height="xl"
-            accessibilityHint="clears HMIS input"
+            accessibilityHint="Generates or clears GIRP note"
             size="full"
             variant="secondary"
-            title={autoNote !== publicNote ? 'Regenerate' : 'Clear'}
+            title={(!!publicNote && 'Clear') || 'Generate'}
           />
         </View>
 


### PR DESCRIPTION
DEV-1020

## Summary by Sourcery

Initialize the PublicNote interaction input as empty, revamp the generate/clear button behavior and labels, remove the change-warning banner, and update UI text to use “tap” and streamlined instructions.

Enhancements:
- Initialize note input without prepopulated text by removing default population logic
- Remove the change-warning banner shown when editing generated text
- Update Generate/Clear button logic, title, and accessibility hint for GIRP note generation
- Revise UI text to use “tap” instead of “click” and streamline the note placeholder instructions