### PR TITLE
Fix NGINX Image Deploy

### DIFF
--- a/apps/nginx/Dockerfile
+++ b/apps/nginx/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.27.5
+FROM nginx:1.28.0
 
 COPY ./templates /etc/nginx/templates

--- a/apps/nginx/project.json
+++ b/apps/nginx/project.json
@@ -33,12 +33,11 @@
       }
     },
     "deploy": {
+      "command": "tools/deploy/ecs_deploy.sh",
       "configurations": {
+        "production": {},
         "preview": {
           "command": "echo 'Skipping deploy'"
-        },
-        "production": {
-          "command": "tools/deploy/ecs_deploy.sh"
         }
       }
     }


### PR DESCRIPTION
## Summary by Sourcery

Consolidate ECS deploy settings by moving the deploy script to a global default, skipping deployment for preview environments, and update the Nginx base image to the latest patch version.

Bug Fixes:
- Ensure production deployment uses the correct ECS deploy script by centralizing the command in project.json.

Enhancements:
- Set a default deploy command in apps/nginx/project.json and override it to skip deployment for preview configurations.

Chores:
- Bump the Nginx Docker base image from version 1.27.5 to 1.28.0.