### PR TITLE
Dev 1551 clear button should be in each filter

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
@@ -68,6 +68,11 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
     setIsModalVisible(false);
   };
 
+  const clearBoxes = () => {
+    setSelected([]);
+    setIsModalVisible(true);
+  }
+
   const handleCloseModal = () => {
     setSelected(filters.authors);
     setIsModalVisible(false);
@@ -159,6 +164,14 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
               </View>
             )}
           </ScrollView>
+
+          <Button
+            onPress={clearBoxes}
+            size="full"
+            title="Clear"
+            variant="primary"
+            accessibilityHint="apply selected created by filter"
+          />
 
           <Button
             onPress={handleOnDone}

--- a/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@monorepo/expo/shared/ui-components';
 import { debounce } from '@monorepo/expo/shared/utils';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { Ordering, SelahTeamEnum } from '../../../../apollo';
 import { useInfiniteScroll, useUser } from '../../../../hooks';
 import { Modal } from '../../../../ui-components';
@@ -71,7 +71,7 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
   const handleClearBoxes = () => {
     setSelected([]);
     setIsModalVisible(true);
-  }
+  };
 
   const handleCloseModal = () => {
     setSelected(filters.authors);
@@ -165,23 +165,26 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
             )}
           </ScrollView>
 
-          <Button
-            onPress={handleClearBoxes}
-            size="full"
-            title="Clear"
-            variant="primary"
-            accessibilityHint="apply selected created by filter"
-          />
+          <View>
+            <Button
+              onPress={handleClearBoxes}
+              size="full"
+              title="Clear"
+              variant="primary"
+              accessibilityHint="apply selected created by filter"
+            />
 
-          <Button
-            onPress={handleOnDone}
-            size="full"
-            title="Done"
-            variant="primary"
-            accessibilityHint="apply selected created by filter"
-          />
+            <Button
+              onPress={handleOnDone}
+              size="full"
+              title="Done"
+              variant="primary"
+              accessibilityHint="apply selected created by filter"
+            />
+          </View>
         </View>
       </Modal>
     </View>
   );
 }
+

--- a/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
@@ -68,7 +68,7 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
     setIsModalVisible(false);
   };
 
-  const clearBoxes = () => {
+  const handleClearBoxes = () => {
     setSelected([]);
     setIsModalVisible(true);
   }
@@ -166,7 +166,7 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
           </ScrollView>
 
           <Button
-            onPress={clearBoxes}
+            onPress={handleClearBoxes}
             size="full"
             title="Clear"
             variant="primary"

--- a/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
@@ -171,7 +171,7 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
               size="md"
               title="Clear"
               variant="secondary"
-              accessibilityHint="apply selected created by filter"
+              accessibilityHint="clear all selected"
             />
 
             <Button

--- a/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
@@ -165,18 +165,18 @@ export default function AuthorsFilter(props: IAuthorsFilterProps) {
             )}
           </ScrollView>
 
-          <View>
+          <View style={{'flexDirection': 'row', 'justifyContent': 'center', 'gap': 10}}>
             <Button
               onPress={handleClearBoxes}
-              size="full"
+              size="md"
               title="Clear"
-              variant="primary"
+              variant="secondary"
               accessibilityHint="apply selected created by filter"
             />
 
             <Button
               onPress={handleOnDone}
-              size="full"
+              size="md"
               title="Done"
               variant="primary"
               accessibilityHint="apply selected created by filter"

--- a/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/AuthorsFilter/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@monorepo/expo/shared/ui-components';
 import { debounce } from '@monorepo/expo/shared/utils';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { Ordering, SelahTeamEnum } from '../../../../apollo';
 import { useInfiniteScroll, useUser } from '../../../../hooks';
 import { Modal } from '../../../../ui-components';

--- a/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/TeamsFilter.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/InteractionsFilters/TeamsFilter.tsx
@@ -39,6 +39,11 @@ export default function TeamsFilter(props: ITeamFilterProps) {
     setIsModalVisible(false);
   };
 
+  const handleClearBoxes = () => {
+    setSelected([]);
+    setIsModalVisible(true);
+  };
+
   const handleCloseModal = () => {
     setSelected(filters.teams);
     setIsModalVisible(false);
@@ -82,13 +87,26 @@ export default function TeamsFilter(props: ITeamFilterProps) {
               labelKey="label"
             />
           </ScrollView>
-          <Button
-            onPress={handleOnDone}
-            size="full"
-            title="Done"
-            variant="primary"
-            accessibilityHint="apply selected teams filter"
-          />
+
+          <View
+            style={{ flexDirection: 'row', justifyContent: 'center', gap: 10 }}
+          >
+            <Button
+              onPress={handleClearBoxes}
+              size="md"
+              title="Clear"
+              variant="secondary"
+              accessibilityHint="clear all selected"
+            />
+
+            <Button
+              onPress={handleOnDone}
+              size="md"
+              title="Done"
+              variant="primary"
+              accessibilityHint="apply selected teams filter"
+            />
+          </View>
         </View>
       </Modal>
     </View>

--- a/libs/expo/shared/ui-components/src/lib/Button/Button.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Button/Button.tsx
@@ -25,8 +25,9 @@ type TVariants = {
   };
 };
 
-const SIZES: Record<'sm' | 'full' | 'auto', DimensionValue> = {
+const SIZES: Record<'sm' | 'md' | 'full' | 'auto', DimensionValue> = {
   sm: 132,
+  md: 155,
   full: '100%',
   auto: 'auto',
 };
@@ -111,7 +112,7 @@ const VARIANTS: TVariants = {
   },
   secondary: {
     bg: Colors.WHITE,
-    color: Colors.PRIMARY_EXTRA_DARK,
+    color: Colors.PRIMARY_DARK,
     border: Colors.NEUTRAL_LIGHT,
   },
   negative: {
@@ -125,7 +126,7 @@ type TSpacing = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 interface IButtonProps {
   title: string;
-  size?: 'sm' | 'full' | 'auto';
+  size?: 'sm' | 'md'| 'full' | 'auto';
   onPress?: () => void;
   variant:
     | 'primary'


### PR DESCRIPTION
[DEV-1551](https://betterangels.atlassian.net/browse/DEV-1551)

This story focuses on implementing a Clear button with the functionality of clearing all checked boxes once pressed.

[DEV-1551]: https://betterangels.atlassian.net/browse/DEV-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a "Clear" button to filter modals to reset all selections and enhance the shared Button component with a new "md" size and updated secondary color

New Features:
- Add "Clear" button in AuthorsFilter modal to reset selected checkboxes

Enhancements:
- Introduce "md" size option for Button component
- Change secondary Button variant color to PRIMARY_DARK