### PR TITLE
Release Outreach 1.0.44

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.0.43',
+    version: '1.0.44',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.0.54',
+      buildNumber: '1.0.55',
       associatedDomains: [`applinks:${HOSTNAME}`],
       usesAppleSignIn: true,
       config: {
@@ -73,7 +73,7 @@ export default {
           apiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLEMAPS_APIKEY,
         },
       },
-      versionCode: 53,
+      versionCode: 54,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "expo-image-picker": "~16.1.2",
     "expo-linking": "~7.1.2",
     "expo-location": "~18.1.2",
-    "expo-router": "~5.0.6",
+    "expo-router": "~5.0.7",
     "expo-secure-store": "~14.2.1",
     "expo-sharing": "~13.1.3",
     "expo-splash-screen": "~0.30.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4929,7 +4929,7 @@ __metadata:
     expo-image-picker: "npm:~16.1.2"
     expo-linking: "npm:~7.1.2"
     expo-location: "npm:~18.1.2"
-    expo-router: "npm:~5.0.6"
+    expo-router: "npm:~5.0.7"
     expo-secure-store: "npm:~14.2.1"
     expo-sharing: "npm:~13.1.3"
     expo-splash-screen: "npm:~0.30.5"
@@ -14225,9 +14225,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-router@npm:~5.0.6":
-  version: 5.0.6
-  resolution: "expo-router@npm:5.0.6"
+"expo-router@npm:~5.0.7":
+  version: 5.0.7
+  resolution: "expo-router@npm:5.0.7"
   dependencies:
     "@expo/metro-runtime": "npm:5.0.4"
     "@expo/server": "npm:^0.6.2"
@@ -14258,7 +14258,7 @@ __metadata:
       optional: true
     react-native-reanimated:
       optional: true
-  checksum: 10/aa0a6eda5abdd0b0112fe99825bff52b8455826a718085545cc18fb4c67d79fdc483e3df741e8a98bc75da262825d120ba21256c25ba6a84e280ff7f8026c9a3
+  checksum: 10/3cd0c9db0b56ea2cb48813574ceae38a8210c255a13d4fb58d48aa008a897c0716a674c8887866195c17d01c4ba2b6dc528f78b78d1665180e72c5e4bbcc21bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary by Sourcery

Prepare BetterAngels 1.0.44 release by bumping app version and updating expo-router dependency

Build:
- Bump app version to 1.0.44 with iOS buildNumber 1.0.55 and Android versionCode 54
- Upgrade expo-router to ~5.0.7

Chores:
- Regenerate yarn.lock to reflect dependency changes