### PR TITLE
update pill variants (DEV-1817)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Note/NoteServices.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Note/NoteServices.tsx
@@ -18,7 +18,7 @@ export default function NoteServices({
       </TextBold>
       <PillContainer
         maxVisible={5}
-        type={type === 'providedServices' ? 'success' : 'primary'}
+        type={type === 'providedServices' ? 'warning' : 'success'}
         data={data?.note[type].map((item) =>
           item.service === ServiceEnum.Other
             ? item.serviceOther || ''

--- a/libs/expo/betterangels/src/lib/screens/Note/NoteServices.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Note/NoteServices.tsx
@@ -18,7 +18,7 @@ export default function NoteServices({
       </TextBold>
       <PillContainer
         maxVisible={5}
-        type={type === 'providedServices' ? 'warning' : 'success'}
+        variant={type === 'providedServices' ? 'warning' : 'success'}
         data={data?.note[type].map((item) =>
           item.service === ServiceEnum.Other
             ? item.serviceOther || ''

--- a/libs/expo/betterangels/src/lib/ui-components/NoteCard/NoteCardPills.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteCard/NoteCardPills.tsx
@@ -13,7 +13,7 @@ export default function NoteCardPills({
     service: ServiceEnum;
     serviceOther?: string | null;
   }[];
-  type: 'success' | 'primary';
+  type: 'success' | 'primary' | 'warning';
 }) {
   return (
     <View
@@ -27,7 +27,7 @@ export default function NoteCardPills({
       {services.slice(0, 3).map((item, idx) => (
         <Pill
           key={idx}
-          type={type}
+          variant={type}
           label={
             item.service === ServiceEnum.Other
               ? item.serviceOther || ''

--- a/libs/expo/betterangels/src/lib/ui-components/NoteCard/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteCard/index.tsx
@@ -41,10 +41,10 @@ export default function NoteCard(props: INoteCardProps) {
         isSubmitted={note.isSubmitted}
       />
       {!!note.providedServices.length && (
-        <NoteCardPills type="success" services={note.providedServices} />
+        <NoteCardPills type="warning" services={note.providedServices} />
       )}
       {!!note.requestedServices.length && (
-        <NoteCardPills type="primary" services={note.requestedServices} />
+        <NoteCardPills type="success" services={note.requestedServices} />
       )}
     </Pressable>
   );

--- a/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/index.tsx
@@ -44,7 +44,7 @@ export default function RequestedProvidedServices(
           >
             {initialServices.map((item, index) => (
               <Pill
-                type={
+                variant={
                   type === ServiceRequestTypeEnum.Provided
                     ? 'success'
                     : 'primary'

--- a/libs/expo/shared/ui-components/src/lib/Pill/Pill.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Pill/Pill.tsx
@@ -2,16 +2,46 @@ import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
 import { StyleSheet, View } from 'react-native';
 import TextRegular from '../TextRegular';
 
+type TVariants = {
+  [key in 'primary' | 'success' | 'warning']: {
+    bg: string;
+    border: string;
+  };
+};
+
+const VARIANTS: TVariants = {
+  primary: {
+    bg: Colors.PRIMARY_EXTRA_LIGHT,
+    border: Colors.PRIMARY_DARK,
+  },
+  success: {
+    bg: Colors.SUCCESS_EXTRA_LIGHT,
+    border: Colors.SUCCESS,
+  },
+  warning: {
+    bg: Colors.WARNING_EXTRA_LIGHT,
+    border: Colors.WARNING,
+  },
+};
+
 interface IPillProps {
-  type?: 'primary' | 'success';
+  variant: 'primary' | 'success' | 'warning';
   label: string;
 }
 
 export function Pill(props: IPillProps) {
-  const { label, type = 'success' } = props;
+  const { label, variant = 'success' } = props;
 
   return (
-    <View style={[styles.pill, styles[type]]}>
+    <View
+      style={[
+        styles.pill,
+        {
+          backgroundColor: VARIANTS[variant].bg,
+          borderColor: VARIANTS[variant].border,
+        },
+      ]}
+    >
       <TextRegular>{label}</TextRegular>
     </View>
   );
@@ -22,17 +52,15 @@ const styles = StyleSheet.create({
     borderRadius: Radiuses.md,
     justifyContent: 'center',
     alignItems: 'center',
+    borderWidth: 1,
+    paddingVertical: Spacings.xxs - 1,
+    paddingHorizontal: Spacings.sm - 1,
   },
   success: {
     backgroundColor: Colors.SUCCESS_EXTRA_LIGHT,
-    paddingHorizontal: Spacings.sm,
-    paddingVertical: Spacings.xxs,
   },
   primary: {
     backgroundColor: Colors.PRIMARY_EXTRA_LIGHT,
     borderColor: Colors.PRIMARY_DARK,
-    borderWidth: 1,
-    paddingVertical: Spacings.xxs - 1,
-    paddingHorizontal: Spacings.sm - 1,
   },
 });

--- a/libs/expo/shared/ui-components/src/lib/Pill/Pill.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Pill/Pill.tsx
@@ -25,7 +25,7 @@ const VARIANTS: TVariants = {
 };
 
 interface IPillProps {
-  variant: 'primary' | 'success' | 'warning';
+  variant?: 'primary' | 'success' | 'warning';
   label: string;
 }
 

--- a/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.tsx
+++ b/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.tsx
@@ -7,11 +7,11 @@ import TextBold from '../TextBold';
 
 export function PillContainer({
   data,
-  type,
+  variant,
   maxVisible,
 }: {
   data: string[];
-  type: 'primary' | 'success' | 'warning';
+  variant: 'primary' | 'success' | 'warning';
   maxVisible: number;
 }) {
   const [showAll, setShowAll] = useState(false);
@@ -21,7 +21,7 @@ export function PillContainer({
     <View>
       <View style={styles.pillContainer}>
         {servicesToDisplay.map((item, idx) => (
-          <Pill variant={type} label={item} key={idx} />
+          <Pill variant={variant} label={item} key={idx} />
         ))}
       </View>
 

--- a/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.tsx
+++ b/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.tsx
@@ -11,7 +11,7 @@ export function PillContainer({
   maxVisible,
 }: {
   data: string[];
-  type?: 'primary' | 'success';
+  type: 'primary' | 'success' | 'warning';
   maxVisible: number;
 }) {
   const [showAll, setShowAll] = useState(false);
@@ -21,7 +21,7 @@ export function PillContainer({
     <View>
       <View style={styles.pillContainer}>
         {servicesToDisplay.map((item, idx) => (
-          <Pill type={type} label={item} key={idx} />
+          <Pill variant={type} label={item} key={idx} />
         ))}
       </View>
 


### PR DESCRIPTION
DEV-1817

## Summary by Sourcery

Introduce a warning variant to the Pill component, refactor its API to use a variant-based styling map, and adjust all related components to adopt the new prop and styling conventions.

New Features:
- Add 'warning' variant to the Pill component with corresponding background and border colors

Enhancements:
- Replace Pill's optional type prop with a required variant prop and centralize variant styling in a VARIANTS map
- Extract common padding and border settings into the base pill style
- Update all Pill usages (NoteCardPills, NoteCard, PillContainer, NoteServices, RequestedProvidedServices) to use the variant prop and remap service types to the new warning and success variants