### PR TITLE
enable default picker item if no selectedValue

### DIFF
--- a/libs/expo/shared/ui-components/src/lib/Picker/Picker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Picker/Picker.tsx
@@ -77,7 +77,7 @@ export default function Picker(props: IPickerProps) {
             color={
               allowSelectNone ? styles.itemStyle.color : Colors.NEUTRAL_DARK
             }
-            enabled={!!allowSelectNone}
+            enabled={!!allowSelectNone || !selectedValue}
           />
           {items.map((item) => (
             <RNPicker.Item


### PR DESCRIPTION
### [Regression - Android] The pickers are not usable on new profile
https://betterangels.atlassian.net/browse/DEV-1825


* makes first Picker Item enabled if there is no selectedValue
  * otherwise it's not clickable when undefined and does not open the picker