### PR TITLE
Hide 3 dot menu in user table (DEV-2060)

### DIFF
--- a/libs/react/betterangels-admin/src/lib/pages/users/index.tsx
+++ b/libs/react/betterangels-admin/src/lib/pages/users/index.tsx
@@ -1,5 +1,5 @@
 import { useAppDrawer } from '@monorepo/react/components';
-import { EllipseIcon, PlusIcon } from '@monorepo/react/icons';
+import { PlusIcon } from '@monorepo/react/icons';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { useEffect, useState } from 'react';
 import { OrganizationMemberType } from '../../apollo/graphql/__generated__/types';
@@ -107,14 +107,15 @@ export default function Users() {
                 return '';
             }
           }}
-          action={(member) => (
-            <button
-              onClick={() => console.log('Clicked:', member)}
-              className="p-2 rounded-lg hover:bg-neutral-100"
-            >
-              <EllipseIcon className="h-5 w-5 text-neutral-500" />
-            </button>
-          )}
+          // TODO: for future implementation
+          // action={(member) => (
+          //   <button
+          //     onClick={() => console.log('Clicked:', member)}
+          //     className="p-2 rounded-lg hover:bg-neutral-100"
+          //   >
+          //     <EllipseIcon className="h-5 w-5 text-neutral-500" />
+          //   </button>
+          // )}
           page={page}
           totalPages={totalPages}
           onPageChange={(newPage) => setPage(newPage)}


### PR DESCRIPTION
DEV-2060

## Summary by Sourcery

Hide the three-dot action menu in the users table by commenting out its renderer and mark it for future implementation

Enhancements:
- Comment out the action prop to remove the ellipsis button from each user row

Chores:
- Add a TODO note indicating future restoration of the action menu