### PR TITLE
replace notes order with ordering (DEV-2068)

### DIFF
--- a/apps/betterangels/src/app/(private-screens)/add-note/[noteId].tsx
+++ b/apps/betterangels/src/app/(private-screens)/add-note/[noteId].tsx
@@ -98,7 +98,7 @@ export default function AddNote() {
         query: NotesDocument,
         variables: {
           pagination: { limit: 10 + 1, offset: 0 },
-          order: { interactedAt: Ordering.Desc, id: Ordering.Desc },
+          ordering: [{ interactedAt: Ordering.Desc}, {id: Ordering.Desc }],
           filters: { authors: [user?.id], search: '' },
         },
       },

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/queries.generated.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/queries.generated.ts
@@ -6,7 +6,7 @@ const defaultOptions = {} as const;
 export type NotesQueryVariables = Types.Exact<{
   filters?: Types.InputMaybe<Types.NoteFilter>;
   pagination?: Types.InputMaybe<Types.OffsetPaginationInput>;
-  order?: Types.InputMaybe<Types.NoteOrder>;
+  ordering?: Array<Types.NoteOrder> | Types.NoteOrder;
 }>;
 
 
@@ -21,8 +21,8 @@ export type ViewNoteQuery = { __typename?: 'Query', note: { __typename?: 'NoteTy
 
 
 export const NotesDocument = gql`
-    query Notes($filters: NoteFilter, $pagination: OffsetPaginationInput, $order: NoteOrder) {
-  notes(filters: $filters, pagination: $pagination, order: $order) {
+    query Notes($filters: NoteFilter, $pagination: OffsetPaginationInput, $ordering: [NoteOrder!]! = []) {
+  notes(filters: $filters, pagination: $pagination, ordering: $ordering) {
     totalCount
     pageInfo {
       limit
@@ -104,7 +104,7 @@ export const NotesDocument = gql`
  *   variables: {
  *      filters: // value for 'filters'
  *      pagination: // value for 'pagination'
- *      order: // value for 'order'
+ *      ordering: // value for 'ordering'
  *   },
  * });
  */

--- a/libs/expo/betterangels/src/lib/apollo/graphql/queries.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/queries.ts
@@ -4,9 +4,9 @@ export const GET_NOTES = gql`
   query Notes(
     $filters: NoteFilter
     $pagination: OffsetPaginationInput
-    $order: NoteOrder
+    $ordering: [NoteOrder!]! = []
   ) {
-    notes(filters: $filters, pagination: $pagination, order: $order) {
+    notes(filters: $filters, pagination: $pagination, ordering: $ordering) {
       totalCount
       pageInfo {
         limit

--- a/libs/expo/betterangels/src/lib/hooks/interactions/useGetClientInteractionsWithLocation.ts
+++ b/libs/expo/betterangels/src/lib/hooks/interactions/useGetClientInteractionsWithLocation.ts
@@ -5,10 +5,10 @@ import {
   useNotesQuery,
 } from '../../apollo';
 
-const defaultSortOrder: NoteOrder = {
-  interactedAt: Ordering.Desc,
-  id: Ordering.Desc,
-};
+const defaultSortOrder: Array<NoteOrder> = [
+  { interactedAt: Ordering.Desc },
+  { id: Ordering.Desc },
+];
 
 type TProps = {
   id: string;
@@ -24,7 +24,7 @@ export function useGetClientInteractionsWithLocation(props: TProps) {
   const { data, error, loading } = useNotesQuery({
     variables: {
       pagination: { limit: 1000, offset: 0 },
-      order: sortOrder,
+      ordering: sortOrder,
       filters: {
         clientProfile: id,
       },

--- a/libs/expo/betterangels/src/lib/screens/Client/Interactions/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Interactions/index.tsx
@@ -25,7 +25,7 @@ export default function Interactions({
   const { data, loading, error, refetch } = useNotesQuery({
     variables: {
       pagination: { limit: paginationLimit, offset: offset },
-      order: { interactedAt: Ordering.Desc, id: Ordering.Desc },
+      ordering: [{ interactedAt: Ordering.Desc }, { id: Ordering.Desc }],
       filters: {
         clientProfile: client?.clientProfile?.id,
         search: filterSearch,

--- a/libs/expo/betterangels/src/lib/screens/Interactions/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Interactions/index.tsx
@@ -44,7 +44,7 @@ export default function Interactions() {
   const { data, loading, error, refetch } = useNotesQuery({
     variables: {
       pagination: { limit: paginationLimit, offset: offset },
-      order: { interactedAt: Ordering.Desc, id: Ordering.Desc },
+      ordering: [{ interactedAt: Ordering.Desc }, { id: Ordering.Desc }],
       filters: {
         authors: filters.authors.length
           ? filters.authors.map((item) => item.id)


### PR DESCRIPTION
DEV-2068

before, after
<div>
<img width="250" height="463" alt="image" src="https://github.com/user-attachments/assets/0a941e15-abd6-40b7-bf12-05e210a02d6c" />
<img width="251" height="460" alt="image" src="https://github.com/user-attachments/assets/2b8716d0-df18-4c56-8799-e6ac25438203" />
</div>



## Summary by Sourcery

Enhancements:
- Switch notes queries and related components to accept an ‘ordering’ array of NoteOrder entries instead of a single order object