### PR TITLE
add location history flag (DEV-1735)

### DIFF
--- a/libs/expo/betterangels/src/lib/providers/featureControls/constants.ts
+++ b/libs/expo/betterangels/src/lib/providers/featureControls/constants.ts
@@ -1,6 +1,7 @@
 export const FeatureFlags = {
-  PROFILE_REDESIGN_FF: 'ffClientProfileRedesign',
-  CLIENT_DEDUPE_FF: 'ffClientDedupe',
   APP_UPDATE_PROMPT_FF: 'ffAppUpdatePrompt',
+  CLIENT_DEDUPE_FF: 'ffClientDedupe',
+  LOCATION_HISTORY_FF: 'ffLocationHistory',
+  PROFILE_REDESIGN_FF: 'ffClientProfileRedesign',
   SHOW_DEBUG_INFO_FF: 'ffShowDebugInfo',
 } as const;


### PR DESCRIPTION
DEV-1735

prod
<img width="571" alt="image" src="https://github.com/user-attachments/assets/80635264-8da8-4202-8a51-44244c241273" />

dev
<img width="574" alt="image" src="https://github.com/user-attachments/assets/78428fc8-d779-4509-ad37-43cfc86e04e9" />


## Summary by Sourcery

Add a location history feature flag and adjust the ordering of existing feature flag constants

New Features:
- Introduce a new LOCATION_HISTORY_FF feature flag

Enhancements:
- Reorder feature flag constants for consistency