### PR TITLE
fix note export service label generation (DEV-2150)

### DIFF
--- a/apps/betterangels-backend/notes/admin.py
+++ b/apps/betterangels-backend/notes/admin.py
@@ -99,7 +99,7 @@ class NoteResource(resources.ModelResource):
 
     def _join_services(self, services: QuerySet) -> str:
         return ", ".join(
-            s.service_other if s.service_enum == ServiceEnum.OTHER else s.get_service_display() for s in services
+            s.service_other if s.service_enum == ServiceEnum.OTHER else str(s.service_enum.label) for s in services
         )
 
     def dehydrate_requested_services(self, note: Note) -> str:


### PR DESCRIPTION
DEV-2150

## Summary by Sourcery

Bug Fixes:
- Use service_enum.label for non-OTHER services in the note export admin’s _join_services method instead of calling get_service_display()