### PR TITLE
operating hours backend (DEV-1925)

### DIFF
--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1524,6 +1524,7 @@ type ShelterType {
   InteriorPhotos: [ShelterPhotoType!]
   heroImage: String
   distanceInMiles: Float
+  operatingHours: [TimeRange]
 }
 
 type ShelterTypeOffsetPaginated {
@@ -1640,6 +1641,11 @@ enum TaskTypeEnum {
 
 """Time (isoformat)"""
 scalar Time
+
+type TimeRange {
+  start: DateTime
+  end: DateTime
+}
 
 enum TrainingServiceChoices {
   JOB_TRAINING

--- a/apps/betterangels-backend/shelters/tests/test_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_queries.py
@@ -79,6 +79,7 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             maxStay
             name
             onSiteSecurity
+            operatingHours { start end}
             otherRules
             otherServices
             overallRating
@@ -143,6 +144,12 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             max_stay=7,
             name="name",
             on_site_security=True,
+            operating_hours=[
+                {
+                    datetime.datetime(2025, 7, 1, 6, 00, 00).time(),
+                    datetime.datetime(2025, 7, 1, 22, 00, 00).time(),
+                }
+            ],
             organization=shelter_organization,
             other_rules="other rules",
             other_services="other services",
@@ -217,7 +224,7 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             }}
         """
         variables = {"id": shelter.pk}
-        expected_query_count = 21
+        expected_query_count = 22
 
         with self.assertNumQueries(expected_query_count):
             response = self.execute_graphql(query, variables)
@@ -239,6 +246,7 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             "maxStay": 7,
             "name": "name",
             "onSiteSecurity": True,
+            "operatingHours": [{"start": "06:00:00", "end": "22:00:00"}],
             "otherRules": "other rules",
             "otherServices": "other services",
             "overallRating": 3,
@@ -326,7 +334,7 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             }}
         """
 
-        expected_query_count = 22
+        expected_query_count = 24
 
         variables = {"order": {"name": "ASC"}}
 

--- a/apps/betterangels-backend/shelters/tests/test_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_queries.py
@@ -145,10 +145,10 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             name="name",
             on_site_security=True,
             operating_hours=[
-                {
+                (
                     datetime.datetime(2025, 7, 1, 6, 00, 00).time(),
                     datetime.datetime(2025, 7, 1, 22, 00, 00).time(),
-                }
+                )
             ],
             organization=shelter_organization,
             other_rules="other rules",
@@ -342,7 +342,6 @@ class ShelterQueryTestCase(GraphQLTestCaseMixin, ParametrizedTestCase, TestCase)
             response = self.execute_graphql(query, variables)
 
         shelters = response["data"]["shelters"]["results"]
-
         self.assertEqual(len(shelters), shelter_count)
         self.assertEqual(shelters[0]["heroImage"], exterior_photo_0.file.url)
         self.assertEqual(shelters[1]["heroImage"], interior_photo_1.file.url)

--- a/apps/betterangels-backend/shelters/types.py
+++ b/apps/betterangels-backend/shelters/types.py
@@ -245,7 +245,7 @@ class ShelterOrder:
     name: auto
 
 
-@strawberry.type
+@strawberry_django.type
 class TimeRange:
     start: Optional[datetime]
     end: Optional[datetime]

--- a/apps/betterangels-backend/shelters/types.py
+++ b/apps/betterangels-backend/shelters/types.py
@@ -245,7 +245,7 @@ class ShelterOrder:
     name: auto
 
 
-@strawberry_django.type
+@strawberry.type
 class TimeRange:
     start: Optional[datetime]
     end: Optional[datetime]

--- a/apps/betterangels-backend/shelters/types.py
+++ b/apps/betterangels-backend/shelters/types.py
@@ -245,6 +245,12 @@ class ShelterOrder:
     name: auto
 
 
+@strawberry.type
+class TimeRange:
+    start: Optional[datetime]
+    end: Optional[datetime]
+
+
 @strawberry_django.type(Shelter, filters=ShelterFilter, order=ShelterOrder)  # type: ignore
 class ShelterType:
     id: ID
@@ -330,3 +336,14 @@ class ShelterType:
             return float(distance.mi)
 
         return None
+
+    @strawberry_django.field
+    def operating_hours(self, root: Shelter) -> Optional[List[Optional[TimeRange]]]:
+        ranges: List[Optional[TimeRange]] = []
+        if root.operating_hours:
+            for start, end in root.operating_hours:
+                if start is not None or end is not None:
+                    ranges.append(TimeRange(start=start, end=end))
+                else:
+                    ranges.append(None)
+        return ranges or None

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -1874,6 +1874,7 @@ export type ShelterType = {
   maxStay?: Maybe<Scalars['Int']['output']>;
   name: Scalars['String']['output'];
   onSiteSecurity?: Maybe<Scalars['Boolean']['output']>;
+  operatingHours?: Maybe<Array<Maybe<TimeRange>>>;
   organization?: Maybe<OrganizationType>;
   otherRules?: Maybe<Scalars['String']['output']>;
   otherServices?: Maybe<Scalars['String']['output']>;
@@ -2014,6 +2015,12 @@ export enum TaskTypeEnum {
   NextStep = 'NEXT_STEP',
   Purpose = 'PURPOSE'
 }
+
+export type TimeRange = {
+  __typename?: 'TimeRange';
+  end?: Maybe<Scalars['DateTime']['output']>;
+  start?: Maybe<Scalars['DateTime']['output']>;
+};
 
 export enum TrainingServiceChoices {
   JobTraining = 'JOB_TRAINING',

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -1874,6 +1874,7 @@ export type ShelterType = {
   maxStay?: Maybe<Scalars['Int']['output']>;
   name: Scalars['String']['output'];
   onSiteSecurity?: Maybe<Scalars['Boolean']['output']>;
+  operatingHours?: Maybe<Array<Maybe<TimeRange>>>;
   organization?: Maybe<OrganizationType>;
   otherRules?: Maybe<Scalars['String']['output']>;
   otherServices?: Maybe<Scalars['String']['output']>;
@@ -2014,6 +2015,12 @@ export enum TaskTypeEnum {
   NextStep = 'NEXT_STEP',
   Purpose = 'PURPOSE'
 }
+
+export type TimeRange = {
+  __typename?: 'TimeRange';
+  end?: Maybe<Scalars['DateTime']['output']>;
+  start?: Maybe<Scalars['DateTime']['output']>;
+};
 
 export enum TrainingServiceChoices {
   JobTraining = 'JOB_TRAINING',


### PR DESCRIPTION
DEV-1925

## Summary by Sourcery

Add support for shelter operating hours in the GraphQL API by introducing a TimeRange type and exposing an operatingHours field on ShelterType.

New Features:
- Introduce a TimeRange GraphQL type with optional start and end fields.
- Expose operatingHours on ShelterType to return a list of TimeRange objects based on backend data.

Enhancements:
- Implement a resolver that maps internal operating_hours tuples into TimeRange instances.

Chores:
- Regenerate client-side TypeScript GraphQL types for the updated schema.