### PR TITLE
Bump nginx to `1.28.0`

### DIFF
--- a/apps/nginx/Dockerfile
+++ b/apps/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.27.5
+FROM nginx:1.28.0
 
 COPY ./templates /etc/nginx/templates


### PR DESCRIPTION
Bump nginx to latest version, while also trying to trigger a new deploy.

## Summary by Sourcery

Build:
- Upgrade nginx Docker base image from 1.27.5 to 1.28.0