### PR TITLE
add withoutClient variant for TaskCard (DEV-2129)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
@@ -31,7 +31,9 @@ export function TasksTab(props: TProps) {
   }, []);
 
   const renderTaskItem = useCallback(
-    (task: TTask) => <TaskCard task={task} onPress={handleTaskPress} />,
+    (task: TTask) => (
+      <TaskCard task={task} onPress={handleTaskPress} variant="withoutClient" />
+    ),
     [handleTaskPress]
   );
 

--- a/libs/expo/betterangels/src/lib/ui-components/TaskCard/TaskCard.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskCard/TaskCard.tsx
@@ -7,13 +7,16 @@ import TaskCardClient from './TaskCardClient';
 import TaskCardCreatedBy from './TaskCardCreatedBy';
 import TaskCardStatus from './TaskCardStatus';
 
+type TaskCardVariant = 'default' | 'withoutClient';
+
 type TaskCardProps = {
   task: TasksQuery['tasks']['results'][number];
   onPress?: (task: TasksQuery['tasks']['results'][number]) => void;
+  variant?: TaskCardVariant;
 };
 
 export function TaskCard(props: TaskCardProps) {
-  const { task, onPress } = props;
+  const { task, onPress, variant = 'default' } = props;
 
   return (
     <View style={styles.container}>
@@ -25,9 +28,11 @@ export function TaskCard(props: TaskCardProps) {
         <TextBold size="sm" mb="sm">
           {task.summary}
         </TextBold>
-        {task.clientProfile && (
+
+        {variant !== 'withoutClient' && task.clientProfile && (
           <TaskCardClient clientProfile={task.clientProfile} />
         )}
+
         <TaskCardCreatedBy
           organization={task.organization}
           createdBy={task.createdBy}


### PR DESCRIPTION
Client's name is visible on Client Profile - Tasks page
DEV-2129


Tasks Page
<img width="320" alt="image" src="https://github.com/user-attachments/assets/2e9fb994-a5de-4df2-a036-2683bc2d6581" />

Client Profile Tab
<img width="320" alt="image" src="https://github.com/user-attachments/assets/1f794d9c-bfd2-4a7b-a9e2-7b01355d3058" />

## Summary by Sourcery

Introduce a skipClient prop in TaskCard to conditionally hide the client profile section and enable it in the Client Tasks tab to omit redundant client names

New Features:
- Add skipClient prop to TaskCard to optionally skip rendering the clientProfile section
- Pass skipClient=true to TaskCard in Client Tasks tab to hide client names on the Tasks page