### PR TITLE
fix android oauth (DEV-1840)

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/SocialLogin/GoogleSignIn.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/SocialLogin/GoogleSignIn.tsx
@@ -12,8 +12,7 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { Linking, View } from 'react-native';
-import { useAppState } from '../../hooks';
+import { AppState, Linking, View } from 'react-native';
 import useSignIn from '../../hooks/user/useSignIn';
 
 export const GOOGLE_AUTH_MUTATION = gql`
@@ -73,7 +72,6 @@ export function GoogleSignIn({
 }: GoogleSignInProps) {
   const { signIn } = useSignIn(GOOGLE_AUTH_MUTATION);
   const discovery = AuthSession.useAutoDiscovery(discoveryUrl);
-  const { currentAppState } = useAppState();
   const [generatedState, setGeneratedState] = useState<string | undefined>(
     undefined
   );
@@ -157,7 +155,7 @@ export function GoogleSignIn({
       https://github.com/expo/expo/issues/12044#issuecomment-1431310529
     */
 
-    if (currentAppState === 'active') {
+    if (AppState.currentState === 'active') {
       const listener = (event: { url: string }) => {
         void handleDeepLinking(event.url);
       };
@@ -167,7 +165,7 @@ export function GoogleSignIn({
       };
     }
     return;
-  }, [currentAppState, handleDeepLinking]);
+  }, [handleDeepLinking]);
 
   useEffect(() => {
     void Linking.getInitialURL().then(async (url) => handleDeepLinking(url));

--- a/libs/expo/betterangels/src/lib/ui-components/SocialLogin/GoogleSignIn.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/SocialLogin/GoogleSignIn.tsx
@@ -155,6 +155,7 @@ export function GoogleSignIn({
       https://github.com/expo/expo/issues/12044#issuecomment-1431310529
     */
 
+    // Not using useAppState hook because including it as a dependency breaks oauth on android. (See links above)
     if (AppState.currentState === 'active') {
       const listener = (event: { url: string }) => {
         void handleDeepLinking(event.url);


### PR DESCRIPTION
DEV-1840

removed the hook from google signin because including it in useEffect dependencies broke android oauth

## Summary by Sourcery

Fix Android OAuth flow by replacing the custom useAppState hook with AppState.currentState and adjusting deep link effect dependencies

Bug Fixes:
- Fix Android OAuth flow by replacing the custom useAppState hook with AppState.currentState to avoid broken redirects

Enhancements:
- Simplify deep link handling effect to only depend on handleDeepLinking