### PR TITLE
Dev 1826/android picker backgrounds (DEV-1826)

### DIFF
--- a/libs/expo/shared/ui-components/src/lib/Picker/Picker.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Picker/Picker.tsx
@@ -74,6 +74,7 @@ export default function Picker(props: IPickerProps) {
           <RNPicker.Item
             label={noneLabel}
             value={NONE_VALUE}
+            style={styles.itemStyle}
             color={
               allowSelectNone ? styles.itemStyle.color : Colors.NEUTRAL_DARK
             }
@@ -82,6 +83,7 @@ export default function Picker(props: IPickerProps) {
           {items.map((item) => (
             <RNPicker.Item
               style={styles.itemStyle}
+              color={styles.itemStyle.color}
               key={item.value}
               label={item.displayValue || item.value}
               value={item.value}
@@ -112,5 +114,7 @@ const styles = StyleSheet.create({
   },
   itemStyle: {
     color: Colors.PRIMARY_EXTRA_DARK,
+    borderRadius: Radiuses.xs,
+    backgroundColor: Colors.WHITE,
   },
 });


### PR DESCRIPTION
[Regression - Picker Menu] The CSS of Picker Option menu is not applied
https://betterangels.atlassian.net/browse/DEV-1826

## Summary by Sourcery

Fix regression in Picker component by applying CSS styles to Android picker menu options

Enhancements:
- Apply itemStyle and explicit color to all RNPicker.Item components for consistent styling
- Allow the “none” option to be enabled when no value is selected
- Add backgroundColor and borderRadius to itemStyle to restore intended menu appearance