### PR TITLE
add org to notetype (DEV-1796)

### DIFF
--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple
 import strawberry
 import strawberry_django
 from accounts.models import User
-from accounts.types import UserType
+from accounts.types import OrganizationType, UserType
 from clients.types import ClientProfileType
 from common.graphql.types import LocationInput, LocationType
 from django.db.models import Case, Exists, F, Q, QuerySet, Value, When
@@ -195,6 +195,7 @@ class NoteFilter:
 @strawberry_django.type(models.Note, pagination=True, filters=NoteFilter, order=NoteOrder)  # type: ignore[literal-required]
 class NoteType:
     id: ID
+    organization: OrganizationType
     purpose: auto
     team: Optional[SelahTeamEnum]
     location: Optional[LocationType]

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1016,6 +1016,7 @@ input NoteOrder {
 
 type NoteType {
   id: ID!
+  organization: OrganizationType!
   purpose: String
   team: SelahTeamEnum
   location: LocationType

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/queries.generated.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/queries.generated.ts
@@ -10,14 +10,14 @@ export type NotesQueryVariables = Types.Exact<{
 }>;
 
 
-export type NotesQuery = { __typename?: 'Query', notes: { __typename?: 'NoteTypeOffsetPaginated', totalCount: number, pageInfo: { __typename?: 'OffsetPaginationInfo', limit?: number | null, offset: number }, results: Array<{ __typename?: 'NoteType', id: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayCaseManager: string, user?: { __typename?: 'UserType', id: string, username: string } | null } | null, createdBy: { __typename?: 'UserType', id: string, email?: string | null, username: string, firstName?: string | null, lastName?: string | null } }> } };
+export type NotesQuery = { __typename?: 'Query', notes: { __typename?: 'NoteTypeOffsetPaginated', totalCount: number, pageInfo: { __typename?: 'OffsetPaginationInfo', limit?: number | null, offset: number }, results: Array<{ __typename?: 'NoteType', id: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, organization: { __typename?: 'OrganizationType', id: string, name: string }, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayCaseManager: string, user?: { __typename?: 'UserType', id: string, username: string } | null } | null, createdBy: { __typename?: 'UserType', id: string, email?: string | null, username: string, firstName?: string | null, lastName?: string | null } }> } };
 
 export type ViewNoteQueryVariables = Types.Exact<{
   id: Types.Scalars['ID']['input'];
 }>;
 
 
-export type ViewNoteQuery = { __typename?: 'Query', note: { __typename?: 'NoteType', id: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, createdAt: any, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null } | null, createdBy: { __typename?: 'UserType', id: string } } };
+export type ViewNoteQuery = { __typename?: 'Query', note: { __typename?: 'NoteType', id: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, createdAt: any, organization: { __typename?: 'OrganizationType', id: string, name: string }, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null } | null, createdBy: { __typename?: 'UserType', id: string } } };
 
 
 export const NotesDocument = gql`
@@ -32,6 +32,10 @@ export const NotesDocument = gql`
       id
       purpose
       team
+      organization {
+        id
+        name
+      }
       location {
         address {
           id
@@ -123,6 +127,10 @@ export const ViewNoteDocument = gql`
     id
     purpose
     team
+    organization {
+      id
+      name
+    }
     location {
       address {
         id

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -1284,6 +1284,7 @@ export type NoteType = {
   location?: Maybe<LocationType>;
   moods: Array<MoodType>;
   nextSteps: Array<TaskType>;
+  organization: OrganizationType;
   privateDetails?: Maybe<Scalars['String']['output']>;
   providedServices: Array<ServiceRequestType>;
   publicDetails: Scalars['String']['output'];

--- a/libs/expo/betterangels/src/lib/apollo/graphql/queries.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/queries.ts
@@ -16,6 +16,10 @@ export const GET_NOTES = gql`
         id
         purpose
         team
+        organization {
+          id
+          name
+        }
         location {
           address {
             id
@@ -74,6 +78,10 @@ export const GET_NOTE = gql`
       id
       purpose
       team
+      organization {
+        id
+        name
+      }
       location {
         address {
           id

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -1284,6 +1284,7 @@ export type NoteType = {
   location?: Maybe<LocationType>;
   moods: Array<MoodType>;
   nextSteps: Array<TaskType>;
+  organization: OrganizationType;
   privateDetails?: Maybe<Scalars['String']['output']>;
   providedServices: Array<ServiceRequestType>;
   publicDetails: Scalars['String']['output'];


### PR DESCRIPTION
DEV-1796

need this for the card update

## Summary by Sourcery

Add organization association to NoteType by extending server schema and client queries to include organization details

New Features:
- Expose organization field (id and name) on Note in GET_NOTES and GET_NOTE client queries
- Add non-null organization field to NoteType in GraphQL schema and backend type definitions