### PR TITLE
add task admin & fix task form client id (DEV-2019, DEV-2126)

### DIFF
--- a/apps/betterangels-backend/tasks/admin.py
+++ b/apps/betterangels-backend/tasks/admin.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+from django.contrib import admin
+from import_export.admin import ExportActionMixin
+from rangefilter.filters import DateRangeFilterBuilder
+
+from .models import Task
+
+
+@admin.register(Task)
+class TaskAdmin(ExportActionMixin, admin.ModelAdmin):
+
+    list_display = (
+        "task_summary",
+        "client_profile_name",
+        "created_by_name",
+        "team",
+        "organization",
+        "status",
+        "created_at",
+        "updated_at",
+        "note",
+    )
+    list_filter = (
+        "organization",
+        "status",
+        ("created_at", DateRangeFilterBuilder()),
+        ("updated_at", DateRangeFilterBuilder()),
+    )
+    search_fields = (
+        "summary",
+        "description",
+        "client_profile__email",
+        "client_profile__first_name",
+        "client_profile__last_name",
+        "client_profile__middle_name",
+        "client_profile__nickname",
+        "created_by__first_name",
+        "created_by__last_name",
+        "created_by__email",
+        "organization__name",
+    )
+    readonly_fields = (
+        "created_at",
+        "updated_at",
+    )
+
+    def task_summary(self, obj: Task) -> str:
+        return f"{obj.summary} ({obj.pk})"
+
+    def created_by_name(self, obj: Task) -> Optional[str]:
+        return (
+            f"{obj.created_by.first_name} {obj.created_by.last_name} ({obj.created_by.pk})" if obj.created_by else None
+        )
+
+    def client_profile_name(self, obj: Task) -> Optional[str]:
+        return (
+            f"{obj.client_profile.first_name or ''} {obj.client_profile.last_name or ''} ({obj.client_profile.pk})"
+            if obj.client_profile
+            else None
+        )

--- a/apps/betterangels-backend/tasks/tests/utils.py
+++ b/apps/betterangels-backend/tasks/tests/utils.py
@@ -8,7 +8,7 @@ class TaskGraphQLUtilsMixin(HasGraphQLProtocol):
         return """
             id
             clientProfile { id firstName lastName }
-        createdAt
+            createdAt
             createdBy { id firstName lastName }
             description
             note { pk }

--- a/apps/betterangels/src/app/(private-screens)/add-note/Tasks/index.tsx
+++ b/apps/betterangels/src/app/(private-screens)/add-note/Tasks/index.tsx
@@ -9,6 +9,7 @@ import { RefObject } from 'react';
 import { ScrollView } from 'react-native';
 
 interface ITasksProps {
+  clientProfileId: string;
   noteId: string;
   scrollRef: RefObject<ScrollView | null>;
   tasks: ViewNoteQuery['note']['tasks'];
@@ -20,10 +21,11 @@ interface ITasksProps {
 }
 
 export default function Tasks(props: ITasksProps) {
-  const { noteId, tasks, scrollRef, refetch, team } = props;
+  const { clientProfileId, noteId, tasks, scrollRef, refetch, team } = props;
 
   return (
     <NoteTasks
+      clientProfileId={clientProfileId}
       noteId={noteId}
       scrollRef={scrollRef}
       tasks={tasks}

--- a/apps/betterangels/src/app/(private-screens)/add-note/[noteId].tsx
+++ b/apps/betterangels/src/app/(private-screens)/add-note/[noteId].tsx
@@ -249,6 +249,10 @@ export default function AddNote() {
     return null;
   }
 
+  if (!data.note.clientProfile || isLoading) {
+    return null;
+  }
+
   return (
     <View style={{ flex: 1 }}>
       <MainScrollContainer
@@ -272,7 +276,12 @@ export default function AddNote() {
         /> */}
         <ProvidedServices services={data.note.providedServices} {...props} />
         <RequestedServices services={data.note.requestedServices} {...props} />
-        <Tasks tasks={data.note.tasks} team={data.note.team} {...props} />
+        <Tasks
+          clientProfileId={data.note.clientProfile.id}
+          tasks={data.note.tasks}
+          team={data.note.team}
+          {...props}
+        />
         <PublicNote
           note={data.note.publicDetails}
           isPublicNoteEdited={isPublicNoteEdited}

--- a/libs/expo/betterangels/src/lib/ui-components/NoteTasks/NoteTaskModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteTasks/NoteTaskModal.tsx
@@ -8,6 +8,7 @@ import { useModalScreen } from '../../providers';
 import { TaskForm } from '../TaskForm';
 
 interface INoteTasksModalProps {
+  clientProfileId: string;
   noteId: string;
   refetch: () => void;
   team?: SelahTeamEnum | null;
@@ -15,7 +16,7 @@ interface INoteTasksModalProps {
 }
 
 export default function NoteTasksModal(props: INoteTasksModalProps) {
-  const { noteId, refetch, team, task } = props;
+  const { clientProfileId, noteId, refetch, team, task } = props;
 
   const { closeModalScreen } = useModalScreen();
   const { top: topInset } = useSafeAreaInsets();
@@ -54,6 +55,7 @@ export default function NoteTasksModal(props: INoteTasksModalProps) {
         </IconButton>
       </View>
       <TaskForm
+        clientProfileId={clientProfileId}
         onCancel={closeModal}
         task={task}
         team={team}

--- a/libs/expo/betterangels/src/lib/ui-components/NoteTasks/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteTasks/index.tsx
@@ -11,6 +11,7 @@ import { useModalScreen } from '../../providers';
 import NoteTasksModal from './NoteTaskModal';
 
 interface INoteTasksProps {
+  clientProfileId: string;
   noteId: string;
   scrollRef: RefObject<ScrollView | null>;
   tasks?: ViewNoteQuery['note']['tasks'];
@@ -19,7 +20,7 @@ interface INoteTasksProps {
 }
 
 export default function NoteTasks(props: INoteTasksProps) {
-  const { noteId, tasks, scrollRef, refetch, team } = props;
+  const { clientProfileId, noteId, tasks, scrollRef, refetch, team } = props;
   const { showModalScreen } = useModalScreen();
 
   if (!tasks) {
@@ -32,6 +33,7 @@ export default function NoteTasks(props: INoteTasksProps) {
       hideHeader: true,
       content: (
         <NoteTasksModal
+          clientProfileId={clientProfileId}
           task={task}
           team={team}
           noteId={noteId}
@@ -53,7 +55,12 @@ export default function NoteTasks(props: INoteTasksProps) {
             presentation: 'fullScreenModal',
             hideHeader: true,
             content: (
-              <NoteTasksModal team={team} noteId={noteId} refetch={refetch} />
+              <NoteTasksModal
+                clientProfileId={clientProfileId}
+                team={team}
+                noteId={noteId}
+                refetch={refetch}
+              />
             ),
           });
       }}
@@ -85,6 +92,7 @@ export default function NoteTasks(props: INoteTasksProps) {
                   hideHeader: true,
                   content: (
                     <NoteTasksModal
+                      clientProfileId={clientProfileId}
                       team={team}
                       noteId={noteId}
                       refetch={refetch}

--- a/libs/expo/betterangels/src/lib/ui-components/TaskForm/TaskForm.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskForm/TaskForm.tsx
@@ -35,7 +35,6 @@ export function TaskForm(props: TProps) {
   const { showSnackbar } = useSnackbar();
   const [createTaskMutation] = useCreateTaskMutation();
   const [updateTaskMutation] = useUpdateTaskMutation();
-  console.log(clientProfileId);
   const {
     control,
     handleSubmit,

--- a/libs/expo/betterangels/src/lib/ui-components/TaskForm/TaskForm.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskForm/TaskForm.tsx
@@ -35,7 +35,7 @@ export function TaskForm(props: TProps) {
   const { showSnackbar } = useSnackbar();
   const [createTaskMutation] = useCreateTaskMutation();
   const [updateTaskMutation] = useUpdateTaskMutation();
-
+  console.log(clientProfileId);
   const {
     control,
     handleSubmit,


### PR DESCRIPTION
DEV-2019, DEV-2126

## Summary by Sourcery

Register Task model in Django admin and propagate clientProfileId prop through task-related UI components to ensure tasks are correctly associated with clients, while adding a guard in the AddNote screen for missing client profiles.

New Features:
- Add TaskAdmin in Django admin with list display, filters, search, and export actions

Enhancements:
- Pass clientProfileId through NoteTasks, Tasks, NoteTasksModal, and TaskForm components
- Add clientProfile null and loading check in AddNote screen before rendering tasks