### PR TITLE
link ccm name to contacts page in header (DEV-1799)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/ClientHeader/ClientCaseManager.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientHeader/ClientCaseManager.tsx
@@ -1,0 +1,63 @@
+import { PersonIcon } from '@monorepo/expo/shared/icons';
+import { Colors, Spacings } from '@monorepo/expo/shared/static';
+import { TextRegular } from '@monorepo/expo/shared/ui-components';
+import { HrefObject, Link } from 'expo-router';
+import { StyleSheet, View } from 'react-native';
+import { RelationshipTypeEnum } from '../../../apollo';
+import { ClientProfileSectionEnum } from '../../../screenRouting';
+import { getEditButtonRoute } from '../ClientProfile/utils/getEditButtonRoute';
+import { ClientProfileQuery } from '../__generated__/Client.generated';
+
+type TProps = {
+  client: ClientProfileQuery['clientProfile'] | undefined;
+};
+
+export function ClientCaseManager(props: TProps) {
+  const { client } = props;
+
+  const caseManagers =
+    client?.contacts?.filter(
+      (contact) =>
+        contact.relationshipToClient === RelationshipTypeEnum.CurrentCaseManager
+    ) || [];
+
+  const primaryCCM = caseManagers[0];
+
+  let ccmHref: HrefObject | undefined = undefined;
+
+  if (client && primaryCCM) {
+    ccmHref = getEditButtonRoute({
+      clientProfile: client,
+      section: ClientProfileSectionEnum.RelevantContacts,
+    });
+  }
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: Spacings.xxs,
+      }}
+    >
+      <PersonIcon color={Colors.PRIMARY_EXTRA_DARK} />
+      <View>
+        <TextRegular>Current Case Manager:</TextRegular>
+      </View>
+
+      {!!ccmHref && (
+        <Link href={ccmHref} style={styles.ccmLink}>
+          <TextRegular>{primaryCCM.name}</TextRegular>
+        </Link>
+      )}
+
+      {!ccmHref && <TextRegular>Not Assigned</TextRegular>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  ccmLink: {
+    textDecorationLine: 'underline',
+  },
+});

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientHeader/ClientHeader.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientHeader/ClientHeader.tsx
@@ -1,7 +1,6 @@
 import {
   GlobeIcon,
   LocationDotIcon,
-  PersonIcon,
   UserIcon,
 } from '@monorepo/expo/shared/icons';
 import { Colors, Spacings } from '@monorepo/expo/shared/static';
@@ -11,16 +10,16 @@ import {
   TextRegular,
 } from '@monorepo/expo/shared/ui-components';
 import { View } from 'react-native';
-import { enumDisplayLanguage } from '../../static/enumDisplayMapping';
-import { ClientProfileQuery } from './__generated__/Client.generated';
+import { enumDisplayLanguage } from '../../../static/enumDisplayMapping';
+import { ClientProfileQuery } from '../__generated__/Client.generated';
+import { ClientCaseManager } from './ClientCaseManager';
 
 interface IClientHeaderProps {
   client: ClientProfileQuery['clientProfile'] | undefined;
-  onCaseManagerPress?: () => void;
 }
 
-export default function ClientHeader(props: IClientHeaderProps) {
-  const { client, onCaseManagerPress } = props;
+export function ClientHeader(props: IClientHeaderProps) {
+  const { client } = props;
 
   return (
     <View
@@ -81,29 +80,7 @@ export default function ClientHeader(props: IClientHeaderProps) {
           </View>
         )}
       </View>
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: Spacings.xxs,
-        }}
-      >
-        <PersonIcon color={Colors.PRIMARY_EXTRA_DARK} />
-        <TextRegular>
-          Current Case Manager:{' '}
-          {client?.displayCaseManager !== 'Not Assigned' &&
-          onCaseManagerPress ? (
-            <TextRegular
-              onPress={onCaseManagerPress}
-              textDecorationLine="underline"
-            >
-              {client?.displayCaseManager}
-            </TextRegular>
-          ) : (
-            <TextRegular>{client?.displayCaseManager}</TextRegular>
-          )}
-        </TextRegular>
-      </View>
+      <ClientCaseManager client={client} />
       {client?.residenceAddress && (
         <View
           style={{

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientHeader/index.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientHeader/index.ts
@@ -1,0 +1,1 @@
+export { ClientHeader } from './ClientHeader';

--- a/libs/expo/betterangels/src/lib/screens/Client/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/index.tsx
@@ -18,7 +18,7 @@ import {
 import { Pressable, View } from 'react-native';
 import { ClientProfileSectionEnum } from '../../screenRouting';
 import { MainContainer } from '../../ui-components';
-import ClientHeader from './ClientHeader';
+import { ClientHeader } from './ClientHeader';
 import { ClientNavMenu } from './ClientNavMenu/ClientNavMenu';
 import ClientProfileView from './ClientProfile';
 import ClientTabs, { ClientViewTabEnum } from './ClientTabs';


### PR DESCRIPTION
### CPR: update onCaseManagerPress functionality
DEV-1799

## Summary by Sourcery

Extract the case manager display into a dedicated component and make the case manager name a navigable link to the contacts page.

New Features:
- Link the current case manager name to the contacts (RelevantContacts) page in the header

Enhancements:
- Extract case manager rendering into a new ClientCaseManager component
- Swap out the inline case manager section in ClientHeader for the new component
- Correct import paths for enumDisplayLanguage and ClientProfileQuery