### PR TITLE
Fix Django Postoffice Email Lock

### DIFF
--- a/apps/betterangels-backend/accounts/tasks.py
+++ b/apps/betterangels-backend/accounts/tasks.py
@@ -1,0 +1,54 @@
+import logging
+from typing import Optional
+
+from celery import Task, shared_task
+from common.celery import single_instance
+from django.db import connection as db_connection
+from post_office.mail import get_queued, send_queued
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    bind=True,
+    name="post_office.tasks.send_queued_mail",
+    ignore_result=True,
+)
+@single_instance(
+    cache_alias="default",
+    lock_key="celery-lock:post_office.tasks.send_queued_mail",
+    lock_ttl=15,
+    retry_delay=5,
+)
+def send_queued_mail(
+    self: Task,
+    processes: int = 1,
+    log_level: Optional[int] = None,
+) -> None:
+    """
+    Custom replacement for post_office.tasks.send_queued_mail.
+    Processes the queue in batches until empty, under a single-instance lock.
+    """
+    logger.info(
+        "Starting send_queued_mail (task id=%s) with processes=%d, log_level=%s",
+        self.request.id,
+        processes,
+        log_level,
+    )
+
+    while True:
+        try:
+            send_queued(processes=processes, log_level=log_level)
+        except Exception:
+            logger.exception(
+                "Error sending queued mail",
+                extra={"status_code": 500},
+            )
+            raise
+
+        # Close DB connection to avoid multiprocessing errors
+        db_connection.close()
+
+        if not get_queued().exists():
+            logger.info("Queue empty, send_queued_mail complete")
+            break

--- a/apps/betterangels-backend/common/celery.py
+++ b/apps/betterangels-backend/common/celery.py
@@ -1,7 +1,6 @@
 import functools
 from typing import Any, Callable, TypeVar, cast
 
-from celery import Task
 from celery.exceptions import Ignore
 from django.core.cache import caches
 

--- a/apps/betterangels-backend/common/celery.py
+++ b/apps/betterangels-backend/common/celery.py
@@ -1,0 +1,41 @@
+import functools
+from typing import Callable, Concatenate, ParamSpec, TypeVar
+
+from celery import Task
+from celery.exceptions import Ignore
+from django.core.cache import caches
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def single_instance(
+    *,
+    cache_alias: str = "default",
+    lock_key: str | None = None,
+    lock_ttl: int = 3600,
+    retry_delay: int = 60,
+) -> Callable[[Callable[Concatenate[Task, P], R]], Callable[Concatenate[Task, P], R]]:
+    """Decorator that guarantees only one running instance of a Celery task."""
+
+    cache = caches[cache_alias]
+
+    def decorator(func: Callable[Concatenate[Task, P], R]) -> Callable[Concatenate[Task, P], R]:
+        @functools.wraps(func)
+        def wrapper(self: Task, *args: P.args, **kwargs: P.kwargs) -> R:  # <- R only
+            key = lock_key or f"celery-lock:{self.name}"
+            acquired = bool(cache.add(key, "1", timeout=lock_ttl))
+
+            if not acquired:
+                # Another instance is running — re‑queue and skip
+                self.apply_async(args=args, kwargs=kwargs, countdown=retry_delay)
+                raise Ignore()  # raises → never returns
+
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                cache.delete(key)
+
+        return wrapper
+
+    return decorator

--- a/apps/betterangels-backend/common/tests/test_single_instance.py
+++ b/apps/betterangels-backend/common/tests/test_single_instance.py
@@ -1,0 +1,89 @@
+# common/tests/test_single_instance.py
+from unittest.mock import MagicMock
+
+from celery import Task
+from celery.exceptions import Ignore
+from common.celery import single_instance
+from django.core.cache import caches
+from django.test import SimpleTestCase, override_settings
+
+# use Django’s in‑memory cache for isolation
+LOC_MEM = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "single-instance-tests",
+    }
+}
+
+
+@override_settings(CACHES=LOC_MEM)
+class SingleInstanceDecoratorTests(SimpleTestCase):
+    def setUp(self) -> None:
+        self.cache = caches["default"]
+        self.cache.clear()
+
+    class FakeTask(Task):
+        name = "test.task"
+        apply_async: MagicMock
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.apply_async = MagicMock()
+
+    def test_runs_when_no_lock(self) -> None:
+        calls: list[int] = []
+
+        @single_instance(lock_ttl=60, retry_delay=5)
+        def my_task(self: Task, x: int) -> None:
+            calls.append(x)
+
+        t = self.FakeTask()
+        my_task(t, 123)
+
+        self.assertEqual(calls, [123])
+        t.apply_async.assert_not_called()
+
+    def test_skips_and_requeues_when_locked(self) -> None:
+        calls: list[int] = []
+
+        @single_instance(lock_ttl=60, retry_delay=5)
+        def my_task(self: Task, x: int) -> None:
+            calls.append(x)
+
+        t = self.FakeTask()
+        # simulate a held lock
+        self.cache.add("celery-lock:test.task", "1", timeout=60)
+
+        with self.assertRaises(Ignore):
+            my_task(t, 42)
+
+        t.apply_async.assert_called_once_with(args=(42,), kwargs={}, countdown=5)
+        self.assertEqual(calls, [])
+
+    def test_lock_released_on_success(self) -> None:
+        key = "celery-lock:test.task"
+
+        @single_instance(lock_ttl=60, retry_delay=5)
+        def my_task(self: Task) -> str:
+            return "done"
+
+        t = self.FakeTask()
+        result = my_task(t)
+
+        # key should be gone
+        self.assertIsNone(self.cache.get(key))
+        self.assertEqual(result, "done")
+
+    def test_lock_released_on_exception(self) -> None:
+        key = "celery-lock:test.task"
+
+        @single_instance(lock_ttl=60, retry_delay=5)
+        def my_task(self: Task) -> None:
+            raise RuntimeError("boom")
+
+        t = self.FakeTask()
+        with self.assertRaises(RuntimeError):
+            my_task(t)
+
+        self.assertIsNone(self.cache.get(key))
+        self.assertIsNone(self.cache.get(key))

--- a/apps/betterangels-backend/common/tests/test_single_instance.py
+++ b/apps/betterangels-backend/common/tests/test_single_instance.py
@@ -23,7 +23,7 @@ class SingleInstanceDecoratorTests(SimpleTestCase):
 
     class FakeTask(Task):
         name = "test.task"
-        apply_async: MagicMock  # type: ignore[override]
+        apply_async: MagicMock
 
         def __init__(self) -> None:
             super().__init__()

--- a/apps/betterangels-backend/common/tests/test_single_instance.py
+++ b/apps/betterangels-backend/common/tests/test_single_instance.py
@@ -1,4 +1,3 @@
-# common/tests/test_single_instance.py
 from unittest.mock import MagicMock
 
 from celery import Task


### PR DESCRIPTION
## Summary by Sourcery

Implement a single-instance locking mechanism for Celery tasks, apply it to the Post Office email sending task to prevent concurrent runs, and include tests covering locking behavior, requeuing, and lock cleanup

New Features:
- Introduce single_instance decorator to ensure only one running instance of a Celery task
- Add custom send_queued_mail Celery task for Post Office that uses single-instance locking

Bug Fixes:
- Prevent concurrent execution conflicts in Post Office email sending by enforcing task locking

Enhancements:
- Add detailed logging and close the database connection between email send iterations in send_queued_mail

Tests:
- Add unit tests for the single_instance decorator to verify lock acquisition, requeue behavior, and lock release on success or failure