### PR TITLE
update ClientCard (DEV-1875)

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/ClientCard/CardMenuBtn.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientCard/CardMenuBtn.tsx
@@ -1,0 +1,31 @@
+import { ThreeDotIcon } from '@monorepo/expo/shared/icons';
+import { IconButton } from '@monorepo/expo/shared/ui-components';
+import { StyleSheet, ViewStyle } from 'react-native';
+
+type TCardMenu = {
+  onPress: () => void;
+  style?: ViewStyle;
+};
+
+export function CardMenuBtn(props: TCardMenu) {
+  const { onPress, style } = props;
+
+  return (
+    <IconButton
+      style={[styles.container, style]}
+      onPress={onPress}
+      variant="transparent"
+      accessibilityLabel={'open client options menu'}
+      accessibilityHint={'open client options menu'}
+    >
+      <ThreeDotIcon />
+    </IconButton>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    position: 'relative',
+  },
+});

--- a/libs/expo/betterangels/src/lib/ui-components/ClientCard/ClientCard.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientCard/ClientCard.tsx
@@ -1,0 +1,63 @@
+import {
+  Colors,
+  Radiuses,
+  Spacings,
+  TMarginProps,
+  getMarginStyles,
+} from '@monorepo/expo/shared/static';
+import { Pressable, StyleSheet, View, ViewStyle } from 'react-native';
+import { ClientProfilesQuery } from '../../screens/Clients/__generated__/Clients.generated';
+import { ClientCardBase } from './ClientCardBase';
+
+type TClientProfile = ClientProfilesQuery['clientProfiles']['results'][number];
+
+export interface IClientCardProps extends TMarginProps {
+  client: TClientProfile | undefined;
+  onPress?: (client: TClientProfile) => void;
+  onMenuPress?: (client: TClientProfile) => void;
+  style?: ViewStyle;
+}
+
+export function ClientCard(props: IClientCardProps) {
+  const { client, onPress, style } = props;
+
+  if (!client) {
+    return null;
+  }
+
+  const wrapperStyle = [styles.container, style, getMarginStyles(props)];
+
+  if (!onPress) {
+    return (
+      <View style={wrapperStyle}>
+        <ClientCardBase {...props} />
+      </View>
+    );
+  }
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={() => onPress(client)}
+      style={({ pressed }) => [
+        wrapperStyle,
+        {
+          backgroundColor: pressed ? Colors.GRAY_PRESSED : Colors.WHITE,
+        },
+      ]}
+    >
+      <ClientCardBase {...props} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    borderRadius: Radiuses.xs,
+    padding: Spacings.xs,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    backgroundColor: Colors.WHITE,
+  },
+});

--- a/libs/expo/betterangels/src/lib/ui-components/ClientCard/ClientCardBase.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientCard/ClientCardBase.tsx
@@ -1,0 +1,105 @@
+import {
+  IdCardOutlineIcon,
+  LocationDotIcon,
+  UserOutlineIcon,
+} from '@monorepo/expo/shared/icons';
+import { Colors, Spacings } from '@monorepo/expo/shared/static';
+import {
+  Avatar,
+  TextBold,
+  TextRegular,
+  formatDateStatic,
+} from '@monorepo/expo/shared/ui-components';
+import { StyleSheet, View } from 'react-native';
+import { HmisProfileType, Maybe } from '../../apollo';
+import { CardMenuBtn } from './CardMenuBtn';
+import { IClientCardProps } from './ClientCard';
+
+export function ClientCardBase(props: IClientCardProps) {
+  const { client, onMenuPress } = props;
+
+  if (!client) {
+    return null;
+  }
+
+  const formatHeight = (inches: number) => {
+    const feet = Math.floor(inches / 12);
+    const remainingInches = inches % 12;
+    return `${feet}' ${remainingInches}"`;
+  };
+
+  const getLahsaHmisId = (
+    hmisProfiles: Maybe<HmisProfileType[] | undefined>
+  ) => {
+    return hmisProfiles?.find((profile) => profile?.agency === 'LAHSA')?.hmisId;
+  };
+
+  const formattedHeight = client.heightInInches
+    ? formatHeight(client.heightInInches)
+    : null;
+
+  const lahsaHmisId = client.hmisProfiles
+    ? getLahsaHmisId(client.hmisProfiles)
+    : null;
+
+  return (
+    <>
+      <Avatar
+        accessibilityLabel={`client's profile photo`}
+        accessibilityHint={`client's profile photo`}
+        imageUrl={client.profilePhoto?.url}
+        size="xl"
+        mr="xs"
+      />
+      <View style={{ gap: Spacings.xxs, flex: 2 }}>
+        <TextBold size="sm">
+          {client.firstName} {client.lastName}{' '}
+          {client.nickname && `(${client.nickname})`}
+        </TextBold>
+        {(client.dateOfBirth || formattedHeight) && (
+          <View style={styles.row}>
+            <UserOutlineIcon mr="xxs" size="sm" color={Colors.NEUTRAL_DARK} />
+            {!!client.dateOfBirth && (
+              <TextRegular size="xs">
+                {formatDateStatic({
+                  date: client.dateOfBirth,
+                  inputFormat: 'yyyy-MM-dd',
+                  outputFormat: 'MM/dd/yyyy',
+                })}{' '}
+                ({client.age})
+              </TextRegular>
+            )}
+            {!!client.dateOfBirth && !!client.heightInInches && (
+              <TextRegular size="xs"> | </TextRegular>
+            )}
+            {!!client.heightInInches && (
+              <TextRegular size="xs">Height: {formattedHeight}</TextRegular>
+            )}
+          </View>
+        )}
+        {!!client.residenceAddress && (
+          <View style={styles.row}>
+            <LocationDotIcon size="sm" mr="xxs" color={Colors.NEUTRAL_DARK} />
+            <TextRegular size="xs">{client.residenceAddress}</TextRegular>
+          </View>
+        )}
+        {!!lahsaHmisId && (
+          <View style={styles.row}>
+            <IdCardOutlineIcon size="sm" mr="xxs" color={Colors.NEUTRAL_DARK} />
+            <TextRegular size="xs">LAHSA HMIS ID: {lahsaHmisId}</TextRegular>
+          </View>
+        )}
+      </View>
+      {!!onMenuPress && <CardMenuBtn onPress={() => onMenuPress(client)} />}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 0,
+    marginBottom: 0,
+  },
+});

--- a/libs/expo/betterangels/src/lib/ui-components/ClientCard/index.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientCard/index.ts
@@ -1,0 +1,1 @@
+export { ClientCard } from './ClientCard';


### PR DESCRIPTION
### refactor ClientCard
**Opened against** `DEV-1875/create-note-dbl-create` **branch**

* motivation: 
  * simplify onPress logic by removing `select` prop + arrivedFrom
  * make card `onPress` optional so can render Card as a card and not as link
* can see implementation in Draft PR #1420 
 
part of DEV-1875 refactor

Note: not added to lib `index` exports to prevent conflicts. Will add once implemented

## Summary by Sourcery

Refactor the ClientCard UI by breaking it into modular components and enhance its layout to display comprehensive client details

Enhancements:
- Modularize ClientCard into a base component, a wrapper handling pressable and non-pressable variants, and a CardMenuBtn for menu actions
- Render client avatar, full name (with optional nickname), date of birth with age, formatted height, residence address, and LAHSA HMIS ID
- Support customizable margins and a pressed-state background for the pressable variant
- Expose ClientCard via an index file export