### PR TITLE
update MainModal (DEV-1875)

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModal.tsx
@@ -80,10 +80,12 @@ export function MainModal(props: IMainModalProps) {
           {topSection}
 
           {actions.map((action, idx: number) => {
+            // if action is a ReactNode, return (render)
             if (isValidElement(action)) {
               return cloneElement(action, { key: idx });
             }
 
+            // is not ReactNode, so treat as `TMainModalAction` type
             const { title, route, params, Icon, onPress } =
               action as TMainModalAction;
 

--- a/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModal.tsx
@@ -1,6 +1,6 @@
 import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
 import { useRouter } from 'expo-router';
-import { ElementType, ReactNode, cloneElement, isValidElement } from 'react';
+import { ElementType, Fragment, ReactNode, isValidElement } from 'react';
 import { DimensionValue, StyleSheet, View } from 'react-native';
 import Modal from 'react-native-modal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -82,7 +82,7 @@ export function MainModal(props: IMainModalProps) {
           {actions.map((action, idx: number) => {
             // if action is a ReactNode, return (render)
             if (isValidElement(action)) {
-              return cloneElement(action, { key: idx });
+              return <Fragment key={idx}>{action}</Fragment>;
             }
 
             // is not ReactNode, so treat as `TMainModalAction` type

--- a/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModal.tsx
@@ -1,0 +1,132 @@
+import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
+import { useRouter } from 'expo-router';
+import { ElementType, ReactNode, cloneElement, isValidElement } from 'react';
+import { DimensionValue, StyleSheet, View } from 'react-native';
+import Modal from 'react-native-modal';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { MainModalActionBtn } from './MainModalActionBtn';
+import { MainModalCloseBtn } from './MainModalCloseBtn';
+
+export type TMainModalAction = {
+  title: string;
+  Icon: ElementType;
+  route?: string;
+  params?: Record<string, string>;
+  onPress?: () => void;
+};
+
+interface IMainModalProps {
+  isModalVisible: boolean;
+  closeModal: () => void;
+  actions: (TMainModalAction | ReactNode)[];
+  bottomSection?: ReactNode;
+  topSection?: ReactNode;
+  closeButton?: boolean;
+  opacity?: number;
+  vertical?: boolean;
+  ml?: number;
+  height?: DimensionValue;
+}
+
+export function MainModal(props: IMainModalProps) {
+  const {
+    isModalVisible,
+    closeModal,
+    actions,
+    bottomSection,
+    topSection,
+    closeButton,
+    opacity = 0,
+    vertical = false,
+    ml = 0,
+    height = 'auto',
+  } = props;
+
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const bottomOffset = insets.bottom;
+  const topOffset = insets.top;
+
+  return (
+    <Modal
+      style={{
+        margin: 0,
+        marginLeft: ml,
+        flex: 1,
+        justifyContent: 'flex-end',
+      }}
+      animationIn={vertical ? 'slideInUp' : 'slideInRight'}
+      animationOut={vertical ? 'slideOutDown' : 'slideOutRight'}
+      backdropOpacity={opacity}
+      isVisible={isModalVisible}
+      onBackdropPress={closeModal}
+      useNativeDriverForBackdrop={true}
+    >
+      <View
+        style={{
+          borderTopLeftRadius: Radiuses.xs,
+          borderTopRightRadius: Radiuses.xs,
+          paddingTop: topOffset + Spacings.xs,
+          paddingHorizontal: Spacings.md,
+          paddingBottom: 35 + bottomOffset,
+          backgroundColor: Colors.WHITE,
+          height,
+        }}
+      >
+        {closeButton && <MainModalCloseBtn onPress={closeModal} />}
+
+        <View style={styles.modalOverlay}>
+          {topSection}
+
+          {actions.map((action, idx: number) => {
+            if (isValidElement(action)) {
+              return cloneElement(action, { key: idx });
+            }
+
+            const { title, route, params, Icon, onPress } =
+              action as TMainModalAction;
+
+            return (
+              <MainModalActionBtn
+                key={idx}
+                title={title}
+                Icon={Icon}
+                onPress={() => {
+                  // custom callback: invoke and return
+                  if (onPress) {
+                    return onPress();
+                  }
+
+                  // default behavior
+                  closeModal();
+
+                  if (route) {
+                    router.navigate({
+                      pathname: route,
+                      params: params,
+                    });
+                  }
+                }}
+              />
+            );
+          })}
+
+          {bottomSection}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalOverlay: {
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    backgroundColor: Colors.WHITE,
+    position: 'relative',
+    width: '100%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  },
+});

--- a/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModalActionBtn.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModalActionBtn.tsx
@@ -1,0 +1,45 @@
+import { Colors } from '@monorepo/expo/shared/static';
+import { ElementType } from 'react';
+import { Pressable, StyleSheet, ViewStyle } from 'react-native';
+import { MainModalActionBtnBody } from './MainModalActionBtnBody';
+
+type TProps = {
+  title: string;
+  Icon: ElementType;
+  onPress: () => void;
+  disabled?: boolean;
+  style?: ViewStyle;
+};
+
+export function MainModalActionBtn(props: TProps) {
+  const { title, Icon, onPress, disabled, style } = props;
+
+  return (
+    <Pressable
+      disabled={disabled}
+      onPress={onPress}
+      accessibilityRole="button"
+      style={[styles.container, style]}
+    >
+      {({ pressed }) => (
+        <MainModalActionBtnBody
+          title={title}
+          Icon={Icon}
+          style={{
+            backgroundColor: pressed
+              ? Colors.NEUTRAL_EXTRA_LIGHT
+              : Colors.WHITE,
+          }}
+        />
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});

--- a/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModalActionBtnBody.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModalActionBtnBody.tsx
@@ -1,0 +1,42 @@
+import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
+import { TextRegular } from '@monorepo/expo/shared/ui-components';
+import { ElementType } from 'react';
+import { StyleSheet, View, ViewStyle } from 'react-native';
+
+type TProps = {
+  title: string;
+  Icon: ElementType;
+  style?: ViewStyle;
+};
+
+export function MainModalActionBtnBody(props: TProps) {
+  const { title, Icon, style } = props;
+
+  return (
+    <View style={[styles.body, style]}>
+      <View style={styles.iconWrapper}>
+        <Icon color={Colors.PRIMARY_EXTRA_DARK} />
+      </View>
+
+      <TextRegular color={Colors.PRIMARY_EXTRA_DARK}>{title}</TextRegular>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: '100%',
+    borderRadius: Radiuses.xs,
+    paddingHorizontal: Spacings.sm,
+    paddingVertical: Spacings.sm,
+  },
+  iconWrapper: {
+    marginRight: Spacings.sm,
+    height: Spacings.xl,
+    width: Spacings.xl,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModalCloseBtn.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/MainModal/MainModalCloseBtn.tsx
@@ -1,0 +1,24 @@
+import { PlusIcon } from '@monorepo/expo/shared/icons';
+import { Colors } from '@monorepo/expo/shared/static';
+import { Pressable } from 'react-native';
+
+type TProps = {
+  onPress: () => void;
+};
+
+export function MainModalCloseBtn(props: TProps) {
+  const { onPress } = props;
+
+  return (
+    <Pressable
+      style={{ marginLeft: 'auto' }}
+      accessible
+      accessibilityHint="closes the modal"
+      accessibilityRole="button"
+      accessibilityLabel="close"
+      onPress={onPress}
+    >
+      <PlusIcon size="md" color={Colors.BLACK} rotate="45deg" />
+    </Pressable>
+  );
+}

--- a/libs/expo/betterangels/src/lib/ui-components/MainModal/index.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/MainModal/index.ts
@@ -1,0 +1,4 @@
+export { MainModal } from './MainModal';
+export type { TMainModalAction } from './MainModal';
+export { MainModalActionBtn } from './MainModalActionBtn';
+export { MainModalActionBtnBody } from './MainModalActionBtnBody';


### PR DESCRIPTION
### refactor MainModal

* motivation: 
  * extend `MainModal` to accept `ReactNode` as an `action
  * export `MainModalActionBtnBody` that can be reused in custom buttons passed in as ReactNode 
* can see implementation in Draft PR #1420 

**Opened against** `DEV-1875/create-note-dbl-create` **branch**

part of DEV-1875 refactor

Note: not added to lib `index` exports to prevent conflicts. Will add once implemented

## Summary by Sourcery

Introduce a reusable MainModal component and its supporting subcomponents to standardize modal dialogs with configurable sections, actions, and navigation integration

New Features:
- Add MainModal component with props for visibility, custom top/bottom sections, opacity, orientation, and height
- Implement TMainModalAction-driven action items with navigation or custom onPress handling
- Create MainModalActionBtn and MainModalActionBtnBody to render styled, press-responsive action buttons
- Add MainModalCloseBtn for a consistent close control
- Export MainModal, action button components, and associated types from the ui-components index