### PR TITLE
dynamically inject manger-head.html with base path

### DIFF
--- a/apps/storybook-react/.storybook/manager-head.html
+++ b/apps/storybook-react/.storybook/manager-head.html
@@ -1,2 +1,0 @@
-<!-- Set base path for manager shell -->
-<base href="/branches/storybook-app/">

--- a/apps/storybook-react/.storybook/preview-head.html
+++ b/apps/storybook-react/.storybook/preview-head.html
@@ -1,2 +1,0 @@
-<!-- Optional but recommended: sets base for iframe -->
-<base href="/branches/storybook-app/">

--- a/apps/storybook-react/project.json
+++ b/apps/storybook-react/project.json
@@ -15,6 +15,13 @@
         "preview": {}
       }
     },
+    "generate-storybook-head": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "node tools/scripts/generate-storybook-head.js"
+      },
+      "dependsOn": ["set-env"]
+    },
     "storybook": {
       "executor": "@nx/storybook:storybook",
       "options": {
@@ -24,7 +31,7 @@
     },
     "build": {
       "executor": "@nx/storybook:build",
-      "dependsOn": ["set-env"],
+      "dependsOn": ["set-env", "generate-storybook-head"],
       "outputs": ["{workspaceRoot}/dist/apps/storybook-react"],
       "options": {
         "configDir": "apps/storybook-react/.storybook",

--- a/tools/scripts/generate-storybook-head.js
+++ b/tools/scripts/generate-storybook-head.js
@@ -1,0 +1,54 @@
+/**
+ * Script: generate-storybook-head.js
+ * -----------------------------------
+ * This script generates the Storybook head files (`manager-head.html` and `preview-head.html`)
+ * with the appropriate <base href="..."> tag, based on the VITE_APP_BASE_PATH set in `.env.local`.
+ * The manager/preview-head.html files are used by Storybook to inject <base href=VITE_APP_BASE_PATH />
+ * into the main html document.
+ *
+ * It is intended to be run as an Nx target using the environment variable `NX_TASK_TARGET_PROJECT`,
+ * which is automatically set by Nx when you run the script as a target for a specific project.
+ *
+ * Prerequisites:
+ * - `.env.local` must exist at `apps/<project>/.env.local` and contain a valid `VITE_APP_BASE_PATH`.
+ * - The project must be a Storybook app with `.storybook/` directory.
+ *
+ * Example usage (via Nx target):
+ *   nx run storybook-react:generate-head
+ */
+
+import { config } from 'dotenv';
+import { existsSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const project = process.env.NX_TASK_TARGET_PROJECT;
+if (!project) {
+  console.error('❌ NX_TASK_TARGET_PROJECT not found. Must be run via Nx.');
+  process.exit(1);
+}
+
+const envPath = resolve(process.cwd(), `apps/${project}/.env.local`);
+config({ path: envPath });
+
+const basePath = process.env.VITE_APP_BASE_PATH;
+if (!basePath) {
+  console.error(`❌ VITE_APP_BASE_PATH not set in ${envPath}`);
+  process.exit(1);
+}
+
+const headDir = resolve(process.cwd(), `apps/${project}/.storybook`);
+
+if (!existsSync(headDir)) {
+  console.error(`❌ .storybook folder not found at: ${headDir}`);
+  process.exit(1);
+}
+
+const baseTag = `<base href="${
+  basePath.endsWith('/') ? basePath : basePath + '/'
+}" />\n`;
+
+['manager-head.html', 'preview-head.html'].forEach((file) => {
+  const outPath = resolve(headDir, file);
+  writeFileSync(outPath, baseTag, 'utf8');
+  console.log(`✅ [${project}] wrote ${file} with basePath [${basePath}]`);
+});


### PR DESCRIPTION
## Summary by Sourcery

Generate Storybook head files with a dynamic base path by adding a new Nx target and accompanying script, and ensure the build step runs this generator before bundling.

New Features:
- Add an Nx target `generate-storybook-head` to create Storybook head files
- Introduce a Node script to inject a `<base href>` tag into `manager-head.html` and `preview-head.html` from `VITE_APP_BASE_PATH`

Enhancements:
- Make the Storybook build step depend on the `generate-storybook-head` target