### PR TITLE
clear service column before changing col type (DEV-2082)

### DIFF
--- a/apps/betterangels-backend/notes/migrations/0025_servicerequest_service_use_fk.py
+++ b/apps/betterangels-backend/notes/migrations/0025_servicerequest_service_use_fk.py
@@ -6,6 +6,13 @@ import pgtrigger.migrations
 from django.db import migrations, models
 
 
+def clear_column_values(apps, schema_editor) -> None:
+    ServiceRequest = apps.get_model("notes", "ServiceRequest")
+    ServiceRequestEvent = apps.get_model("notes", "ServiceRequestEvent")
+    ServiceRequest.objects.all().update(service=None)
+    ServiceRequestEvent.objects.all().update(service=None)
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -13,6 +20,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(clear_column_values, migrations.RunPython.noop),
         pgtrigger.migrations.RemoveTrigger(
             model_name="servicerequest",
             name="service_request_add_insert",


### PR DESCRIPTION
DEV-2082

need to clear `service` col before changing type. this migration failed to run in dev. should be safe to update it and let it rerun

https://us-west-2.console.aws.amazon.com/ecs/v2/clusters/default/services/betterangels-backend-migration/logs?region=us-west-2