### PR TITLE
add perm checks to org portal (DEV-2048)

### DIFF
--- a/apps/betterangels-admin/src/app/Layout/AppSidebar.tsx
+++ b/apps/betterangels-admin/src/app/Layout/AppSidebar.tsx
@@ -4,11 +4,7 @@ import {
   Sidebar,
   mergeCss,
 } from '@monorepo/react/components';
-import {
-  GroupsIcon,
-  HandHeartOutlineIcon,
-  UsersIcon,
-} from '@monorepo/react/icons';
+import { UsersIcon } from '@monorepo/react/icons';
 import { useState } from 'react';
 
 type IProps = {
@@ -32,31 +28,16 @@ export function AppSidebar(props: IProps) {
           <h2 className="text-2xl truncate">{userOrganization.name}</h2>
         )}
       </Sidebar.Header>
-
       <Sidebar.Content>
-        <Sidebar.Link
-          to="/users"
-          collapsed={!isOpen}
-          icon={(color: string) => <UsersIcon className="w-4" fill={color} />}
-        >
-          Users
-        </Sidebar.Link>
-        <Sidebar.Link
-          to="/teams"
-          collapsed={!isOpen}
-          icon={(color: string) => <GroupsIcon className="w-4" fill={color} />}
-        >
-          Teams
-        </Sidebar.Link>
-        <Sidebar.Link
-          to="/services"
-          collapsed={!isOpen}
-          icon={(color: string) => (
-            <HandHeartOutlineIcon className="w-4" fill={color} />
-          )}
-        >
-          Services
-        </Sidebar.Link>
+        {user?.canViewOrgMembers && (
+          <Sidebar.Link
+            to="/users"
+            collapsed={!isOpen}
+            icon={(color: string) => <UsersIcon className="w-4" fill={color} />}
+          >
+            Users
+          </Sidebar.Link>
+        )}
       </Sidebar.Content>
     </Sidebar>
   );

--- a/apps/betterangels-admin/src/app/pages/home.tsx
+++ b/apps/betterangels-admin/src/app/pages/home.tsx
@@ -4,9 +4,8 @@ export default function Home() {
   const { user } = useUser();
   return (
     <div className="flex items-center justify-center h-full bg-white flex-col">
-      {user?.canAccessOrgPortal ? (
-        <div>Welcome to Home, {user?.email}!</div>
-      ) : (
+      {user?.canAccessOrgPortal && <div>Welcome to Home, {user?.email}!</div>}
+      {!user?.canAccessOrgPortal && (
         <div>You don't have permission to access this service.</div>
       )}
     </div>

--- a/apps/betterangels-admin/src/app/pages/home.tsx
+++ b/apps/betterangels-admin/src/app/pages/home.tsx
@@ -2,10 +2,13 @@ import { useUser } from '@monorepo/react/betterangels-admin';
 
 export default function Home() {
   const { user } = useUser();
-
   return (
     <div className="flex items-center justify-center h-full bg-white flex-col">
-      <div>Welcome to Home, {user?.email}!</div>
+      {user?.canAccessOrgPortal ? (
+        <div>Welcome to Home, {user?.email}!</div>
+      ) : (
+        <div>You don't have permission to access this service.</div>
+      )}
     </div>
   );
 }

--- a/libs/react/betterangels-admin/src/lib/pages/users/index.tsx
+++ b/libs/react/betterangels-admin/src/lib/pages/users/index.tsx
@@ -83,7 +83,7 @@ export default function Users() {
           </button>
         )}
       </div>
-      {user.canViewOrgMembers ? (
+      {user.canViewOrgMembers && (
         <Table<(typeof members)[number]>
           header={TABLE_HEADER}
           data={members}
@@ -119,9 +119,9 @@ export default function Users() {
           totalPages={totalPages}
           onPageChange={(newPage) => setPage(newPage)}
         />
-      ) : (
-        "You don't have permission to view this organization's members."
       )}
+      {!user.canViewOrgMembers &&
+        "You don't have permission to view this organization's members."}
     </div>
   );
 }

--- a/libs/react/betterangels-admin/src/lib/pages/users/index.tsx
+++ b/libs/react/betterangels-admin/src/lib/pages/users/index.tsx
@@ -73,49 +73,55 @@ export default function Users() {
             organization.
           </p>
         </div>
-        <button
-          onClick={handleShowDrawer}
-          className="btn btn-primary btn-lg gap-2 inline-flex"
-        >
-          <PlusIcon color="white" className="w-3 h-3" />
-          Add User
-        </button>
-      </div>
-      <Table<(typeof members)[number]>
-        header={TABLE_HEADER}
-        data={members}
-        renderCell={(member, colIndex) => {
-          switch (colIndex) {
-            case 0:
-              return member.firstName ?? '';
-            case 1:
-              return member.lastName ?? '';
-            case 2:
-              return member.memberRole ?? '';
-            case 3:
-              return member.email ?? '';
-            case 4:
-              return member.lastLogin
-                ? formatDistanceToNow(parseISO(member.lastLogin), {
-                    addSuffix: true,
-                  })
-                : 'Never';
-            default:
-              return '';
-          }
-        }}
-        action={(member) => (
+        {user.canAddOrgMember && (
           <button
-            onClick={() => console.log('Clicked:', member)}
-            className="p-2 rounded-lg hover:bg-neutral-100"
+            onClick={handleShowDrawer}
+            className="btn btn-primary btn-lg gap-2 inline-flex"
           >
-            <EllipseIcon className="h-5 w-5 text-neutral-500" />
+            <PlusIcon color="white" className="w-3 h-3" />
+            Add User
           </button>
         )}
-        page={page}
-        totalPages={totalPages}
-        onPageChange={(newPage) => setPage(newPage)}
-      />
+      </div>
+      {user.canViewOrgMembers ? (
+        <Table<(typeof members)[number]>
+          header={TABLE_HEADER}
+          data={members}
+          renderCell={(member, colIndex) => {
+            switch (colIndex) {
+              case 0:
+                return member.firstName ?? '';
+              case 1:
+                return member.lastName ?? '';
+              case 2:
+                return member.memberRole ?? '';
+              case 3:
+                return member.email ?? '';
+              case 4:
+                return member.lastLogin
+                  ? formatDistanceToNow(parseISO(member.lastLogin), {
+                      addSuffix: true,
+                    })
+                  : 'Never';
+              default:
+                return '';
+            }
+          }}
+          action={(member) => (
+            <button
+              onClick={() => console.log('Clicked:', member)}
+              className="p-2 rounded-lg hover:bg-neutral-100"
+            >
+              <EllipseIcon className="h-5 w-5 text-neutral-500" />
+            </button>
+          )}
+          page={page}
+          totalPages={totalPages}
+          onPageChange={(newPage) => setPage(newPage)}
+        />
+      ) : (
+        "You don't have permission to view this organization's members."
+      )}
     </div>
   );
 }

--- a/libs/react/betterangels-admin/src/lib/providers/user/UserContext.ts
+++ b/libs/react/betterangels-admin/src/lib/providers/user/UserContext.ts
@@ -13,9 +13,11 @@ export type TUser = {
   lastName?: string;
   email?: string | null;
   organizations: TOrganization[] | null;
-  isOutreachAuthorized?: boolean;
-  hasAcceptedTos?: boolean;
-  hasAcceptedPrivacyPolicy?: boolean;
+  canAccessOrgPortal: boolean;
+  canAddOrgMember: boolean;
+  canChangeOrgMemberRole: boolean;
+  canRemoveOrgMember: boolean;
+  canViewOrgMembers: boolean;
 };
 
 export interface IUserProviderValue {

--- a/libs/react/betterangels-admin/src/lib/providers/user/UserContext.ts
+++ b/libs/react/betterangels-admin/src/lib/providers/user/UserContext.ts
@@ -13,11 +13,11 @@ export type TUser = {
   lastName?: string;
   email?: string | null;
   organizations: TOrganization[] | null;
-  canAccessOrgPortal: boolean;
-  canAddOrgMember: boolean;
-  canChangeOrgMemberRole: boolean;
-  canRemoveOrgMember: boolean;
-  canViewOrgMembers: boolean;
+  canAccessOrgPortal?: boolean;
+  canAddOrgMember?: boolean;
+  canChangeOrgMemberRole?: boolean;
+  canRemoveOrgMember?: boolean;
+  canViewOrgMembers?: boolean;
 };
 
 export interface IUserProviderValue {

--- a/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.graphql
+++ b/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.graphql
@@ -1,4 +1,4 @@
-query currentUser {
+query currentOrgUser {
   currentUser {
     id
     username
@@ -8,9 +8,7 @@ query currentUser {
     organizations: organizationsOrganization {
       id
       name
+      userPermissions
     }
-    isOutreachAuthorized
-    hasAcceptedTos
-    hasAcceptedPrivacyPolicy
   }
 }

--- a/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.tsx
+++ b/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.tsx
@@ -16,29 +16,25 @@ const parseUser = (
   if (!user) {
     return undefined;
   }
-
   const userOrganization = user.organizations?.[0];
-
   if (!userOrganization) {
     return undefined;
   }
 
-  const { userPermissions } = userOrganization;
+  const userPermissions = userOrganization.userPermissions ?? [];
+  const permissionMap = {
+    [UserOrganizationPermissions.AccessOrgPortal]: 'canAccessOrgPortal',
+    [UserOrganizationPermissions.AddOrgMember]: 'canAddOrgMember',
+    [UserOrganizationPermissions.ChangeOrgMemberRole]: 'canChangeOrgMemberRole',
+    [UserOrganizationPermissions.RemoveOrgMember]: 'canRemoveOrgMember',
+    [UserOrganizationPermissions.ViewOrgMembers]: 'canViewOrgMembers',
+  };
 
-  const canAccessOrgPortal = userPermissions?.includes(
-    UserOrganizationPermissions.AccessOrgPortal
-  );
-  const canAddOrgMember = userPermissions?.includes(
-    UserOrganizationPermissions.AddOrgMember
-  );
-  const canChangeOrgMemberRole = userPermissions?.includes(
-    UserOrganizationPermissions.ChangeOrgMemberRole
-  );
-  const canRemoveOrgMember = userPermissions?.includes(
-    UserOrganizationPermissions.RemoveOrgMember
-  );
-  const canViewOrgMembers = userPermissions?.includes(
-    UserOrganizationPermissions.ViewOrgMembers
+  const permFlags = Object.fromEntries(
+    Object.entries(permissionMap).map(([perm, key]) => [
+      key,
+      userPermissions.includes(perm as UserOrganizationPermissions),
+    ])
   );
 
   return {
@@ -49,11 +45,7 @@ const parseUser = (
     lastName: user.lastName ?? undefined,
     email: user.email,
     organizations: user.organizations ?? null,
-    canAccessOrgPortal: canAccessOrgPortal ?? false,
-    canAddOrgMember: canAddOrgMember ?? false,
-    canChangeOrgMemberRole: canChangeOrgMemberRole ?? false,
-    canRemoveOrgMember: canRemoveOrgMember ?? false,
-    canViewOrgMembers: canViewOrgMembers ?? false,
+    ...permFlags,
   };
 };
 

--- a/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.tsx
+++ b/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.tsx
@@ -1,8 +1,9 @@
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { UserOrganizationPermissions } from '../../apollo/graphql/__generated__/types';
 import UserContext, { TUser } from './UserContext';
 import {
-  CurrentUserQuery,
-  useCurrentUserQuery,
+  CurrentOrgUserQuery,
+  useCurrentOrgUserQuery,
 } from './__generated__/UserProvider.generated';
 
 interface UserProviderProps {
@@ -10,13 +11,35 @@ interface UserProviderProps {
 }
 
 const parseUser = (
-  user?: CurrentUserQuery['currentUser']
+  user?: CurrentOrgUserQuery['currentUser']
 ): TUser | undefined => {
   if (!user) {
     return undefined;
   }
 
   const userOrganization = user.organizations?.[0];
+
+  if (!userOrganization) {
+    return undefined;
+  }
+
+  const { userPermissions } = userOrganization;
+
+  const canAccessOrgPortal = userPermissions?.includes(
+    UserOrganizationPermissions.AccessOrgPortal
+  );
+  const canAddOrgMember = userPermissions?.includes(
+    UserOrganizationPermissions.AddOrgMember
+  );
+  const canChangeOrgMemberRole = userPermissions?.includes(
+    UserOrganizationPermissions.ChangeOrgMemberRole
+  );
+  const canRemoveOrgMember = userPermissions?.includes(
+    UserOrganizationPermissions.RemoveOrgMember
+  );
+  const canViewOrgMembers = userPermissions?.includes(
+    UserOrganizationPermissions.ViewOrgMembers
+  );
 
   return {
     id: user.id,
@@ -26,14 +49,16 @@ const parseUser = (
     lastName: user.lastName ?? undefined,
     email: user.email,
     organizations: user.organizations ?? null,
-    isOutreachAuthorized: user.isOutreachAuthorized ?? false,
-    hasAcceptedTos: user.hasAcceptedTos ?? false,
-    hasAcceptedPrivacyPolicy: user.hasAcceptedPrivacyPolicy ?? false,
+    canAccessOrgPortal: canAccessOrgPortal ?? false,
+    canAddOrgMember: canAddOrgMember ?? false,
+    canChangeOrgMemberRole: canChangeOrgMemberRole ?? false,
+    canRemoveOrgMember: canRemoveOrgMember ?? false,
+    canViewOrgMembers: canViewOrgMembers ?? false,
   };
 };
 
 type UserResponse = {
-  data?: CurrentUserQuery;
+  data?: CurrentOrgUserQuery;
   errors?: readonly { message: string }[];
 };
 
@@ -41,7 +66,7 @@ export default function UserProvider({ children }: UserProviderProps) {
   const [user, setUser] = useState<TUser | undefined>();
   const [isLoading, setIsLoading] = useState(true);
 
-  const { data, loading, error, refetch } = useCurrentUserQuery({
+  const { data, loading, error, refetch } = useCurrentOrgUserQuery({
     fetchPolicy: 'network-only',
     errorPolicy: 'all',
   });

--- a/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.tsx
+++ b/libs/react/betterangels-admin/src/lib/providers/user/UserProvider.tsx
@@ -22,7 +22,7 @@ const parseUser = (
   }
 
   const userPermissions = userOrganization.userPermissions ?? [];
-  const permissionMap = {
+  const permissionMap: Record<UserOrganizationPermissions, string> = {
     [UserOrganizationPermissions.AccessOrgPortal]: 'canAccessOrgPortal',
     [UserOrganizationPermissions.AddOrgMember]: 'canAddOrgMember',
     [UserOrganizationPermissions.ChangeOrgMemberRole]: 'canChangeOrgMemberRole',

--- a/libs/react/betterangels-admin/src/lib/providers/user/__generated__/UserProvider.generated.ts
+++ b/libs/react/betterangels-admin/src/lib/providers/user/__generated__/UserProvider.generated.ts
@@ -3,14 +3,14 @@ import * as Types from '../../../apollo/graphql/__generated__/types';
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 const defaultOptions = {} as const;
-export type CurrentUserQueryVariables = Types.Exact<{ [key: string]: never; }>;
+export type CurrentOrgUserQueryVariables = Types.Exact<{ [key: string]: never; }>;
 
 
-export type CurrentUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'UserType', id: string, username: string, firstName?: any | null, lastName?: any | null, email?: any | null, isOutreachAuthorized?: boolean | null, hasAcceptedTos?: boolean | null, hasAcceptedPrivacyPolicy?: boolean | null, organizations?: Array<{ __typename?: 'OrganizationForUserType', id: string, name: string }> | null } };
+export type CurrentOrgUserQuery = { __typename?: 'Query', currentUser: { __typename?: 'UserType', id: string, username: string, firstName?: any | null, lastName?: any | null, email?: any | null, organizations?: Array<{ __typename?: 'OrganizationForUserType', id: string, name: string, userPermissions?: Array<Types.UserOrganizationPermissions> | null }> | null } };
 
 
-export const CurrentUserDocument = gql`
-    query currentUser {
+export const CurrentOrgUserDocument = gql`
+    query currentOrgUser {
   currentUser {
     id
     username
@@ -20,42 +20,40 @@ export const CurrentUserDocument = gql`
     organizations: organizationsOrganization {
       id
       name
+      userPermissions
     }
-    isOutreachAuthorized
-    hasAcceptedTos
-    hasAcceptedPrivacyPolicy
   }
 }
     `;
 
 /**
- * __useCurrentUserQuery__
+ * __useCurrentOrgUserQuery__
  *
- * To run a query within a React component, call `useCurrentUserQuery` and pass it any options that fit your needs.
- * When your component renders, `useCurrentUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useCurrentOrgUserQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCurrentOrgUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useCurrentUserQuery({
+ * const { data, loading, error } = useCurrentOrgUserQuery({
  *   variables: {
  *   },
  * });
  */
-export function useCurrentUserQuery(baseOptions?: Apollo.QueryHookOptions<CurrentUserQuery, CurrentUserQueryVariables>) {
+export function useCurrentOrgUserQuery(baseOptions?: Apollo.QueryHookOptions<CurrentOrgUserQuery, CurrentOrgUserQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<CurrentUserQuery, CurrentUserQueryVariables>(CurrentUserDocument, options);
+        return Apollo.useQuery<CurrentOrgUserQuery, CurrentOrgUserQueryVariables>(CurrentOrgUserDocument, options);
       }
-export function useCurrentUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrentUserQuery, CurrentUserQueryVariables>) {
+export function useCurrentOrgUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrentOrgUserQuery, CurrentOrgUserQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<CurrentUserQuery, CurrentUserQueryVariables>(CurrentUserDocument, options);
+          return Apollo.useLazyQuery<CurrentOrgUserQuery, CurrentOrgUserQueryVariables>(CurrentOrgUserDocument, options);
         }
-export function useCurrentUserSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CurrentUserQuery, CurrentUserQueryVariables>) {
+export function useCurrentOrgUserSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CurrentOrgUserQuery, CurrentOrgUserQueryVariables>) {
           const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<CurrentUserQuery, CurrentUserQueryVariables>(CurrentUserDocument, options);
+          return Apollo.useSuspenseQuery<CurrentOrgUserQuery, CurrentOrgUserQueryVariables>(CurrentOrgUserDocument, options);
         }
-export type CurrentUserQueryHookResult = ReturnType<typeof useCurrentUserQuery>;
-export type CurrentUserLazyQueryHookResult = ReturnType<typeof useCurrentUserLazyQuery>;
-export type CurrentUserSuspenseQueryHookResult = ReturnType<typeof useCurrentUserSuspenseQuery>;
-export type CurrentUserQueryResult = Apollo.QueryResult<CurrentUserQuery, CurrentUserQueryVariables>;
+export type CurrentOrgUserQueryHookResult = ReturnType<typeof useCurrentOrgUserQuery>;
+export type CurrentOrgUserLazyQueryHookResult = ReturnType<typeof useCurrentOrgUserLazyQuery>;
+export type CurrentOrgUserSuspenseQueryHookResult = ReturnType<typeof useCurrentOrgUserSuspenseQuery>;
+export type CurrentOrgUserQueryResult = Apollo.QueryResult<CurrentOrgUserQuery, CurrentOrgUserQueryVariables>;


### PR DESCRIPTION
DEV-2048

## Summary by Sourcery

Introduce granular organization-level permission checks across the admin portal by extending the user context with new permission flags and conditionally rendering UI elements based on those flags.

Enhancements:
- Extend UserProvider to use a CurrentOrgUser query and expose userPermissions flags (AccessOrgPortal, AddOrgMember, ChangeOrgMemberRole, RemoveOrgMember, ViewOrgMembers).
- Update GraphQL query to fetch userPermissions and rename it from currentUser to currentOrgUser.
- Gate access to key UI components (home page welcome message, sidebar links, add-user button, and members table) based on the appropriate permission flags.