### PR TITLE
update client nav back btn to use router.dismissTo (DEV-1900)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/index.tsx
@@ -99,9 +99,7 @@ export default function Client({
           accessibilityRole="button"
           accessible
           accessibilityHint="goes to previous screen"
-          onPress={() =>
-            arrivedFrom ? router.navigate(arrivedFrom) : router.navigate('/')
-          }
+          onPress={() => router.dismissTo(arrivedFrom || '/')}
         >
           <TextRegular color={Colors.WHITE}>Back</TextRegular>
         </Pressable>


### PR DESCRIPTION
### Switching between Client screens crashes Android
DEV-1900

## Summary by Sourcery

Bug Fixes:
- Replace router.navigate with router.dismissTo for the back button to fix Android crash on navigating between Client screens