### PR TITLE
Add `betterangels-admin` CI/CD (DEV-1919)

### DIFF
--- a/apps/betterangels-admin/.env.build.preview
+++ b/apps/betterangels-admin/.env.build.preview
@@ -1,0 +1,1 @@
+VITE_SHELTER_API_URL=https://api.dev.betterangels.la

--- a/apps/betterangels-admin/.env.build.production
+++ b/apps/betterangels-admin/.env.build.production
@@ -1,0 +1,2 @@
+VITE_SHELTER_API_URL=https://api.prod.betterangels.la
+VITE_APP_BASE_PATH="/"

--- a/apps/betterangels-admin/.env.deploy.preview
+++ b/apps/betterangels-admin/.env.deploy.preview
@@ -1,0 +1,3 @@
+S3_BUCKET=development-us-west-2-betterangels-admin-web
+CF_DISTRIBUTION_ID=ERS0ZS4CLSFJ2
+ASSUME_ROLE=arn:aws:iam::784154756963:role/github-actions-deploy

--- a/apps/betterangels-admin/.env.deploy.production
+++ b/apps/betterangels-admin/.env.deploy.production
@@ -1,0 +1,4 @@
+S3_BUCKET=production-us-west-2-betterangels-admin-web
+CF_DISTRIBUTION_ID=E1IJVIITUZU5EH
+ASSUME_ROLE=arn:aws:iam::792513288588:role/github-actions-deploy
+VITE_APP_BASE_PATH="/"

--- a/apps/betterangels-admin/project.json
+++ b/apps/betterangels-admin/project.json
@@ -11,6 +11,49 @@
       "options": {
         "jestConfig": "apps/betterangels-admin/jest.config.ts"
       }
+    },
+    "set-env": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node tools/scripts/set-base-path.js"
+      },
+      "configurations": {
+        "production": {},
+        "preview": {}
+      }
+    },
+    "build": {
+      "executor": "@nx/vite:build",
+      "dependsOn": ["set-env"],
+      "options": {
+        "outputPath": "dist/apps/betterangels-admin",
+        "configFile": "apps/betterangels-admin/vite.config.mts"
+      },
+      "configurations": {
+        "production": {},
+        "preview": {}
+      }
+    },
+    "deploy": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "./tools/deploy/cloudfront_deploy.sh"
+      },
+      "configurations": {
+        "production": {},
+        "preview": {}
+      },
+      "dependsOn": ["build"]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"]
+    },
+    "post-pr-preview": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node tools/scripts/post-preview-comment.js --url=https://admin.dev.betterangels.la$VITE_APP_BASE_PATH"
+      }
     }
   }
 }

--- a/apps/betterangels-admin/src/main.tsx
+++ b/apps/betterangels-admin/src/main.tsx
@@ -1,7 +1,9 @@
 import { StrictMode } from 'react';
-import { BrowserRouter } from 'react-router-dom';
 import * as ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './app/app';
+
+const basename = import.meta.env.VITE_APP_BASE_PATH || '/';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -9,7 +11,7 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <App />
     </BrowserRouter>
   </StrictMode>

--- a/apps/betterangels-admin/vite.config.mts
+++ b/apps/betterangels-admin/vite.config.mts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import { ProxyOptions, defineConfig } from 'vite';
 
-const SERVER_PORT = 8083;
+const SERVER_PORT = 8084;
 
 const MEDIA_PATH = path.resolve(__dirname, '../betterangels-backend/media');
 const devServerProxy: Record<string, string | ProxyOptions> = {
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => {
     }),
 
     preview: {
-      port: 8183,
+      port: 8184,
       host: 'localhost',
     },
 

--- a/apps/betterangels-admin/vite.config.mts
+++ b/apps/betterangels-admin/vite.config.mts
@@ -1,0 +1,58 @@
+/// <reference types='vitest' />
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { ProxyOptions, defineConfig } from 'vite';
+
+const SERVER_PORT = 8083;
+
+const MEDIA_PATH = path.resolve(__dirname, '../betterangels-backend/media');
+const devServerProxy: Record<string, string | ProxyOptions> = {
+  // to import media from from betterangels-backend
+  '/media': {
+    target: `http://localhost:${SERVER_PORT}/@fs${MEDIA_PATH}`,
+    changeOrigin: true,
+    rewrite: (path) => path.replace(/^\/media/, ''),
+  },
+};
+
+export default defineConfig(({ mode }) => {
+  const isDev = mode === 'development';
+  const basePath = isDev ? '/' : process.env.VITE_APP_BASE_PATH;
+  return {
+    base: basePath,
+    root: __dirname,
+    cacheDir: '../../node_modules/.vite/apps/betterangels-admin',
+
+    define: {
+      'import.meta.env.VITE_APP_BASE_PATH': JSON.stringify(basePath),
+    },
+
+    ...(isDev && {
+      server: {
+        port: SERVER_PORT,
+        host: 'localhost',
+        proxy: devServerProxy,
+      },
+    }),
+
+    preview: {
+      port: 8183,
+      host: 'localhost',
+    },
+
+    plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+
+    resolve: {},
+
+    build: {
+      outDir: '../../dist/apps/betterangels-admin',
+      emptyOutDir: true,
+      reportCompressedSize: true,
+      commonjsOptions: {
+        transformMixedEsModules: true,
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary by Sourcery

Set up CI/CD pipeline for the betterangels-admin app by defining Nx targets for environment setup, build, deployment, linting, and post-preview comments and by adding environment configuration files.

Enhancements:
- Add a post-PR preview comment command to notify with the live preview URL

Build:
- Introduce a ‘set-env’ target to configure the base path before builds
- Configure a Vite-based ‘build’ target that depends on environment setup
- Add a lint target using ESLint

Deployment:
- Add a ‘deploy’ target that runs a CloudFront deployment script

Chores:
- Add placeholder ‘.env.build’ and ‘.env.deploy’ files for preview and production environments