### PR TITLE
Add userCanEdit check to interactions (DEV-1898)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Note/NoteSummary.graphql
+++ b/libs/expo/betterangels/src/lib/screens/Note/NoteSummary.graphql
@@ -53,5 +53,6 @@ query NoteSummary($id: ID!) {
         name
       }
     }
+    userCanEdit
   }
 }

--- a/libs/expo/betterangels/src/lib/screens/Note/__generated__/NoteSummary.generated.ts
+++ b/libs/expo/betterangels/src/lib/screens/Note/__generated__/NoteSummary.generated.ts
@@ -8,7 +8,7 @@ export type NoteSummaryQueryVariables = Types.Exact<{
 }>;
 
 
-export type NoteSummaryQuery = { __typename?: 'Query', note: { __typename?: 'NoteType', id: string, createdAt: any, interactedAt: any, isSubmitted: boolean, publicDetails: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, profilePhoto?: { __typename?: 'DjangoImageType', url: string } | null } | null, createdBy: { __typename?: 'UserType', id: string, firstName?: string | null, lastName?: string | null, email?: string | null }, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, organization: { __typename?: 'OrganizationType', id: string, name: string } } };
+export type NoteSummaryQuery = { __typename?: 'Query', note: { __typename?: 'NoteType', id: string, createdAt: any, interactedAt: any, isSubmitted: boolean, publicDetails: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, userCanEdit: boolean, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, profilePhoto?: { __typename?: 'DjangoImageType', url: string } | null } | null, createdBy: { __typename?: 'UserType', id: string, firstName?: string | null, lastName?: string | null, email?: string | null }, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, organization: { __typename?: 'OrganizationType', id: string, name: string } } };
 
 
 export const NoteSummaryDocument = gql`
@@ -67,6 +67,7 @@ export const NoteSummaryDocument = gql`
         name
       }
     }
+    userCanEdit
   }
 }
     `;


### PR DESCRIPTION
## Summary by Sourcery

Add a userCanEdit permission check to the Note screen so the Edit button only appears for editable notes and refactor code for improved readability and styling.

New Features:
- Expose userCanEdit in the NoteSummary GraphQL query
- Show the Edit button in the header only if userCanEdit is true

Enhancements:
- Refactor Note screen to use a local note constant and simplify repeated data access
- Extract inline loading view style into StyleSheet and update useEffect dependencies for header setup
- Streamline conditional rendering of note sections (location, services, public details)