### PR TITLE
Fix delete modal not coming back on hitting X (DEV-1891)

### DIFF
--- a/libs/expo/shared/ui-components/src/lib/DeleteModal/index.tsx
+++ b/libs/expo/shared/ui-components/src/lib/DeleteModal/index.tsx
@@ -18,15 +18,17 @@ type TProps = {
   deleteableItemName?: string;
 };
 
-export default function DeleteModal({
-  title,
-  body,
-  onCancel,
-  onDelete,
-  button,
-  isVisible = false,
-  deleteableItemName,
-}: TProps) {
+export default function DeleteModal(props: TProps) {
+  const {
+    title,
+    body,
+    onCancel,
+    onDelete,
+    button,
+    deleteableItemName,
+    isVisible = false,
+  } = props;
+
   const [visible, setVisible] = useState(isVisible);
 
   useEffect(() => {

--- a/libs/expo/shared/ui-components/src/lib/DeleteModal/index.tsx
+++ b/libs/expo/shared/ui-components/src/lib/DeleteModal/index.tsx
@@ -8,13 +8,14 @@ import TextBold from '../TextBold';
 import TextButton from '../TextButton';
 import TextRegular from '../TextRegular';
 
-export type DeleteModalProps = {
+type TProps = {
   title: string;
   body?: string;
   onDelete: () => void;
   onCancel?: () => void;
   button?: ReactElement<ButtonProps>;
   isVisible?: boolean;
+  deleteableItemName?: string;
 };
 
 export default function DeleteModal({
@@ -24,7 +25,8 @@ export default function DeleteModal({
   onDelete,
   button,
   isVisible = false,
-}: DeleteModalProps) {
+  deleteableItemName,
+}: TProps) {
   const [visible, setVisible] = useState(isVisible);
 
   useEffect(() => {
@@ -68,7 +70,7 @@ export default function DeleteModal({
           >
             <TextButton
               title="Cancel"
-              accessibilityHint="Cancel deletion"
+              accessibilityHint="cancel the delete action"
               color={Colors.PRIMARY}
               fontSize="sm"
               onPress={() => {
@@ -80,7 +82,9 @@ export default function DeleteModal({
           <View style={{ flex: 1, marginLeft: Spacings.xs }}>
             <Button
               title="Delete"
-              accessibilityHint="Confirm deletion"
+              accessibilityHint={
+                deleteableItemName ? `delete ${deleteableItemName}` : 'delete'
+              }
               variant="primary"
               size="full"
               fontSize="sm"

--- a/libs/expo/shared/ui-components/src/lib/DeleteModal/index.tsx
+++ b/libs/expo/shared/ui-components/src/lib/DeleteModal/index.tsx
@@ -1,38 +1,40 @@
 import { Colors, Spacings } from '@monorepo/expo/shared/static';
 import { ReactElement, cloneElement, useEffect, useState } from 'react';
-import { ButtonProps, View } from 'react-native';
+import type { ButtonProps } from 'react-native';
+import { View } from 'react-native';
 import BasicModal from '../BasicModal';
 import Button from '../Button';
 import TextBold from '../TextBold';
 import TextButton from '../TextButton';
 import TextRegular from '../TextRegular';
 
-type TProps = {
+export type DeleteModalProps = {
   title: string;
   body?: string;
   onDelete: () => void;
   onCancel?: () => void;
   button?: ReactElement<ButtonProps>;
   isVisible?: boolean;
-  deleteableItemName?: string;
 };
 
-export default function DeleteModal(props: TProps) {
-  const {
-    isVisible,
-    title,
-    body,
-    onCancel,
-    onDelete,
-    button,
-    deleteableItemName,
-  } = props;
-
-  const [visible, setVisible] = useState(false);
+export default function DeleteModal({
+  title,
+  body,
+  onCancel,
+  onDelete,
+  button,
+  isVisible = false,
+}: DeleteModalProps) {
+  const [visible, setVisible] = useState(isVisible);
 
   useEffect(() => {
-    setVisible(!!isVisible);
+    setVisible(isVisible);
   }, [isVisible]);
+
+  const handleClose = () => {
+    setVisible(false);
+    onCancel?.();
+  };
 
   const clonedButton =
     button &&
@@ -46,10 +48,10 @@ export default function DeleteModal(props: TProps) {
   return (
     <>
       {clonedButton}
-      <BasicModal visible={visible} onClose={() => setVisible(false)}>
+      <BasicModal visible={visible} onClose={handleClose}>
         <TextBold size="lg">{title}</TextBold>
         {body && (
-          <TextRegular size="sm" mt="sm">
+          <TextRegular size="sm" style={{ marginTop: Spacings.sm }}>
             {body}
           </TextRegular>
         )}
@@ -65,29 +67,27 @@ export default function DeleteModal(props: TProps) {
             style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}
           >
             <TextButton
+              title="Cancel"
+              accessibilityHint="Cancel deletion"
+              color={Colors.PRIMARY}
               fontSize="sm"
-              onPress={async () => {
-                onCancel && onCancel();
+              onPress={() => {
+                onCancel?.();
                 setVisible(false);
               }}
-              color={Colors.PRIMARY}
-              accessibilityHint="cancel the delete action"
-              title="Cancel"
             />
           </View>
           <View style={{ flex: 1, marginLeft: Spacings.xs }}>
             <Button
-              fontSize="sm"
+              title="Delete"
+              accessibilityHint="Confirm deletion"
+              variant="primary"
               size="full"
-              accessibilityHint={
-                deleteableItemName ? `delete ${deleteableItemName}` : 'delete'
-              }
-              onPress={async () => {
+              fontSize="sm"
+              onPress={() => {
                 onDelete();
                 setVisible(false);
               }}
-              variant="primary"
-              title="Delete"
             />
           </View>
         </View>


### PR DESCRIPTION
## Summary by Sourcery

Sync DeleteModal's internal visibility state with the isVisible prop, centralize closing behavior, and standardize styling and button props to fix the modal reopen issue.

Bug Fixes:
- Fix delete modal not reopening after hitting the X by properly syncing visibility state and invoking onCancel.

Enhancements:
- Initialize internal visibility state from the isVisible prop and update it on prop change.
- Add a handleClose function to unify closing behavior for the modal and Cancel button.
- Standardize button and TextButton props by explicitly setting titles, accessibility hints, and font sizes.
- Update the body text margin to use Spacings.sm via the style prop.