### PR TITLE
Remove user from ClientProfile query

### DIFF
--- a/apps/betterangels-backend/clients/types.py
+++ b/apps/betterangels-backend/clients/types.py
@@ -301,8 +301,6 @@ class ClientProfileType(ClientProfileBaseType):
     consent_form_documents: Optional[List[ClientDocumentType]]
     other_documents: Optional[List[ClientDocumentType]]
 
-    user: UserType | None
-
     @strawberry.field
     def display_case_manager(self, info: Info) -> str:
         if case_managers := getattr(self, "case_managers", None):

--- a/apps/betterangels-backend/clients/types.py
+++ b/apps/betterangels-backend/clients/types.py
@@ -5,7 +5,6 @@ from typing import List, Optional, Tuple
 
 import strawberry
 import strawberry_django
-from accounts.types import UserType
 from clients.enums import (
     AdaAccommodationEnum,
     ClientDocumentNamespaceEnum,

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -399,7 +399,6 @@ type ClientProfileType {
   docReadyDocuments: [ClientDocumentType!]
   consentFormDocuments: [ClientDocumentType!]
   otherDocuments: [ClientDocumentType!]
-  user: UserType
   displayCaseManager: String!
 }
 

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/queries.generated.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/queries.generated.ts
@@ -10,7 +10,7 @@ export type NotesQueryVariables = Types.Exact<{
 }>;
 
 
-export type NotesQuery = { __typename?: 'Query', notes: { __typename?: 'NoteTypeOffsetPaginated', totalCount: number, pageInfo: { __typename?: 'OffsetPaginationInfo', limit?: number | null, offset: number }, results: Array<{ __typename?: 'NoteType', id: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, organization: { __typename?: 'OrganizationType', id: string, name: string }, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayCaseManager: string, profilePhoto?: { __typename?: 'DjangoImageType', name: string, url: string } | null, user?: { __typename?: 'UserType', id: string, username: string } | null } | null, createdBy: { __typename?: 'UserType', id: string, email?: string | null, username: string, firstName?: string | null, lastName?: string | null } }> } };
+export type NotesQuery = { __typename?: 'Query', notes: { __typename?: 'NoteTypeOffsetPaginated', totalCount: number, pageInfo: { __typename?: 'OffsetPaginationInfo', limit?: number | null, offset: number }, results: Array<{ __typename?: 'NoteType', id: string, purpose?: string | null, team?: Types.SelahTeamEnum | null, publicDetails: string, isSubmitted: boolean, interactedAt: any, organization: { __typename?: 'OrganizationType', id: string, name: string }, location?: { __typename?: 'LocationType', point: any, pointOfInterest?: string | null, address: { __typename?: 'AddressType', id: string, street?: string | null, city?: string | null, state?: string | null, zipCode?: string | null } } | null, moods: Array<{ __typename?: 'MoodType', id: string, descriptor: Types.MoodEnum }>, providedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, requestedServices: Array<{ __typename?: 'ServiceRequestType', id: string, service: Types.ServiceEnum, serviceOther?: string | null }>, clientProfile?: { __typename?: 'ClientProfileType', id: string, email?: string | null, firstName?: string | null, lastName?: string | null, displayCaseManager: string, profilePhoto?: { __typename?: 'DjangoImageType', name: string, url: string } | null } | null, createdBy: { __typename?: 'UserType', id: string, email?: string | null, username: string, firstName?: string | null, lastName?: string | null } }> } };
 
 export type ViewNoteQueryVariables = Types.Exact<{
   id: Types.Scalars['ID']['input'];
@@ -72,10 +72,6 @@ export const NotesDocument = gql`
         profilePhoto {
           name
           url
-        }
-        user {
-          id
-          username
         }
         profilePhoto {
           url

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -401,7 +401,6 @@ export type ClientProfileType = {
   residenceGeolocation?: Maybe<Scalars['Point']['output']>;
   socialMediaProfiles?: Maybe<Array<SocialMediaProfileType>>;
   spokenLanguages?: Maybe<Array<LanguageEnum>>;
-  user?: Maybe<UserType>;
   veteranStatus?: Maybe<VeteranStatusEnum>;
 };
 

--- a/libs/expo/betterangels/src/lib/apollo/graphql/queries.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/queries.ts
@@ -58,10 +58,6 @@ export const GET_NOTES = gql`
             name
             url
           }
-          user {
-            id
-            username
-          }
           profilePhoto {
             url
           }

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -401,7 +401,6 @@ export type ClientProfileType = {
   residenceGeolocation?: Maybe<Scalars['Point']['output']>;
   socialMediaProfiles?: Maybe<Array<SocialMediaProfileType>>;
   spokenLanguages?: Maybe<Array<LanguageEnum>>;
-  user?: Maybe<UserType>;
   veteranStatus?: Maybe<VeteranStatusEnum>;
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Remove the deprecated user field from ClientProfile across the frontend GraphQL query, backend schema, and generated types