### PR TITLE
Add generalized modal provider system and Docs upload modal implementation

### DIFF
--- a/apps/betterangels/src/app/AppRoutesStack.tsx
+++ b/apps/betterangels/src/app/AppRoutesStack.tsx
@@ -1,0 +1,58 @@
+import {
+  getDefaultStackModalOptions,
+  useModalScreen,
+} from '@monorepo/expo/betterangels';
+import { ArrowLeftIcon } from '@monorepo/expo/shared/icons';
+import { IconButton } from '@monorepo/expo/shared/ui-components';
+import { Stack, useRouter } from 'expo-router';
+
+export default function AppRoutesStack() {
+  const router = useRouter();
+  const {
+    presentation,
+    title: modalScreenTitle,
+    hideHeader: hideModalHeader,
+  } = useModalScreen();
+
+  return (
+    <Stack>
+      <Stack.Screen
+        name="(tabs)"
+        options={{ headerShown: false, gestureEnabled: false }}
+      />
+      <Stack.Screen
+        name="(private-screens)"
+        options={{ headerShown: false, gestureEnabled: false }}
+      />
+      <Stack.Screen
+        name="modal-screen"
+        key={presentation} // force a re‐mount when presentation changes
+        options={getDefaultStackModalOptions({
+          presentation,
+          title: modalScreenTitle,
+          hideHeader: hideModalHeader,
+          onClose: () => router.back(),
+        })}
+      />
+      <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+      <Stack.Screen
+        name="sign-in"
+        options={{
+          headerLeft: () => (
+            <IconButton
+              onPress={() => router.back()}
+              variant="transparent"
+              accessibilityLabel="goes to get started screen"
+              accessibilityHint="goes to get started screen"
+            >
+              <ArrowLeftIcon />
+            </IconButton>
+          ),
+          headerShadowVisible: false,
+          title: '',
+        }}
+      />
+      <Stack.Screen name="auth" options={{ headerShown: false }} />
+    </Stack>
+  );
+}

--- a/apps/betterangels/src/app/_layout.tsx
+++ b/apps/betterangels/src/app/_layout.tsx
@@ -7,6 +7,7 @@ import {
   FeatureFlagControlled,
   FeatureFlags,
   KeyboardToolbarProvider,
+  ModalScreenProvider,
   SnackbarProvider,
   useNewRelic,
   UserProvider,
@@ -15,14 +16,12 @@ import {
   ApiConfigProvider,
   ApolloClientProvider,
 } from '@monorepo/expo/shared/clients';
-import { ArrowLeftIcon } from '@monorepo/expo/shared/icons';
-import { IconButton } from '@monorepo/expo/shared/ui-components';
-import { Stack, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { apiUrl, demoApiUrl } from '../../config';
 
 import { type ErrorBoundaryProps } from 'expo-router';
+import AppRoutesStack from './AppRoutesStack';
 
 export const unstable_settings = {
   // Ensure that reloading on `/modal` keeps a back button present.
@@ -35,7 +34,6 @@ export function ErrorBoundary(props: ErrorBoundaryProps) {
 }
 
 export default function RootLayout() {
-  const router = useRouter();
   useNewRelic();
 
   return (
@@ -46,47 +44,16 @@ export default function RootLayout() {
             <KeyboardToolbarProvider>
               <UserProvider>
                 <SnackbarProvider>
-                  <StatusBar style="light" />
-                  <FeatureFlagControlled
-                    flag={FeatureFlags.APP_UPDATE_PROMPT_FF}
-                  >
-                    <AppUpdatePrompt />
-                  </FeatureFlagControlled>
-                  <Stack>
-                    <Stack.Screen
-                      name="(tabs)"
-                      options={{ headerShown: false, gestureEnabled: false }}
-                    />
-                    <Stack.Screen
-                      name="(private-screens)"
-                      options={{ headerShown: false, gestureEnabled: false }}
-                    />
-                    <Stack.Screen
-                      name="modal"
-                      options={{ presentation: 'modal' }}
-                    />
-                    <Stack.Screen
-                      name="sign-in"
-                      options={{
-                        headerLeft: () => (
-                          <IconButton
-                            onPress={() => router.back()}
-                            variant="transparent"
-                            accessibilityLabel="goes to get started screen"
-                            accessibilityHint="goes to get started screen"
-                          >
-                            <ArrowLeftIcon />
-                          </IconButton>
-                        ),
-                        headerShadowVisible: false,
-                        title: '',
-                      }}
-                    />
-                    <Stack.Screen
-                      name="auth"
-                      options={{ headerShown: false }}
-                    />
-                  </Stack>
+                  <ModalScreenProvider>
+                    <StatusBar style="light" />
+                    <FeatureFlagControlled
+                      flag={FeatureFlags.APP_UPDATE_PROMPT_FF}
+                    >
+                      <AppUpdatePrompt />
+                    </FeatureFlagControlled>
+                    {/* All Stack.Screens in AppRoutesStack */}
+                    <AppRoutesStack />
+                  </ModalScreenProvider>
                 </SnackbarProvider>
               </UserProvider>
             </KeyboardToolbarProvider>

--- a/apps/betterangels/src/app/modal-screen.tsx
+++ b/apps/betterangels/src/app/modal-screen.tsx
@@ -1,0 +1,27 @@
+import {
+  KeyboardToolbarProvider,
+  useModalScreen,
+} from '@monorepo/expo/betterangels';
+import { Colors } from '@monorepo/expo/shared/static';
+import { View } from 'react-native';
+
+export default function BaseModalScreen() {
+  const { content } = useModalScreen();
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <KeyboardToolbarProvider>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: Colors.WHITE,
+        }}
+      >
+        {content}
+      </View>
+    </KeyboardToolbarProvider>
+  );
+}

--- a/libs/expo/betterangels/src/lib/navigation/getDefaultStackModalOptions.tsx
+++ b/libs/expo/betterangels/src/lib/navigation/getDefaultStackModalOptions.tsx
@@ -1,0 +1,74 @@
+import { Colors } from '@monorepo/expo/shared/static';
+import { CloseButton } from '@monorepo/expo/shared/ui-components';
+import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
+import { HeaderLeftButton } from './HeaderLeftButton';
+
+type TProps = {
+  title?: string;
+  presentation?: 'modal' | 'card';
+  hideHeader?: boolean;
+  onClose?: () => void;
+};
+
+export function getDefaultStackModalOptions(
+  props?: TProps
+): NativeStackNavigationOptions {
+  const { presentation, hideHeader } = props || {};
+
+  if (hideHeader) {
+    return {
+      presentation,
+      headerShown: false,
+    };
+  }
+
+  if (presentation === 'modal') {
+    return modalOptions(props);
+  }
+
+  return cardOptions(props);
+}
+
+function cardOptions(props?: TProps): NativeStackNavigationOptions {
+  const { title } = props || {};
+
+  return {
+    presentation: 'card',
+    headerTitleAlign: 'center',
+    title: title || '',
+    headerStyle: {
+      backgroundColor: Colors.WHITE,
+    },
+    headerTitleStyle: {
+      color: Colors.BRAND_DARK_BLUE,
+    },
+    headerLeft: () => (
+      <HeaderLeftButton title="Close" color={Colors.BRAND_DARK_BLUE} />
+    ),
+  };
+}
+
+function modalOptions(props?: TProps): NativeStackNavigationOptions {
+  const { title, onClose } = props || {};
+
+  const baseOpts: NativeStackNavigationOptions = {
+    presentation: 'modal',
+    headerTitleAlign: 'center',
+    title: title || '',
+    headerStyle: {
+      backgroundColor: Colors.WHITE,
+    },
+    headerTitleStyle: {
+      color: Colors.BRAND_DARK_BLUE,
+    },
+    headerBackVisible: false,
+  };
+
+  if (onClose) {
+    baseOpts.headerRight = () => (
+      <CloseButton onClose={onClose} color={Colors.BRAND_DARK_BLUE} />
+    );
+  }
+
+  return baseOpts;
+}

--- a/libs/expo/betterangels/src/lib/navigation/index.ts
+++ b/libs/expo/betterangels/src/lib/navigation/index.ts
@@ -1,2 +1,3 @@
 export { HeaderLeftButton } from './HeaderLeftButton';
+export { getDefaultStackModalOptions } from './getDefaultStackModalOptions';
 export { getDefaultStackNavOptions } from './getDefaultStackNavOptions';

--- a/libs/expo/betterangels/src/lib/providers/index.ts
+++ b/libs/expo/betterangels/src/lib/providers/index.ts
@@ -1,5 +1,6 @@
 export * from './featureControls';
 export { default as KeyboardToolbarProvider } from './keyboardToolbar/keyboardToolbarProvider';
+export * from './modalScreen';
 export { default as SnackbarProvider } from './snackbar/SnackbarProvider';
 export { default as UserProvider } from './user/UserProvider';
 export * from './user/__generated__/mutations.generated';

--- a/libs/expo/betterangels/src/lib/providers/modalScreen/ModalScreenContext.ts
+++ b/libs/expo/betterangels/src/lib/providers/modalScreen/ModalScreenContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import { IModalScreenContext } from './types';
+
+export const ModalScreenContext = createContext<
+  IModalScreenContext | undefined
+>(undefined);

--- a/libs/expo/betterangels/src/lib/providers/modalScreen/ModalScreenProvider.tsx
+++ b/libs/expo/betterangels/src/lib/providers/modalScreen/ModalScreenProvider.tsx
@@ -1,0 +1,94 @@
+import { usePathname, useRouter } from 'expo-router';
+import { ReactNode, useEffect, useState } from 'react';
+import { ModalScreenContext } from './ModalScreenContext';
+import { TModalPresentationType, TShowModalScreenProps } from './types';
+
+/**
+ * ModalScreenProvider
+ *
+ * Wrap the app with this provider to enable showing and closing
+ * a global modal screen via context.
+ *
+ * @example
+ * <ModalScreenProvider>
+ *   // your app components and <Stack> navigator here
+ * </ModalScreenProvider>
+ *
+ * showModalScreen({
+ *  presentation: 'modal',
+ *  hideHeader: true,
+ *  content: (
+ *     <MyComponent />
+ *   ),
+ * })
+ */
+
+const DEFAULT_PRESENTATION: TModalPresentationType = 'modal';
+const SCREEN_PATH_NAME = '/modal-screen';
+
+export const ModalScreenProvider = ({ children }: { children: ReactNode }) => {
+  const [presentation, setPresentation] =
+    useState<TModalPresentationType>(DEFAULT_PRESENTATION);
+  const [modalContent, setModalContent] = useState<React.ReactNode | null>(
+    null
+  );
+  const [onCloseHandler, setOnCloseHandler] = useState<(() => void) | null>(
+    null
+  );
+  const [title, setTitle] = useState<string>('');
+  const [noHeader, setNoHeader] = useState<boolean>(false);
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const showModalScreen = (props: TShowModalScreenProps) => {
+    const { content, presentation, title, hideHeader, onClose } = props;
+
+    setModalContent(content);
+    setPresentation(presentation || DEFAULT_PRESENTATION);
+    setTitle(title || '');
+    setNoHeader(!!hideHeader);
+    setOnCloseHandler(() => onClose ?? null);
+
+    router.push(SCREEN_PATH_NAME);
+  };
+
+  // Auto modal close detection:
+  // Effect listens for route changes and detects when the modal route is exited.
+  // When exiting, it invokes the onClose handler (if any) and resets modal state.
+  useEffect(() => {
+    if (modalContent !== null && pathname !== SCREEN_PATH_NAME) {
+      onCloseHandler?.();
+
+      setModalContent(null);
+      setOnCloseHandler(null);
+    }
+  }, [pathname]);
+
+  // Manual modal close method
+  const closeModalScreen = () => {
+    if (pathname !== SCREEN_PATH_NAME) {
+      console.warn(
+        `ModalScreenProvider: attempting to close modalScreen when path is ${SCREEN_PATH_NAME}`
+      );
+
+      return;
+    }
+
+    router.back();
+  };
+
+  return (
+    <ModalScreenContext.Provider
+      value={{
+        showModalScreen,
+        closeModalScreen,
+        presentation,
+        content: modalContent,
+        hideHeader: noHeader,
+        title,
+      }}
+    >
+      {children}
+    </ModalScreenContext.Provider>
+  );
+};

--- a/libs/expo/betterangels/src/lib/providers/modalScreen/index.ts
+++ b/libs/expo/betterangels/src/lib/providers/modalScreen/index.ts
@@ -1,0 +1,3 @@
+export { ModalScreenProvider } from './ModalScreenProvider';
+export * from './types';
+export { useModalScreen } from './useModalScreen';

--- a/libs/expo/betterangels/src/lib/providers/modalScreen/types.ts
+++ b/libs/expo/betterangels/src/lib/providers/modalScreen/types.ts
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+export type TModalPresentationType = 'modal' | 'card';
+
+export type TShowModalScreenProps = {
+  content: ReactNode;
+  presentation?: TModalPresentationType;
+  title?: string;
+  hideHeader?: boolean;
+  onClose?: () => void;
+};
+export interface IModalScreenContext {
+  showModalScreen: (props: TShowModalScreenProps) => void;
+  closeModalScreen: () => void;
+  content: ReactNode | null;
+  presentation: TModalPresentationType;
+  hideHeader?: boolean;
+  title?: string;
+}

--- a/libs/expo/betterangels/src/lib/providers/modalScreen/useModalScreen.ts
+++ b/libs/expo/betterangels/src/lib/providers/modalScreen/useModalScreen.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { ModalScreenContext } from './ModalScreenContext';
+
+export const useModalScreen = () => {
+  const context = useContext(ModalScreenContext);
+
+  if (!context) {
+    throw new Error('useModalScreen must be used within ModalScreenProvider');
+  }
+
+  return context;
+};

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/index.tsx
@@ -7,10 +7,10 @@ import {
   thumbnailSizes,
 } from '@monorepo/expo/shared/static';
 import { TextBold, TextRegular } from '@monorepo/expo/shared/ui-components';
+import { useRouter } from 'expo-router';
 import * as React from 'react';
 import { useEffect } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
-import Modal from 'react-native-modal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ClientDocumentNamespaceEnum } from '../../../../apollo';
 import FileUploadTab from './FileUploadTab';
@@ -19,7 +19,7 @@ import SingleDocUploads from './SingleDocUploads';
 import { Docs, ITab, IUploadModalProps } from './types';
 
 export default function UploadModal(props: IUploadModalProps) {
-  const { isModalVisible, closeModal, opacity = 0, client } = props;
+  const { client } = props;
   const [tab, setTab] = React.useState<undefined | ITab>();
   const [docs, setDocs] = React.useState<Docs>({
     DriversLicenseFront: undefined,
@@ -45,7 +45,7 @@ export default function UploadModal(props: IUploadModalProps) {
       <SingleDocUploads
         thumbnailSize={thumbnailSizes.PhotoId}
         docType="DriversLicenseFront"
-        title="Upload CA ID or CA Driver’s License - Front"
+        title="Upload CA ID or CA Driver's License - Front"
         {...docProps}
       />
     ),
@@ -53,7 +53,7 @@ export default function UploadModal(props: IUploadModalProps) {
       <SingleDocUploads
         thumbnailSize={thumbnailSizes.PhotoId}
         docType="DriversLicenseBack"
-        title="Upload CA ID or CA Driver’s License - Back"
+        title="Upload CA ID or CA Driver's License - Back"
         {...docProps}
       />
     ),
@@ -148,130 +148,133 @@ export default function UploadModal(props: IUploadModalProps) {
     });
   }, [client]);
 
-  return (
-    <Modal
-      style={{
-        margin: 0,
-        flex: 1,
-        justifyContent: 'flex-end',
-      }}
-      animationIn="slideInUp"
-      animationOut="slideOutDown"
-      backdropOpacity={opacity}
-      isVisible={isModalVisible}
-      onBackdropPress={closeModal}
-      useNativeDriverForBackdrop={true}
-    >
-      <View
-        style={{
-          borderTopLeftRadius: Radiuses.xs,
-          borderTopRightRadius: Radiuses.xs,
-          paddingTop: topOffset + Spacings.xs,
+  const router = useRouter();
+  const closeModal = () => router.back();
 
-          backgroundColor: Colors.WHITE,
-          flex: 1,
-        }}
-      >
-        {tab ? (
-          TABS[tab]
-        ) : (
-          <ScrollView
+  return (
+    // <Modal
+    //   style={{
+    //     margin: 0,
+    //     flex: 1,
+    //     justifyContent: 'flex-end',
+    //   }}
+    //   animationIn="slideInUp"
+    //   animationOut="slideOutDown"
+    //   backdropOpacity={opacity}
+    //   isVisible={isModalVisible}
+    //   onBackdropPress={closeModal}
+    //   useNativeDriverForBackdrop={true}
+    // >
+    <View
+      style={{
+        borderTopLeftRadius: Radiuses.xs,
+        borderTopRightRadius: Radiuses.xs,
+        paddingTop: topOffset + Spacings.xs,
+
+        backgroundColor: Colors.WHITE,
+        flex: 1,
+      }}
+    >
+      {tab ? (
+        TABS[tab]
+      ) : (
+        <ScrollView
+          style={{
+            paddingHorizontal: Spacings.sm,
+            paddingBottom: 35 + bottomOffset,
+          }}
+        >
+          <View
             style={{
-              paddingHorizontal: Spacings.sm,
-              paddingBottom: 35 + bottomOffset,
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginBottom: Spacings.sm,
             }}
           >
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                marginBottom: Spacings.sm,
-              }}
+            <TextBold size="lg">Upload Files</TextBold>
+            <Pressable
+              accessible
+              accessibilityHint="closes the Upload modal"
+              accessibilityRole="button"
+              accessibilityLabel="close"
+              onPress={closeModal}
             >
-              <TextBold size="lg">Upload Files</TextBold>
-              <Pressable
-                accessible
-                accessibilityHint="closes the Upload modal"
-                accessibilityRole="button"
-                accessibilityLabel="close"
-                onPress={closeModal}
-              >
-                <PlusIcon size="md" color={Colors.BLACK} rotate="45deg" />
-              </Pressable>
-            </View>
-            <TextRegular size="sm" mb="md">
-              Select the right file type and you can rename it when it's done
-              (optional).
-            </TextRegular>
-            <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
-              <TextBold>Doc-Ready</TextBold>
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="DriversLicenseFront"
-                title="CA ID or CA Driver’s License - Front"
-              />
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="DriversLicenseBack"
-                title="CA ID or CA Driver’s License - Back"
-              />
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="PhotoId"
-                title="Other Photo ID (e.g., out of state)"
-              />
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="BirthCertificate"
-                title="Birth Certificate"
-              />
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="SocialSecurityCard"
-                title="Social Security Card"
-              />
-            </View>
+              <PlusIcon size="md" color={Colors.BLACK} rotate="45deg" />
+            </Pressable>
+          </View>
+          <TextRegular size="sm" mb="md">
+            Select the right file type and you can rename it when it's done
+            (optional).
+          </TextRegular>
+          <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
+            <TextBold>Doc-Ready</TextBold>
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="DriversLicenseFront"
+              title="CA ID or CA Driver’s License - Front"
+            />
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="DriversLicenseBack"
+              title="CA ID or CA Driver’s License - Back"
+            />
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="PhotoId"
+              title="Other Photo ID (e.g., out of state)"
+            />
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="BirthCertificate"
+              title="Birth Certificate"
+            />
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="SocialSecurityCard"
+              title="Social Security Card"
+            />
+          </View>
 
-            <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
-              <TextBold>Forms</TextBold>
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="ConsentForm"
-                title="Consent Forms"
-              />
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="HmisForm"
-                title="HMIS Forms"
-              />
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="IncomeForm"
-                title="Income Forms (pay stubs)"
-              />
-            </View>
+          <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
+            <TextBold>Forms</TextBold>
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="ConsentForm"
+              title="Consent Forms"
+            />
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="HmisForm"
+              title="HMIS Forms"
+            />
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="IncomeForm"
+              title="Income Forms (pay stubs)"
+            />
+          </View>
 
-            <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
-              <TextBold>Other</TextBold>
-              <FileUploadTab
-                docs={docs}
-                setTab={setTab}
-                tabKey="OtherClientDocument"
-                title="Other Documents"
-              />
-            </View>
-          </ScrollView>
-        )}
-      </View>
-    </Modal>
+          <View style={{ gap: Spacings.xs, marginBottom: Spacings.lg }}>
+            <TextBold>Other</TextBold>
+            <FileUploadTab
+              docs={docs}
+              setTab={setTab}
+              tabKey="OtherClientDocument"
+              title="Other Documents"
+            />
+          </View>
+        </ScrollView>
+      )}
+    </View>
+    // {/* </Modal> */}
   );
 }

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/types.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/types.ts
@@ -14,8 +14,8 @@ export interface IUploadSectionProps {
 }
 
 export interface IUploadModalProps {
-  isModalVisible: boolean;
-  closeModal: () => void;
+  // isModalVisible: boolean;
+  // closeModal: () => void;
   bottomSection?: React.ReactNode;
   topSection?: React.ReactNode;
   opacity?: number;

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/index.tsx
@@ -4,6 +4,7 @@ import { IconButton, TextMedium } from '@monorepo/expo/shared/ui-components';
 import { useState } from 'react';
 import { ScrollView, View } from 'react-native';
 import { ClientDocumentType } from '../../../apollo';
+import { useModalScreen } from '../../../providers';
 import { ClientProfileQuery } from '../__generated__/Client.generated';
 import Documents from './Documents';
 import UploadModal from './UploadModal';
@@ -13,8 +14,8 @@ export default function Docs({
 }: {
   client: ClientProfileQuery | undefined;
 }) {
-  const [isModalVisible, setModalVisible] = useState(false);
   const [expanded, setExpanded] = useState<undefined | string | null>();
+  const { showModalScreen } = useModalScreen();
 
   const props = {
     expanded,
@@ -35,7 +36,13 @@ export default function Docs({
       >
         <TextMedium size="lg">Doc Library</TextMedium>
         <IconButton
-          onPress={() => setModalVisible(true)}
+          onPress={() =>
+            showModalScreen({
+              presentation: 'modal',
+              hideHeader: true,
+              content: <UploadModal client={client} />,
+            })
+          }
           variant="secondary"
           borderColor={Colors.WHITE}
           accessibilityLabel={'add document'}
@@ -44,11 +51,6 @@ export default function Docs({
           <PlusIcon />
         </IconButton>
       </View>
-      <UploadModal
-        client={client}
-        isModalVisible={isModalVisible}
-        closeModal={() => setModalVisible(false)}
-      />
       <View style={{ gap: Spacings.xs, marginTop: Spacings.sm }}>
         {client?.clientProfile.docReadyDocuments &&
           client?.clientProfile.docReadyDocuments?.length > 0 && (


### PR DESCRIPTION
- Introduces a reusable ModalScreenProvider and context for managing modals via Expo Router modal screens
- Migrates Docs upload modal to use the new provider system
- Removes legacy modal state/props from affected components
- Ensures keyboard accessory toolbar and modal presentation work seamlessly