### PR TITLE
storybook with RN-web (DEV-2114)

### DIFF
--- a/apps/betterangels/package.json
+++ b/apps/betterangels/package.json
@@ -87,7 +87,8 @@
     "vite": "*",
     "@nx/vite": "*",
     "ts-essentials": "*",
-    "vitest": "*"
+    "vitest": "*",
+    "@storybook/react-native-web-vite": "*"
   },
   "scripts": {
     "eas-build-pre-install": "corepack enable && mkdir -p .yarn && cp -R ../../.yarn/patches .yarn/patches 2>/dev/null || :",

--- a/apps/shelter-e2e/tsconfig.json
+++ b/apps/shelter-e2e/tsconfig.json
@@ -2,9 +2,5 @@
   "extends": "../../tsconfig.base.json",
   "files": [],
   "include": [],
-  "references": [
-    {
-      "path": "./tsconfig.e2e.json"
-    }
-  ]
+  "references": []
 }

--- a/apps/storybook-react/.storybook/main.ts
+++ b/apps/storybook-react/.storybook/main.ts
@@ -1,21 +1,19 @@
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import type { StorybookConfig } from '@storybook/react-vite';
-import react from '@vitejs/plugin-react';
+import type { StorybookConfig } from '@storybook/react-native-web-vite';
 import 'dotenv/config';
 import { mergeConfig, searchForWorkspaceRoot } from 'vite';
 import svgr from 'vite-plugin-svgr';
-import { LIB_STORY_GLOBS } from '../config';
-import { rawSvgPlugin } from './plugins/rawSvgPlugin';
+import { ALL_LIB_STORY_GLOBS } from '../config';
 
 const config: StorybookConfig = {
-  stories: LIB_STORY_GLOBS,
+  stories: ALL_LIB_STORY_GLOBS,
   addons: [],
   framework: {
-    name: '@storybook/react-vite',
+    name: '@storybook/react-native-web-vite',
     options: {},
   },
 
-  // NOTE: still not sure why, but breaks without it
+  // avoids react-docgen breakage in some setups
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
@@ -24,20 +22,29 @@ const config: StorybookConfig = {
     },
   },
 
-  viteFinal: async (config) => {
-    // storybook does not pass in `mode`
+  viteFinal: async (base) => {
     const isDev = process.env.NODE_ENV === 'development';
     const basePath = isDev ? '/' : process.env.VITE_APP_BASE_PATH || '/';
 
-    return mergeConfig(config, {
+    return mergeConfig(base, {
       base: basePath,
       define: {
         'import.meta.env.VITE_APP_BASE_PATH': JSON.stringify(basePath),
       },
       plugins: [
-        svgr({}),
-        rawSvgPlugin(), // TODO: switch to SVGR globally for react libs
-        react(),
+        // svgr({}),
+        // rawSvgPlugin(), // TODO: switch to SVGR globally for react libs
+
+        // svgr with these options works with rn-native
+        // but removing rawSvgPlugin() breaks the web version of svg icons
+        svgr({
+          include: '**/*.svg',
+          svgrOptions: {
+            exportType: 'default',
+            ref: true,
+          },
+        }),
+        // react(), --  not needed with rn-web?
         nxViteTsPaths(),
       ],
       server: { fs: { allow: [searchForWorkspaceRoot(process.cwd())] } },

--- a/apps/storybook-react/.storybook/main.ts
+++ b/apps/storybook-react/.storybook/main.ts
@@ -4,12 +4,12 @@ import 'dotenv/config';
 import { resolve } from 'path';
 import { mergeConfig, searchForWorkspaceRoot } from 'vite';
 import svgr from 'vite-plugin-svgr';
-import { ALL_LIB_STORY_GLOBS } from '../config';
+import { PLATFORM_STORIES, REACT_STORIES, RN_STORIES } from '../config';
 import { appendReactQueryForRnSvg } from './plugins/appendReactQueryForRnSvg';
 import { rawSvgPlugin } from './plugins/rawSvgPlugin';
 
 const config: StorybookConfig = {
-  stories: ALL_LIB_STORY_GLOBS,
+  stories: [...PLATFORM_STORIES, ...REACT_STORIES, ...RN_STORIES],
   addons: [],
   framework: {
     name: '@storybook/react-native-web-vite',

--- a/apps/storybook-react/.storybook/plugins/appendReactQueryForRnSvg.ts
+++ b/apps/storybook-react/.storybook/plugins/appendReactQueryForRnSvg.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+import type { Plugin } from 'vite';
+
+function norm(p: string) {
+  return p.split(path.sep).join('/');
+}
+
+/**
+ * Appends '?react' to .svg requests *only* when the importer is under a given root.
+ * This lets RN libs get component SVGs without changing source code.
+ */
+export function appendReactQueryForRnSvg(rnRootAbs: string): Plugin {
+  const rnRoot = norm(rnRootAbs);
+  return {
+    name: 'append-react-query-for-rn-svg',
+    enforce: 'pre',
+    async resolveId(source, importer) {
+      if (!importer || !source.endsWith('.svg')) return null;
+      if (/\?(react|raw|url)(?:$|&)/.test(source)) return null; // already explicit
+      const imp = norm(importer);
+      if (imp.includes(rnRoot)) {
+        // Rewrite to request component transform
+        return this.resolve(`${source}?react`, importer, { skipSelf: true });
+      }
+      return null;
+    },
+  };
+}

--- a/apps/storybook-react/.storybook/preview.ts
+++ b/apps/storybook-react/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import '../../../tailwind/fonts-rn.css';
 import '../../../tailwind/fonts.css';
 import '../src/styles/tailwind.css';
 

--- a/apps/storybook-react/.storybook/preview.tsx
+++ b/apps/storybook-react/.storybook/preview.tsx
@@ -1,10 +1,12 @@
+import { CustomLayout } from '@monorepo/react/storybook';
 import type { Preview } from '@storybook/react';
 import '../../../tailwind/fonts-rn.css';
 import '../../../tailwind/fonts.css';
 import '../src/styles/tailwind.css';
 
 const preview: Preview = {
-  parameters: { controls: { expanded: true }, layout: 'centered' },
+  parameters: { controls: { expanded: false }, layout: 'fullscreen' },
+  decorators: [CustomLayout],
 };
 
 export default preview;

--- a/apps/storybook-react/.storybook/tsconfig.json
+++ b/apps/storybook-react/.storybook/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client", "storybook/react-vite"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/apps/storybook-react/config.ts
+++ b/apps/storybook-react/config.ts
@@ -1,44 +1,67 @@
 import { join } from 'path';
+import { StoriesSpecifier } from 'storybook/internal/types';
 
-const LIB_STORY_ROOTS = [
-  '../../libs/react/components/src/lib',
-  '../../libs/assets/src/icons',
-  '../../libs/react/icons/src/lib/components',
+const storyFileTypes = '**/*.@(mdx|stories.@(js|jsx|ts|tsx))';
+
+// source directories
+const ICON_SVG_STORY_DIRS = ['../../libs/assets/src/icons'];
+
+const REACT_ICON_COMPONENT_DIRS = ['../../libs/react/icons/src/lib/components'];
+
+const REACT_COMPONENT_STORY_DIRS = ['../../libs/react/components/src/lib'];
+
+// stories
+export const PLATFORM_STORIES: StoriesSpecifier[] = [
+  ...ICON_SVG_STORY_DIRS.map((d) => ({
+    directory: join(__dirname, d),
+    files: storyFileTypes,
+    titlePrefix: 'Platform',
+  })),
 ];
 
-const RN_LIB_STORY_ROOTS = ['../../libs/expo/shared/ui-components/src/lib'];
+export const REACT_STORIES: StoriesSpecifier[] = [
+  ...REACT_ICON_COMPONENT_DIRS.map((d) => ({
+    directory: join(__dirname, d),
+    files: storyFileTypes,
+    titlePrefix: 'Web/Icons',
+  })),
+  ...REACT_COMPONENT_STORY_DIRS.map((d) => ({
+    directory: join(__dirname, d),
+    files: storyFileTypes,
+    titlePrefix: 'Web/Components',
+  })),
+];
 
-const LIB_CONTENT_ROOTS = [
+// use RN_COMPONENT_STORY_DIRS pattern once expo lib stories are updated
+// currently the placeholder stories have duplicate names which crashes
+export const RN_STORIES: StoriesSpecifier[] = [
+  {
+    directory: join(
+      __dirname,
+      '../../libs/expo/shared/ui-components/src/lib/Pill'
+    ),
+    files: 'Pill.stories.tsx',
+    titlePrefix: 'RN Components',
+  },
+  {
+    directory: join(
+      __dirname,
+      '../../libs/expo/shared/ui-components/src/lib/PillContainer'
+    ),
+    files: 'PillContainer.stories.tsx',
+    titlePrefix: 'RN Components',
+  },
+];
+
+// For tailwind to generate classes
+const TAILWIND_CONTENT_DIRS = [
   './src', // host
   '../../libs/react/storybook/src/lib', // react storybook lib
-  ...LIB_STORY_ROOTS,
+  ...REACT_COMPONENT_STORY_DIRS, // react components lib
 ];
 
-export const REACT_LIB_STORY_GLOBS = [
-  ...LIB_STORY_ROOTS.map((p) =>
-    join(__dirname, p, '**/*.@(mdx|stories.@(js|jsx|ts|tsx))')
+export const TAILWIND_CONTENT_GLOBS = [
+  ...TAILWIND_CONTENT_DIRS.map((p) =>
+    join(__dirname, p, '**/*.{ts,tsx,mdx,html}')
   ),
-];
-
-// TODO: use glob once `placeholder` files are updated
-// right now they all have same name and collide
-// export const RN_LIB_STORY_GLOBS = [
-//   ...RN_LIB_STORY_ROOTS.map((p) =>
-//     join(__dirname, p, '**/*.@(mdx|stories.@(js|jsx|ts|tsx))')
-//   ),
-// ];
-
-export const RN_LIB_STORY_GLOBS = [
-  ...RN_LIB_STORY_ROOTS.map((p) => join(__dirname, p, 'Pill/Pill.stories.tsx')),
-  ...RN_LIB_STORY_ROOTS.map((p) =>
-    join(__dirname, p, 'PillContainer/PillContainer.stories.tsx')
-  ),
-];
-export const ALL_LIB_STORY_GLOBS = [
-  ...REACT_LIB_STORY_GLOBS,
-  ...RN_LIB_STORY_GLOBS,
-];
-
-export const LIB_CONTENT_GLOBS = [
-  ...LIB_CONTENT_ROOTS.map((p) => join(__dirname, p, '**/*.{ts,tsx,mdx,html}')),
 ];

--- a/apps/storybook-react/config.ts
+++ b/apps/storybook-react/config.ts
@@ -6,16 +6,37 @@ const LIB_STORY_ROOTS = [
   '../../libs/react/icons/src/lib/components',
 ];
 
+const RN_LIB_STORY_ROOTS = ['../../libs/expo/shared/ui-components/src/lib'];
+
 const LIB_CONTENT_ROOTS = [
   './src', // host
   '../../libs/react/storybook/src/lib', // react storybook lib
   ...LIB_STORY_ROOTS,
 ];
 
-export const LIB_STORY_GLOBS = [
+export const REACT_LIB_STORY_GLOBS = [
   ...LIB_STORY_ROOTS.map((p) =>
     join(__dirname, p, '**/*.@(mdx|stories.@(js|jsx|ts|tsx))')
   ),
+];
+
+// TODO: use glob once `placeholder` files are updated
+// right now they all have same name and collide
+// export const RN_LIB_STORY_GLOBS = [
+//   ...RN_LIB_STORY_ROOTS.map((p) =>
+//     join(__dirname, p, '**/*.@(mdx|stories.@(js|jsx|ts|tsx))')
+//   ),
+// ];
+
+export const RN_LIB_STORY_GLOBS = [
+  ...RN_LIB_STORY_ROOTS.map((p) => join(__dirname, p, 'Pill/Pill.stories.tsx')),
+  ...RN_LIB_STORY_ROOTS.map((p) =>
+    join(__dirname, p, 'PillContainer/PillContainer.stories.tsx')
+  ),
+];
+export const ALL_LIB_STORY_GLOBS = [
+  ...REACT_LIB_STORY_GLOBS,
+  ...RN_LIB_STORY_GLOBS,
 ];
 
 export const LIB_CONTENT_GLOBS = [

--- a/apps/storybook-react/tailwind.config.ts
+++ b/apps/storybook-react/tailwind.config.ts
@@ -1,10 +1,10 @@
 import type { Config } from 'tailwindcss';
 import tailwindBase from '../../tailwind/tailwind.base.config';
-import { LIB_CONTENT_GLOBS, REACT_LIB_STORY_GLOBS } from './config';
+import { TAILWIND_CONTENT_GLOBS } from './config';
 
 const config: Config = {
   presets: [tailwindBase],
-  content: [...LIB_CONTENT_GLOBS, ...REACT_LIB_STORY_GLOBS],
+  content: [...TAILWIND_CONTENT_GLOBS],
   // SB-only tweaks are safe here:
   // corePlugins: { preflight: false },
   // daisyui: { themes: [] }, // if you want Daisy but no themes in SB

--- a/apps/storybook-react/tailwind.config.ts
+++ b/apps/storybook-react/tailwind.config.ts
@@ -1,10 +1,10 @@
 import type { Config } from 'tailwindcss';
 import tailwindBase from '../../tailwind/tailwind.base.config';
-import { LIB_CONTENT_GLOBS, LIB_STORY_GLOBS } from './config';
+import { LIB_CONTENT_GLOBS, REACT_LIB_STORY_GLOBS } from './config';
 
 const config: Config = {
   presets: [tailwindBase],
-  content: [...LIB_CONTENT_GLOBS, ...LIB_STORY_GLOBS],
+  content: [...LIB_CONTENT_GLOBS, ...REACT_LIB_STORY_GLOBS],
   // SB-only tweaks are safe here:
   // corePlugins: { preflight: false },
   // daisyui: { themes: [] }, // if you want Daisy but no themes in SB

--- a/libs/assets/src/icons/svg/SvgGallery.stories.tsx
+++ b/libs/assets/src/icons/svg/SvgGallery.stories.tsx
@@ -51,7 +51,11 @@ export default meta;
 type Story = StoryObj;
 
 export const ReactSvgGallery: Story = {
-  parameters: { layout: false },
+  parameters: {
+    customLayout: {
+      variant: 'basic',
+    },
+  },
   render: () => {
     return (
       <SbkGallery

--- a/libs/assets/src/icons/svg/SvgGalleryExpo.stories.tsx
+++ b/libs/assets/src/icons/svg/SvgGalleryExpo.stories.tsx
@@ -51,7 +51,11 @@ export default meta;
 type Story = StoryObj;
 
 export const ExpoSvgGallery: Story = {
-  parameters: { layout: false },
+  parameters: {
+    customLayout: {
+      variant: 'basic',
+    },
+  },
   render: () => {
     return (
       <SbkGallery

--- a/libs/expo/shared/static/src/lib/index.ts
+++ b/libs/expo/shared/static/src/lib/index.ts
@@ -1,21 +1,21 @@
 export { Colors } from './colors';
 export { FontSizes } from './fontSizes';
 export {
-  TMarginProps,
   getMarginStyles,
   marginPropKeys,
   omitMarginProps,
+  type TMarginProps,
 } from './margins';
-export { MimeTypes, TMimeType } from './mimeTypes';
-export { Radiuses, TRadius, TRadiusKey } from './radiuses';
+export { MimeTypes, type TMimeType } from './mimeTypes';
+export { Radiuses, type TRadius, type TRadiusKey } from './radiuses';
 export { Regex } from './regex';
 export { Shadow } from './shadow';
 export { Spacings } from './spacings';
 export {
-  FileThumbnailSizeDefault,
   IdThumbnailSize,
   ImageThumbnailSizeDefault,
-  TThumbnailSize,
   thumbnailSizes,
+  type FileThumbnailSizeDefault,
+  type TThumbnailSize,
 } from './thumbnail';
 export * from './types';

--- a/libs/expo/shared/static/src/lib/index.ts
+++ b/libs/expo/shared/static/src/lib/index.ts
@@ -12,10 +12,10 @@ export { Regex } from './regex';
 export { Shadow } from './shadow';
 export { Spacings } from './spacings';
 export {
+  FileThumbnailSizeDefault,
   IdThumbnailSize,
   ImageThumbnailSizeDefault,
   thumbnailSizes,
-  type FileThumbnailSizeDefault,
   type TThumbnailSize,
 } from './thumbnail';
 export * from './types';

--- a/libs/expo/shared/ui-components/src/lib/Pill/Pill.stories.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Pill/Pill.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Pill, type IPillProps } from './Pill';
 
 const meta: Meta<IPillProps> = {
-  title: 'React Native/Pill',
+  title: 'Pill',
   component: Pill,
   args: {
     label: 'Hello',

--- a/libs/expo/shared/ui-components/src/lib/Pill/Pill.stories.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Pill/Pill.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { Pill, type IPillProps } from './Pill';
 
 const meta: Meta<IPillProps> = {

--- a/libs/expo/shared/ui-components/src/lib/Pill/Pill.stories.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Pill/Pill.stories.tsx
@@ -1,23 +1,25 @@
-export default { title: 'Disabled until Expo storybook fixed' };
-export const Placeholder = () => null;
+import type { Meta, StoryObj } from '@storybook/react';
+import { Pill, type IPillProps } from './Pill';
 
-// import type { Meta, StoryObj } from '@storybook/react';
-// import { Pill } from './Pill';
+const meta: Meta<IPillProps> = {
+  title: 'React Native/Pill',
+  component: Pill,
+  args: {
+    label: 'Hello',
+    variant: 'success',
+  },
+  argTypes: {
+    variant: {
+      control: { type: 'inline-radio' },
+      options: ['primary', 'success', 'warning'],
+    },
+    label: { control: 'text' },
+  },
+};
+export default meta;
 
-// const meta: Meta<typeof Pill> = {
-//   title: 'Pill',
-//   component: Pill,
-//   args: {
-//     type: 'success',
-//   },
-// };
+type Story = StoryObj<IPillProps>;
 
-// export default meta;
-
-// type PillStory = StoryObj<typeof Pill>;
-
-// export const Basic: PillStory = {
-//   args: {
-//     type: 'success',
-//   },
-// };
+export const Success: Story = {
+  args: { label: 'Saved', variant: 'success' },
+};

--- a/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.stories.tsx
+++ b/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { PillContainer } from './PillContainer';
 
 const meta: Meta<typeof PillContainer> = {

--- a/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.stories.tsx
+++ b/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.stories.tsx
@@ -1,34 +1,31 @@
-export default { title: 'Disabled until Expo storybook fixed' };
-export const Placeholder = () => null;
+import type { Meta, StoryObj } from '@storybook/react';
+import { PillContainer } from './PillContainer';
 
-// import type { Meta, StoryObj } from '@storybook/react';
-// import { PillContainer } from './PillContainer';
+const meta: Meta<typeof PillContainer> = {
+  title: 'React Native/Pills/PillContainer',
+  component: PillContainer,
+  args: {
+    variant: 'expandable',
+    pills: [
+      'Service 1',
+      'Service 2',
+      'Service 3',
+      'Service 4',
+      'Service 5',
+      'Service 6',
+      'Service 7',
+      'Service 8',
+    ],
+    maxVisible: 3,
+  },
+};
 
-// const meta: Meta<typeof PillContainer> = {
-//   title: 'PillContainer',
-//   component: PillContainer,
-//   args: {
-//     type: 'success',
-//     data: [
-//       'Service 1',
-//       'Service 2',
-//       'Service 3',
-//       'Service 4',
-//       'Service 5',
-//       'Service 6',
-//       'Service 7',
-//       'Service 8',
-//     ],
-//     maxVisible: 5,
-//   },
-// };
+export default meta;
 
-// export default meta;
+type PillContainerStory = StoryObj<typeof PillContainer>;
 
-// type PillContainerStory = StoryObj<typeof PillContainer>;
-
-// export const Basic: PillContainerStory = {
-//   args: {
-//     type: 'success',
-//   },
-// };
+export const Basic: PillContainerStory = {
+  args: {
+    variant: 'expandable',
+  },
+};

--- a/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.stories.tsx
+++ b/libs/expo/shared/ui-components/src/lib/PillContainer/PillContainer.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { PillContainer } from './PillContainer';
 
 const meta: Meta<typeof PillContainer> = {
-  title: 'React Native/Pills/PillContainer',
+  title: 'PillContainer',
   component: PillContainer,
   args: {
     variant: 'expandable',

--- a/libs/react/betterangels-admin/tsconfig.spec.json
+++ b/libs/react/betterangels-admin/tsconfig.spec.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"],
-    "composite": true
+    "types": ["jest", "node"]
   }
 }

--- a/libs/react/components/src/lib/Alert/Alert.stories.tsx
+++ b/libs/react/components/src/lib/Alert/Alert.stories.tsx
@@ -4,7 +4,7 @@ import { Alert } from './Alert';
 import { useAlert } from './state/useAlert';
 
 const meta: Meta = {
-  title: 'Components/Alert',
+  title: 'Alert',
 };
 
 export default meta;

--- a/libs/react/components/src/lib/Alert/Alert.stories.tsx
+++ b/libs/react/components/src/lib/Alert/Alert.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj;
 export const AlertDemo: Story = {
   parameters: {
     customLayout: {
-      canvasStye: { width: 400 },
+      canvasStyle: { width: 400 },
     },
   },
   render: () => {

--- a/libs/react/components/src/lib/Alert/Alert.stories.tsx
+++ b/libs/react/components/src/lib/Alert/Alert.stories.tsx
@@ -1,4 +1,4 @@
-import { SbkButton, SbkPanel } from '@monorepo/react/storybook';
+import { SbkButton } from '@monorepo/react/storybook';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Alert } from './Alert';
 import { useAlert } from './state/useAlert';
@@ -13,14 +13,16 @@ type Story = StoryObj;
 
 export const AlertDemo: Story = {
   parameters: {
-    layout: null,
+    customLayout: {
+      canvasStye: { width: 400 },
+    },
   },
   render: () => {
     const Demo = () => {
       const { showAlert } = useAlert();
 
       return (
-        <SbkPanel className="mt-32 flex gap-8">
+        <>
           <SbkButton
             className="bg-green-400"
             onClick={() =>
@@ -37,7 +39,7 @@ export const AlertDemo: Story = {
           >
             Show Error
           </SbkButton>
-        </SbkPanel>
+        </>
       );
     };
 

--- a/libs/react/components/src/lib/AppDrawer/AppDrawer.stories.tsx
+++ b/libs/react/components/src/lib/AppDrawer/AppDrawer.stories.tsx
@@ -13,12 +13,17 @@ export default meta;
 type Story = StoryObj;
 
 export const AppDrawerDemo: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'flex-col',
+    },
+  },
   render: () => {
     const Demo = () => {
       const { showDrawer } = useAppDrawer();
 
       return (
-        <div className="flex flex-col gap-8">
+        <>
           <SbkButton
             className="bg-purple-400"
             onClick={() => showDrawer({ content: 'hello content' })}
@@ -45,7 +50,7 @@ export const AppDrawerDemo: Story = {
           >
             From Left
           </SbkButton>
-        </div>
+        </>
       );
     };
 

--- a/libs/react/components/src/lib/AppDrawer/AppDrawer.stories.tsx
+++ b/libs/react/components/src/lib/AppDrawer/AppDrawer.stories.tsx
@@ -4,7 +4,7 @@ import { AppDrawer } from './AppDrawer';
 import { useAppDrawer } from './state/useAppDrawer';
 
 const meta: Meta = {
-  title: 'Components/AppDrawer',
+  title: 'AppDrawer',
   decorators: [withMemoryRouter('/')],
 };
 

--- a/libs/react/components/src/lib/BetterAngelsLogoBadge/BetterAngelsLogoBadge.stories.tsx
+++ b/libs/react/components/src/lib/BetterAngelsLogoBadge/BetterAngelsLogoBadge.stories.tsx
@@ -3,7 +3,7 @@ import { BetterAngelsLogoBadge as StoryComponent } from './BetterAngelsLogoBadge
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/BetterAngelsLogoBadge',
+  title: 'BetterAngelsLogoBadge',
 };
 export default meta;
 

--- a/libs/react/components/src/lib/Button/Button.stories.tsx
+++ b/libs/react/components/src/lib/Button/Button.stories.tsx
@@ -3,7 +3,7 @@ import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   component: Button,
-  title: 'Components/Button',
+  title: 'Button',
 };
 export default meta;
 

--- a/libs/react/components/src/lib/Button/Button.stories.tsx
+++ b/libs/react/components/src/lib/Button/Button.stories.tsx
@@ -10,8 +10,13 @@ export default meta;
 type Story = StoryObj<typeof Button>;
 
 export const BasicButton: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'flex-col w-[280px]',
+    },
+  },
   render: (args) => (
-    <div className="flex flex-col gap-4">
+    <>
       <Button {...args}>text</Button>
       <Button {...args} className="pseudo-hover">
         hover
@@ -19,6 +24,6 @@ export const BasicButton: Story = {
       <Button {...args} className="pseudo-active">
         active
       </Button>
-    </div>
+    </>
   ),
 };

--- a/libs/react/components/src/lib/Checkbox/Checkbox.stories.tsx
+++ b/libs/react/components/src/lib/Checkbox/Checkbox.stories.tsx
@@ -29,6 +29,6 @@ export const Checkbox: Story = {
       onChange: setChecked,
     };
 
-    return <StoryComponent {...baseArgs} className="w-[300px]" />;
+    return <StoryComponent {...baseArgs} />;
   },
 };

--- a/libs/react/components/src/lib/Checkbox/Checkbox.stories.tsx
+++ b/libs/react/components/src/lib/Checkbox/Checkbox.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { ICheckbox, Checkbox as StoryComponent } from './Checkbox';
 
 const meta: Meta<typeof StoryComponent> = {
-  title: 'Components/Form-Ui/Checkbox',
+  title: 'Form-Ui/Checkbox',
   component: StoryComponent,
   argTypes: {
     ...disableControls(['onChange']),

--- a/libs/react/components/src/lib/Checkbox/CheckboxGroup.stories.tsx
+++ b/libs/react/components/src/lib/Checkbox/CheckboxGroup.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { CheckboxGroup as StoryComponent, TProps } from './CheckboxGroup';
 
 const meta: Meta<typeof StoryComponent> = {
-  title: 'Components/Form-Ui/Checkbox',
+  title: 'Form-Ui/Checkbox',
   component: StoryComponent,
   argTypes: {
     ...disableControls(['onClick']),

--- a/libs/react/components/src/lib/CurrentLocationDot/CurrentLocationDot.stories.tsx
+++ b/libs/react/components/src/lib/CurrentLocationDot/CurrentLocationDot.stories.tsx
@@ -3,7 +3,7 @@ import { CurrentLocationDot as StoryComponent } from './CurrentLocationDot';
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/CurrentLocationDot',
+  title: 'CurrentLocationDot',
 };
 export default meta;
 

--- a/libs/react/components/src/lib/Dropdown/Dropdown.stories.tsx
+++ b/libs/react/components/src/lib/Dropdown/Dropdown.stories.tsx
@@ -16,13 +16,14 @@ const defaultArgs: DropdownProps<string> = {
 };
 
 export const Dropdown: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'h-[400px] bg-gray-100',
+    },
+  },
   render: (args) => {
     const baseArgs = { ...defaultArgs, ...args };
 
-    return (
-      <div className="h-[300px] px-24 py-12 bg-gray-100">
-        <StoryComponent {...baseArgs} />
-      </div>
-    );
+    return <StoryComponent {...baseArgs} />;
   },
 };

--- a/libs/react/components/src/lib/Dropdown/Dropdown.stories.tsx
+++ b/libs/react/components/src/lib/Dropdown/Dropdown.stories.tsx
@@ -3,7 +3,7 @@ import { DropdownProps, Dropdown as StoryComponent } from './Dropdown';
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/Dropdown',
+  title: 'Dropdown',
 };
 export default meta;
 

--- a/libs/react/components/src/lib/ExpandableContainer/ExpandableContainer.stories.tsx
+++ b/libs/react/components/src/lib/ExpandableContainer/ExpandableContainer.stories.tsx
@@ -26,7 +26,7 @@ export const ExpandableContainerDemo: Story = {
     const baseArgs = { ...defaultArgs, ...args };
 
     return (
-      <ExpandableContainer {...baseArgs} className="w-80">
+      <ExpandableContainer {...baseArgs} className="w-full">
         Lorem ipsum dolor sit amet consectetur adipisicing elit.
       </ExpandableContainer>
     );

--- a/libs/react/components/src/lib/ExpandableContainer/ExpandableContainer.stories.tsx
+++ b/libs/react/components/src/lib/ExpandableContainer/ExpandableContainer.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ExpandableContainer } from './ExpandableContainer';
 
 const meta: Meta<typeof ExpandableContainer> = {
-  title: 'Components/ExpandableContainer',
+  title: 'ExpandableContainer',
   component: ExpandableContainer,
   argTypes: {
     ...disableControls(['onClick']),

--- a/libs/react/components/src/lib/ImageCarousel/ImageCarousel.stories.tsx
+++ b/libs/react/components/src/lib/ImageCarousel/ImageCarousel.stories.tsx
@@ -19,6 +19,11 @@ const defaultArgs: Pick<TProps, 'imageUrls'> = {
 };
 
 export const ImageCarousel: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'w-full',
+    },
+  },
   render: (args) => {
     const baseArgs: TProps = {
       ...defaultArgs,

--- a/libs/react/components/src/lib/ImageCarousel/ImageCarousel.stories.tsx
+++ b/libs/react/components/src/lib/ImageCarousel/ImageCarousel.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { ImageCarousel as StoryComponent, TProps } from './ImageCarousel';
 
 const meta: Meta<typeof StoryComponent> = {
-  title: 'Components/ImageCarousel',
+  title: 'ImageCarousel',
   component: StoryComponent,
 };
 export default meta;

--- a/libs/react/components/src/lib/Input/Input.stories.tsx
+++ b/libs/react/components/src/lib/Input/Input.stories.tsx
@@ -1,4 +1,3 @@
-import { SbkPanel } from '@monorepo/react/storybook';
 import type { Meta, StoryObj } from '@storybook/react';
 import { IInputProps, Input as StoryComponent } from './Input';
 
@@ -15,13 +14,14 @@ const defaultArgs: IInputProps = {
 };
 
 export const Input: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'w-[400px]',
+    },
+  },
   render: (args) => {
     const baseArgs = { ...defaultArgs, ...args };
 
-    return (
-      <SbkPanel variant="bordered" className="w-[400px]">
-        <StoryComponent {...baseArgs} />
-      </SbkPanel>
-    );
+    return <StoryComponent {...baseArgs} />;
   },
 };

--- a/libs/react/components/src/lib/Input/Input.stories.tsx
+++ b/libs/react/components/src/lib/Input/Input.stories.tsx
@@ -4,7 +4,7 @@ import { IInputProps, Input as StoryComponent } from './Input';
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/Form-Ui/Input',
+  title: 'Form-Ui/Input',
 };
 export default meta;
 

--- a/libs/react/components/src/lib/Pill/Pill.stories.tsx
+++ b/libs/react/components/src/lib/Pill/Pill.stories.tsx
@@ -16,8 +16,8 @@ const defaultArgs: IPillProps = {
 
 export const Pill: Story = {
   render: (args) => {
-    const baseArgs = { ...defaultArgs, ...args };
+    const storyArgs = { ...defaultArgs, ...args };
 
-    return <StoryComponent {...baseArgs} />;
+    return <StoryComponent {...storyArgs} />;
   },
 };

--- a/libs/react/components/src/lib/Pill/Pill.stories.tsx
+++ b/libs/react/components/src/lib/Pill/Pill.stories.tsx
@@ -3,7 +3,7 @@ import { IPillProps, Pill as StoryComponent } from './Pill';
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/Pill',
+  title: 'Pill',
 };
 export default meta;
 

--- a/libs/react/components/src/lib/PillContainer/PillContainer.stories.tsx
+++ b/libs/react/components/src/lib/PillContainer/PillContainer.stories.tsx
@@ -7,7 +7,7 @@ import {
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/PillContainer',
+  title: 'PillContainer',
 };
 export default meta;
 

--- a/libs/react/components/src/lib/PillContainer/PillContainer.stories.tsx
+++ b/libs/react/components/src/lib/PillContainer/PillContainer.stories.tsx
@@ -1,4 +1,3 @@
-import { SbkPanel } from '@monorepo/react/storybook';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   PillContainer as StoryComponent,
@@ -30,10 +29,6 @@ export const PillContainer: Story = {
   render: (args) => {
     const baseArgs = { ...defaultArgs, ...args };
 
-    return (
-      <SbkPanel variant="bordered" className="w-[400px]">
-        <StoryComponent {...baseArgs} />
-      </SbkPanel>
-    );
+    return <StoryComponent {...baseArgs} />;
   },
 };

--- a/libs/react/components/src/lib/SearchInput/SearchInput.stories.tsx
+++ b/libs/react/components/src/lib/SearchInput/SearchInput.stories.tsx
@@ -1,4 +1,4 @@
-import { SbkPanel, disableControls } from '@monorepo/react/storybook';
+import { disableControls } from '@monorepo/react/storybook';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import {
@@ -19,6 +19,11 @@ export default meta;
 type Story = StoryObj<typeof StoryComponent>;
 
 export const SearchInput: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'flex-col w-[400px]',
+    },
+  },
   render: (args) => {
     const [val, setVal] = useState('');
 
@@ -28,7 +33,7 @@ export const SearchInput: Story = {
     };
 
     return (
-      <SbkPanel variant="bordered" className="w-[400px] flex-col">
+      <>
         <StoryComponent {...finalArgs} />
 
         <div className="mt-4 text-sm flex items-center">
@@ -36,7 +41,7 @@ export const SearchInput: Story = {
 
           <div className="ml-2 p-2 bg-gray-100 rounded min-h-[24px]">{val}</div>
         </div>
-      </SbkPanel>
+      </>
     );
   },
 };

--- a/libs/react/components/src/lib/SearchInput/SearchInput.stories.tsx
+++ b/libs/react/components/src/lib/SearchInput/SearchInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/Form-Ui/SearchInput',
+  title: 'Form-Ui/SearchInput',
   argTypes: {
     ...disableControls(['onChange', 'className', 'value']),
   },

--- a/libs/react/components/src/lib/SearchList/SearchList.stories.tsx
+++ b/libs/react/components/src/lib/SearchList/SearchList.stories.tsx
@@ -1,4 +1,4 @@
-import { SbkPanel, disableControls } from '@monorepo/react/storybook';
+import { disableControls } from '@monorepo/react/storybook';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import {
@@ -37,6 +37,11 @@ export default meta;
 type Story = StoryObj<typeof StoryComponent>;
 
 export const SearchList: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'flex-col w-[400px]',
+    },
+  },
   render: (args) => {
     const [results, setResults] = useState<string[]>([]);
 
@@ -50,7 +55,7 @@ export const SearchList: Story = {
     };
 
     return (
-      <SbkPanel variant="bordered" className="w-[400px] flex-col">
+      <>
         <StoryComponent {...finalArgs} />
 
         <div className="mt-4 text-sm flex flex-col">
@@ -68,7 +73,7 @@ export const SearchList: Story = {
             )}
           </div>
         </div>
-      </SbkPanel>
+      </>
     );
   },
 };

--- a/libs/react/components/src/lib/SearchList/SearchList.stories.tsx
+++ b/libs/react/components/src/lib/SearchList/SearchList.stories.tsx
@@ -26,7 +26,7 @@ const colors: string[] = [
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/Form-Ui/SearchList',
+  title: 'Form-Ui/SearchList',
   argTypes: {
     ...disableControls(['onChange', 'className', 'value', 'data']),
   },

--- a/libs/react/components/src/lib/Sidebar/Sidebar.stories.tsx
+++ b/libs/react/components/src/lib/Sidebar/Sidebar.stories.tsx
@@ -58,7 +58,7 @@ function SidebarStoryWrapper() {
 }
 
 const meta: Meta<typeof SidebarStoryWrapper> = {
-  title: 'Components/Sidebar/Sidebar',
+  title: 'Sidebar/Sidebar',
   component: SidebarStoryWrapper,
   decorators: [withMemoryRouter('/')],
 };

--- a/libs/react/components/src/lib/Sidebar/Sidebar.stories.tsx
+++ b/libs/react/components/src/lib/Sidebar/Sidebar.stories.tsx
@@ -16,8 +16,8 @@ function SidebarStoryWrapper() {
   const userOrganization = { name: 'Storybook Org' };
 
   return (
-    <div className="border-4 border-gray-300 flex flex-row h-[400px] w-full">
-      <Sidebar className="h-screen" onOpenChange={setIsOpen}>
+    <div className="border-4 border-gray-300 flex flex-row max-h-[800px] w-full">
+      <Sidebar className="h-[600px]" onOpenChange={setIsOpen}>
         <Sidebar.Header>
           <BetterAngelsLogoBadge className="ml-1 mr-2 flex-shrink-0" />
           {userOrganization?.name && isOpen && (
@@ -69,6 +69,8 @@ type Story = StoryObj<typeof SidebarStoryWrapper>;
 
 export const SidebarStory: Story = {
   parameters: {
-    layout: null,
+    customLayout: {
+      variant: 'basic',
+    },
   },
 };

--- a/libs/react/components/src/lib/Sidebar/SidebarLink.stories.tsx
+++ b/libs/react/components/src/lib/Sidebar/SidebarLink.stories.tsx
@@ -1,9 +1,5 @@
 import { UsersIcon } from '@monorepo/react/icons';
-import {
-  SbkPanel,
-  disableControls,
-  withMemoryRouter,
-} from '@monorepo/react/storybook';
+import { disableControls, withMemoryRouter } from '@monorepo/react/storybook';
 import type { Meta, StoryObj } from '@storybook/react';
 import { SidebarLink } from './SidebarLink';
 
@@ -24,11 +20,16 @@ const withIconArgs = {
 };
 
 export const WithIcon: Story = {
+  parameters: {
+    customLayout: {
+      canvasClassName: 'flex-col',
+    },
+  },
   render: (args) => {
     const baseArgs = { ...withIconArgs, ...args };
 
     return (
-      <SbkPanel className="flex-col w-[400px] p-8 border-2 border-gray-100">
+      <>
         <SidebarLink {...baseArgs}>text</SidebarLink>
         <SidebarLink {...baseArgs} className="pseudo-hover">
           hover
@@ -36,7 +37,7 @@ export const WithIcon: Story = {
         <SidebarLink {...baseArgs} className="pseudo-active">
           active
         </SidebarLink>
-      </SbkPanel>
+      </>
     );
   },
 };

--- a/libs/react/components/src/lib/Sidebar/SidebarLink.stories.tsx
+++ b/libs/react/components/src/lib/Sidebar/SidebarLink.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { SidebarLink } from './SidebarLink';
 
 const meta: Meta<typeof SidebarLink> = {
-  title: 'Components/Sidebar/SidebarLink',
+  title: 'Sidebar/SidebarLink',
   component: SidebarLink,
   decorators: [withMemoryRouter('/')],
   argTypes: disableControls(['to', 'icon', 'className', 'children']),

--- a/libs/react/components/src/lib/Table/Table.stories.tsx
+++ b/libs/react/components/src/lib/Table/Table.stories.tsx
@@ -5,7 +5,7 @@ import { Table as StoryComponent } from './Table';
 
 const meta: Meta<typeof StoryComponent> = {
   component: StoryComponent,
-  title: 'Components/Table',
+  title: 'Table',
   parameters: {
     controls: { disable: true },
   },

--- a/libs/react/components/src/lib/Table/Table.stories.tsx
+++ b/libs/react/components/src/lib/Table/Table.stories.tsx
@@ -68,6 +68,11 @@ const pagesData: TTableItem[][] = [
 ];
 
 export const Table: Story = {
+  parameters: {
+    customLayout: {
+      variant: 'basic',
+    },
+  },
   render: () => {
     const [currentPage, setCurrentPage] = useState(1);
 

--- a/libs/react/icons/src/lib/components/IconComponents.stories.tsx
+++ b/libs/react/icons/src/lib/components/IconComponents.stories.tsx
@@ -27,7 +27,11 @@ export default meta;
 type Story = StoryObj;
 
 export const IconComponents: Story = {
-  parameters: { layout: false },
+  parameters: {
+    customLayout: {
+      variant: 'basic',
+    },
+  },
   render: () => {
     return (
       <SbkGallery

--- a/libs/react/icons/src/lib/components/IconComponents.stories.tsx
+++ b/libs/react/icons/src/lib/components/IconComponents.stories.tsx
@@ -20,7 +20,6 @@ const iconList: TIconItem[] = Object.entries(icons).map(([key, value]) => {
 });
 
 const meta: Meta = {
-  title: 'Iconography',
   parameters: { controls: { disable: true } },
 };
 export default meta;

--- a/libs/react/shelter/tsconfig.spec.json
+++ b/libs/react/shelter/tsconfig.spec.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"],
-    "composite": true
+    "types": ["jest", "node"]
   }
 }

--- a/libs/react/storybook/src/lib/components/SbkGallery/SbkGallery.tsx
+++ b/libs/react/storybook/src/lib/components/SbkGallery/SbkGallery.tsx
@@ -44,7 +44,7 @@ function SbkGallery<T>(props: TGalleryProps) {
   const listItemCss = ['border', listItemClassname];
 
   return (
-    <SbkPanel className={mergeCss(parentCss)}>
+    <SbkPanel variant="basic" className={mergeCss(parentCss)}>
       {searchable && (
         <div className="mb-8 w-96">
           <SbkGallerySearch<TGalleryItem>

--- a/libs/react/storybook/src/lib/components/SbkPanel.tsx
+++ b/libs/react/storybook/src/lib/components/SbkPanel.tsx
@@ -1,30 +1,44 @@
 import { mergeCss } from '@monorepo/react/components';
 import { PropsWithChildren } from 'react';
 
-type TVariant = 'bordered';
+type TVariant = 'basic' | 'component';
 
-type TProps = PropsWithChildren<{
+export type TSbkPanelProps = PropsWithChildren<{
   className?: string;
   variant?: TVariant;
+  style?: React.CSSProperties;
+  withBorder?: boolean;
 }>;
 
-export function SbkPanel(props: TProps) {
-  const { children, variant, className } = props;
+export function SbkPanel(props: TSbkPanelProps) {
+  const {
+    children,
+    variant = 'component',
+    style,
+    withBorder,
+    className,
+  } = props;
+
+  const borderCss = 'border-2 border-dotted border-gray-200';
+
+  const componentVariantCss = ['w-[360px]', borderCss];
 
   const parentCss = [
     'w-full',
     'h-full',
-    'p-8',
+    'p-12',
     'bg-white',
     'flex',
-    'grow',
     'gap-8',
     'justify-center',
-    variant === 'bordered'
-      ? 'border-2 border-dotted border-gray-200 p-8'
-      : undefined,
+    variant === 'component' ? componentVariantCss : undefined,
+    withBorder ? borderCss : undefined,
     className,
   ];
 
-  return <div className={mergeCss(parentCss)}>{children}</div>;
+  return (
+    <div className={mergeCss(parentCss)} style={style}>
+      {children}
+    </div>
+  );
 }

--- a/libs/react/storybook/src/lib/decorators/CustomLayout.tsx
+++ b/libs/react/storybook/src/lib/decorators/CustomLayout.tsx
@@ -1,0 +1,41 @@
+import { mergeCss } from '@monorepo/react/components';
+import type { Decorator } from '@storybook/react';
+import { SbkPanel } from '../components';
+
+type TLayoutVariant = 'basic' | 'component';
+
+export type TLayoutParams = {
+  className?: string; // tailwind classes
+  style?: React.CSSProperties; // inline CSS
+  canvasClassName?: string; // tailwind classes
+  canvasStyle?: React.CSSProperties; // inline CSS
+  variant?: TLayoutVariant;
+};
+
+export const CustomLayout: Decorator = (Story, context) => {
+  const { customLayout } = (context.parameters ?? {}) as {
+    customLayout?: TLayoutParams;
+  };
+
+  const {
+    className,
+    style,
+    variant = 'component',
+    canvasClassName,
+    canvasStyle,
+  } = customLayout || {};
+
+  const parentClasses = ['flex', 'justify-center', 'p-8', className];
+
+  return (
+    <div className={mergeCss(parentClasses)} style={style}>
+      {variant === 'component' && (
+        <SbkPanel className={canvasClassName} style={canvasStyle}>
+          <Story />
+        </SbkPanel>
+      )}
+
+      {variant !== 'component' && <Story />}
+    </div>
+  );
+};

--- a/libs/react/storybook/src/lib/decorators/index.ts
+++ b/libs/react/storybook/src/lib/decorators/index.ts
@@ -1,1 +1,3 @@
+export { CustomLayout } from './CustomLayout';
+export type { TLayoutParams } from './CustomLayout';
 export { withMemoryRouter } from './withMemoryRouter';

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@storybook/addon-docs": "9.1.2",
     "@storybook/addon-react-native-web": "^0.0.29",
     "@storybook/react-native": "^9.1.0",
+    "@storybook/react-native-web-vite": "^9.1.5",
     "@storybook/react-vite": "9.1.2",
     "@storybook/react-webpack5": "9.1.2",
     "@svgr/webpack": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "storybook-start": "nx run expo-shared-ui-components:storybook",
-    "storybook-build": "nx storybook build expo-shared-ui-components",
-    "storybook-react": "nx run storybook-react:storybook",
-    "storybook-react-build": "nx run storybook-react:build",
+    "storybook": "nx run storybook-react:storybook",
+    "storybook-build": "nx run storybook-react:build",
     "server": "nx start betterangels-backend",
     "ba": "nx start betterangels",
     "ba:build-dev": "nx build betterangels --profile development",

--- a/tailwind/fonts-rn.css
+++ b/tailwind/fonts-rn.css
@@ -1,0 +1,21 @@
+/* Fonts Family declarations ase used in ract-native */
+@font-face {
+  font-family: 'Poppins-Regular';
+  src: url('../libs/assets/src/fonts/Poppins-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Poppins-Medium';
+  src: url('../libs/assets/src/fonts/Poppins-Medium.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Poppins-SemiBold';
+  src: url('../libs/assets/src/fonts/Poppins-SemiBold.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+}

--- a/tailwind/fonts-rn.css
+++ b/tailwind/fonts-rn.css
@@ -1,21 +1,15 @@
-/* Fonts Family declarations ase used in ract-native */
+/* Fonts Family declarations se used in ract-native */
 @font-face {
   font-family: 'Poppins-Regular';
   src: url('../libs/assets/src/fonts/Poppins-Regular.ttf') format('truetype');
-  font-weight: 400;
-  font-style: normal;
 }
 
 @font-face {
   font-family: 'Poppins-Medium';
   src: url('../libs/assets/src/fonts/Poppins-Medium.ttf') format('truetype');
-  font-weight: 400;
-  font-style: normal;
 }
 
 @font-face {
   font-family: 'Poppins-SemiBold';
   src: url('../libs/assets/src/fonts/Poppins-SemiBold.ttf') format('truetype');
-  font-weight: 400;
-  font-style: normal;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,7 +1140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-flow-strip-types@npm:^7.0.0, @babel/plugin-transform-flow-strip-types@npm:^7.20.0, @babel/plugin-transform-flow-strip-types@npm:^7.25.2":
+"@babel/plugin-transform-flow-strip-types@npm:^7.0.0, @babel/plugin-transform-flow-strip-types@npm:^7.20.0, @babel/plugin-transform-flow-strip-types@npm:^7.25.2, @babel/plugin-transform-flow-strip-types@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-transform-flow-strip-types@npm:7.27.1"
   dependencies:
@@ -1850,6 +1850,16 @@ __metadata:
   version: 2.6.3
   resolution: "@bufbuild/protobuf@npm:2.6.3"
   checksum: 10/906228c55a472fdcb7b070370420af038a54c1f7e9d18e19cdff5a07e32e746255503c0047721990dc9e2263896697c58c4684be078fc7522b4ad97345b4eebb
+  languageName: node
+  linkType: hard
+
+"@bunchtogether/vite-plugin-flow@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@bunchtogether/vite-plugin-flow@npm:1.0.2"
+  dependencies:
+    flow-remove-types: "npm:^2.158.0"
+    rollup-pluginutils: "npm:^2.8.2"
+  checksum: 10/23061c24d2b585c1fee2856fdcb2cb073d6b97b51b7ddeb675a4014f642fdee6768597112f93da170c1f1e17e26f79aa8cb33dd6b283f3a598508314244475f8
   languageName: node
   linkType: hard
 
@@ -4397,6 +4407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: 10/5d9d207b462c11e322d71911e55e21a4e2772f71ffe8d6f1221b8eb5ae6774458c1d242f897fb0814e8714ca9a6b498abfa74dfe4f434493342902b1a48b33a5
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:0.3.9":
   version: 0.3.9
   resolution: "@jridgewell/trace-mapping@npm:0.3.9"
@@ -5115,6 +5132,7 @@ __metadata:
     "@storybook/addon-docs": "npm:9.1.2"
     "@storybook/addon-react-native-web": "npm:^0.0.29"
     "@storybook/react-native": "npm:^9.1.0"
+    "@storybook/react-native-web-vite": "npm:^9.1.5"
     "@storybook/react-vite": "npm:9.1.2"
     "@storybook/react-webpack5": "npm:9.1.2"
     "@svgr/webpack": "npm:^8.1.0"
@@ -7147,6 +7165,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/pluginutils@npm:1.0.0-beta.24":
+  version: 1.0.0-beta.24
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.24"
+  checksum: 10/81d59959c2ec269e0a4fe1f3a4ea0b0e5451e5b3bcadb86cba8276d190cb982964f0067ecae03ff62d39de6717dda990a4d1a505e48876f0fe1c68f4eb6d58c3
+  languageName: node
+  linkType: hard
+
 "@rolldown/pluginutils@npm:1.0.0-beta.27":
   version: 1.0.0-beta.27
   resolution: "@rolldown/pluginutils@npm:1.0.0-beta.27"
@@ -7594,6 +7619,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/builder-vite@npm:9.1.5":
+  version: 9.1.5
+  resolution: "@storybook/builder-vite@npm:9.1.5"
+  dependencies:
+    "@storybook/csf-plugin": "npm:9.1.5"
+    ts-dedent: "npm:^2.0.0"
+  peerDependencies:
+    storybook: ^9.1.5
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10/adf191098abd4685a9451cc9a4da17ecde59e6be951c049add6ab379c26325710d2f15e4191709029b055560bbf59e2845225b85f8d1fd49c1a0d04e82e4d57f
+  languageName: node
+  linkType: hard
+
 "@storybook/builder-webpack5@npm:9.1.2":
   version: 9.1.2
   resolution: "@storybook/builder-webpack5@npm:9.1.2"
@@ -7641,6 +7679,17 @@ __metadata:
   peerDependencies:
     storybook: ^9.1.2
   checksum: 10/801b1d97a908f11d6481941307e340325c9e9926f3935551e055af6a0cb76cfd56738c25b98aa0cc0d955a18f98b8680e802ec782ff7569c5ecbe2a6f87fb4e8
+  languageName: node
+  linkType: hard
+
+"@storybook/csf-plugin@npm:9.1.5":
+  version: 9.1.5
+  resolution: "@storybook/csf-plugin@npm:9.1.5"
+  dependencies:
+    unplugin: "npm:^1.3.1"
+  peerDependencies:
+    storybook: ^9.1.5
+  checksum: 10/f86e178a51d9ea72903392767a7f2fdef98074e251ef90ef50035c9b74f40d9cc62d4ff74079b5e9e0aa9d68d337559beea77f3458ba928b379bfdedda2e5258
   languageName: node
   linkType: hard
 
@@ -7715,6 +7764,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/react-dom-shim@npm:9.1.5":
+  version: 9.1.5
+  resolution: "@storybook/react-dom-shim@npm:9.1.5"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    storybook: ^9.1.5
+  checksum: 10/8aa85b15a2d5584da0af285e52cf78b132fc772846cc2d4369349ecf6d966331ee05a8162c5b1ecf42acefe8d9659f7e0f7cfdd2e1230dc983cb989eefcfb7fe
+  languageName: node
+  linkType: hard
+
 "@storybook/react-native-theming@npm:^9.1.0":
   version: 9.1.0
   resolution: "@storybook/react-native-theming@npm:9.1.0"
@@ -7769,6 +7829,26 @@ __metadata:
     react-native-svg: ">=14"
     storybook: ">=9"
   checksum: 10/24e908b8944db0afc515ad25d5303d84e6bbaf2bd1e7d2d7d5935a5d17c21bafb550b2432fe8934e86ba4df0b74d762c4c5d10c5485d1e95ceca628cb313f723
+  languageName: node
+  linkType: hard
+
+"@storybook/react-native-web-vite@npm:^9.1.5":
+  version: 9.1.5
+  resolution: "@storybook/react-native-web-vite@npm:9.1.5"
+  dependencies:
+    "@storybook/builder-vite": "npm:9.1.5"
+    "@storybook/react": "npm:9.1.5"
+    "@storybook/react-vite": "npm:9.1.5"
+    vite-plugin-rnw: "npm:^0.0.6"
+    vite-tsconfig-paths: "npm:^5.1.4"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-native: ">=0.74.5"
+    react-native-web: ^0.19.12 || ^0.20.0
+    storybook: ^9.1.5
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10/ed6f7be520fd8f27ceedb37bf1ec6203e69dbf15238d08600461296da6cf314541be9f735b802787e2f3d98c8104ee3c55ecf5840d815b3af86047370b908dd5
   languageName: node
   linkType: hard
 
@@ -7834,6 +7914,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/react-vite@npm:9.1.5":
+  version: 9.1.5
+  resolution: "@storybook/react-vite@npm:9.1.5"
+  dependencies:
+    "@joshwooding/vite-plugin-react-docgen-typescript": "npm:0.6.1"
+    "@rollup/pluginutils": "npm:^5.0.2"
+    "@storybook/builder-vite": "npm:9.1.5"
+    "@storybook/react": "npm:9.1.5"
+    find-up: "npm:^7.0.0"
+    magic-string: "npm:^0.30.0"
+    react-docgen: "npm:^8.0.0"
+    resolve: "npm:^1.22.8"
+    tsconfig-paths: "npm:^4.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    storybook: ^9.1.5
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10/77ed64e8187636299b6b7de1a4db96aa2fed8b5be5cee844bbdeeab64b4b231aeb5c6bc5b84014983da095a4e3be782e5ea167126e7867c26d7c5d47263b20be
+  languageName: node
+  linkType: hard
+
 "@storybook/react-webpack5@npm:9.1.2":
   version: 9.1.2
   resolution: "@storybook/react-webpack5@npm:9.1.2"
@@ -7868,6 +7970,24 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/e77f4ac4f1e95375cadaec45b51f5a859effc53d37e8989534392f597b3bd823a653b62ddf0f8a437dea9202f3a090ef76ec43e072239684bdfbf300672eb7be
+  languageName: node
+  linkType: hard
+
+"@storybook/react@npm:9.1.5":
+  version: 9.1.5
+  resolution: "@storybook/react@npm:9.1.5"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/react-dom-shim": "npm:9.1.5"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    storybook: ^9.1.5
+    typescript: ">= 4.9.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10/a5b80438976011498998035b6cffb513246dfd6852b035639212a89f8a9114b16757803ce750feb863393af0b9f47ff170d202c5341b083ee4440663976f2939
   languageName: node
   linkType: hard
 
@@ -10260,7 +10380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.1.0, acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.15.0, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.8.1, acorn@npm:^8.9.0":
+"acorn@npm:^8.1.0, acorn@npm:^8.11.0, acorn@npm:^8.12.1, acorn@npm:^8.14.0, acorn@npm:^8.15.0, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.8.1, acorn@npm:^8.9.0":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -13983,7 +14103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.2.1, es-module-lexer@npm:^1.5.0":
+"es-module-lexer@npm:^1.2.1, es-module-lexer@npm:^1.5.0, es-module-lexer@npm:^1.5.4":
   version: 1.7.0
   resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10/b6f3e576a3fed4d82b0d0ad4bbf6b3a5ad694d2e7ce8c4a069560da3db6399381eaba703616a182b16dde50ce998af64e07dcf49f2ae48153b9e07be3f107087
@@ -14660,6 +14780,13 @@ __metadata:
   version: 5.3.0
   resolution: "estraverse@npm:5.3.0"
   checksum: 10/37cbe6e9a68014d34dbdc039f90d0baf72436809d02edffcc06ba3c2a12eb298048f877511353b130153e532aac8d68ba78430c0dd2f44806ebc7c014b01585e
+  languageName: node
+  linkType: hard
+
+"estree-walker@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "estree-walker@npm:0.6.1"
+  checksum: 10/b8da7815030c4e0b735f5f8af370af09525e052ee14e539cecabc24ad6da1782448778361417e7c438091a59e7ca9f4a0c11642f7da4f2ebf1ba7a150a590bcc
   languageName: node
   linkType: hard
 
@@ -15751,6 +15878,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flow-remove-types@npm:^2.158.0":
+  version: 2.281.0
+  resolution: "flow-remove-types@npm:2.281.0"
+  dependencies:
+    hermes-parser: "npm:0.32.0"
+    pirates: "npm:^3.0.2"
+    vlq: "npm:^0.2.1"
+  bin:
+    flow-node: flow-node
+    flow-remove-types: flow-remove-types
+  checksum: 10/2635ecd72da563b183568b1fe6e7dc6298099bf329686aaaa87b798611d87e62cda5e5630bef8e079e782237179b54897a267c558d79a3814e12900bd27625d0
+  languageName: node
+  linkType: hard
+
 "follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6, follow-redirects@npm:^1.15.9":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
@@ -16318,6 +16459,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: 10/81ce62ee6f800d823d6b7da7687f841676d60ee8f51f934ddd862e4057316d26665c4edc0358d4340a923ac00a514f8b67c787e28fe693aae16350f4e60d55e9
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1, gopd@npm:^1.2.0":
   version: 1.2.0
   resolution: "gopd@npm:1.2.0"
@@ -16656,6 +16804,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hermes-estree@npm:0.32.0":
+  version: 0.32.0
+  resolution: "hermes-estree@npm:0.32.0"
+  checksum: 10/65a30a86a5a560152a2de1842c7bc7ecdadebd62e9cdd7d1809a824de7bc19e8d6a42907d3caff91d9f823862405d4b200447aa0bc25ba16072937e93d0acbd5
+  languageName: node
+  linkType: hard
+
 "hermes-parser@npm:0.14.0":
   version: 0.14.0
   resolution: "hermes-parser@npm:0.14.0"
@@ -16680,6 +16835,15 @@ __metadata:
   dependencies:
     hermes-estree: "npm:0.29.1"
   checksum: 10/2d1ada9d48817668bf12b31deef7c5a4a7d88419448c7e07ad67197a7992462dea3f5e536aea2c6f7e2222940f96bb7cd7a7dc5a101c9b4b2d7a84e1a1272670
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:0.32.0":
+  version: 0.32.0
+  resolution: "hermes-parser@npm:0.32.0"
+  dependencies:
+    hermes-estree: "npm:0.32.0"
+  checksum: 10/496210490cb45e97df14796d94aec6c817c4cefa20f1dbe3ba1df323cc58c930033cfec93f3ecfad6b90e09166fc9ffc4f665843d25b4862523aa70dacbae81f
   languageName: node
   linkType: hard
 
@@ -19534,6 +19698,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.11":
+  version: 0.30.19
+  resolution: "magic-string@npm:0.30.19"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10/5045467fad59ddfba6ccfb00fde6edbc0f841089f0da07d844cf513c73de289bbbf933bde16168cba2c9ef38d75ac68e1617a5ce74aae16d6f39285bda1d51c4
+  languageName: node
+  linkType: hard
+
 "magicast@npm:^0.3.3":
   version: 0.3.5
   resolution: "magicast@npm:0.3.5"
@@ -20609,6 +20782,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-modules-regexp@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "node-modules-regexp@npm:1.0.0"
+  checksum: 10/99541903536c5ce552786f0fca7f06b88df595e62e423c21fa86a1674ee2363dad1f7482d1bec20b4bd9fa5f262f88e6e5cb788fc56411113f2fe2e97783a3a7
+  languageName: node
+  linkType: hard
+
 "node-releases@npm:^2.0.19":
   version: 2.0.19
   resolution: "node-releases@npm:2.0.19"
@@ -21651,6 +21831,15 @@ __metadata:
   version: 4.0.1
   resolution: "pify@npm:4.0.1"
   checksum: 10/8b97cbf9dc6d4c1320cc238a2db0fc67547f9dc77011729ff353faf34f1936ea1a4d7f3c63b2f4980b253be77bcc72ea1e9e76ee3fd53cce2aafb6a8854d07ec
+  languageName: node
+  linkType: hard
+
+"pirates@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "pirates@npm:3.0.2"
+  dependencies:
+    node-modules-regexp: "npm:^1.0.0"
+  checksum: 10/9350e4a088c27b071c1a8dedc58661190ff1f4c562ce4313bc6a3dc5e2204238c6ee991c0aa4d72bb3f658a4a18fe65e5ec88a311802484b3b8ba8c8b111e3e2
   languageName: node
   linkType: hard
 
@@ -23761,6 +23950,15 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 10/063ffaccaaaca2cfd0ef3beafb12d6a03dd7ff1260d752d62a6077b5dfff6ae81bea571f655bb6b589d366930ec1bdd285d40d560c0dae9b12f125e54eb743d5
+  languageName: node
+  linkType: hard
+
+"rollup-pluginutils@npm:^2.8.2":
+  version: 2.8.2
+  resolution: "rollup-pluginutils@npm:2.8.2"
+  dependencies:
+    estree-walker: "npm:^0.6.1"
+  checksum: 10/f3dc20a8731523aff43e07fa50ed84857e9dd3ab81e2cfb0351d517c46820e585bfbd1530a5dddec3ac14d61d41eb9bf50b38ded987e558292790331cc5b0628
   languageName: node
   linkType: hard
 
@@ -26238,6 +26436,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfck@npm:^3.0.3":
+  version: 3.1.6
+  resolution: "tsconfck@npm:3.1.6"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10/8574595286850273bf83319b4e67ca760088df3c36f7ca1425aaf797416672e854271bd31e75c9b3e1836ed5b66410c6bc38cbbda9c638a5416c6a682ed94132
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths-webpack-plugin@npm:4.0.0":
   version: 4.0.0
   resolution: "tsconfig-paths-webpack-plugin@npm:4.0.0"
@@ -26966,6 +27178,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-plugin-commonjs@npm:^0.10.4":
+  version: 0.10.4
+  resolution: "vite-plugin-commonjs@npm:0.10.4"
+  dependencies:
+    acorn: "npm:^8.12.1"
+    magic-string: "npm:^0.30.11"
+    vite-plugin-dynamic-import: "npm:^1.6.0"
+  checksum: 10/ce7df43281bb9a2fd3c429996c1c543d5fd29921e6165f2694135ab65b16e6c0b4ee89081b81a00d8522e5aa1f88b8901c0a72fdd89ccb1db7c633e464e43ae9
+  languageName: node
+  linkType: hard
+
+"vite-plugin-dynamic-import@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "vite-plugin-dynamic-import@npm:1.6.0"
+  dependencies:
+    acorn: "npm:^8.12.1"
+    es-module-lexer: "npm:^1.5.4"
+    fast-glob: "npm:^3.3.2"
+    magic-string: "npm:^0.30.11"
+  checksum: 10/816b17e792e02087c215382d9bcdd6174ec49b2901db59583172fbe25b56adfccb4f1da4dc2bd103559e752856f1d1ae2ce02ccc8e45f6b666ab98f138b53657
+  languageName: node
+  linkType: hard
+
+"vite-plugin-rnw@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "vite-plugin-rnw@npm:0.0.6"
+  dependencies:
+    "@babel/core": "npm:^7.28.0"
+    "@babel/plugin-transform-flow-strip-types": "npm:^7.27.1"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.27.1"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
+    "@bunchtogether/vite-plugin-flow": "npm:^1.0.2"
+    "@rolldown/pluginutils": "npm:1.0.0-beta.24"
+    "@types/babel__core": "npm:^7.20.5"
+    react-refresh: "npm:^0.17.0"
+    vite-plugin-commonjs: "npm:^0.10.4"
+  peerDependencies:
+    react-native-web: "*"
+    typescript: ^5
+    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10/b71ba9afda0e2303b69499e5adc8c747e46975a2b7eafec277fb2802a18f4d5cf1a53ab44518c513279e82e0d4e63bb6f14b7f5c78b0e2e1669809d5b76bc380
+  languageName: node
+  linkType: hard
+
 "vite-plugin-svgr@npm:^4.3.0":
   version: 4.3.0
   resolution: "vite-plugin-svgr@npm:4.3.0"
@@ -26976,6 +27233,22 @@ __metadata:
   peerDependencies:
     vite: ">=2.6.0"
   checksum: 10/9ade316f20dae881f4ee65e4f2a35be11cf75b22a411bfcdb55bd61382c0249395cb925775e06a49e0fdffe483e64d5a25068c3ddfc5823fb72013cf4d932d17
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "vite-tsconfig-paths@npm:5.1.4"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 10/b409dbd17829f560021a71dba3e473b9c06dcf5fdc9d630b72c1f787145ec478b38caff1be04868971ac8bdcbf0f5af45eeece23dbc9c59c54b901f867740ae0
   languageName: node
   linkType: hard
 
@@ -27121,6 +27394,13 @@ __metadata:
   bin:
     vitest: vitest.mjs
   checksum: 10/50d551be2cf6621d3844c42924595007befd73e10e9406e0fa08f1239e2c012d08f85b0a70d8656a11364a6a58930600c35a5ee00d8445071f0ab0afcacd085a
+  languageName: node
+  linkType: hard
+
+"vlq@npm:^0.2.1":
+  version: 0.2.3
+  resolution: "vlq@npm:0.2.3"
+  checksum: 10/2231d8caeb5b2c1a438677ab029e9a94aa6fb61ab05819c72691b792aea0456dab29576aff5ae29309ee45bad0a309e832dc45173119bca1393f3b87709d8f8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Update storybook to render react-native elements as react-native-web
DEV-2114

* update storybook app to render react-native components (as react-native-web)
  * update svg handling
* reorganize stories inUI
* use customLayout decorator in preview.ts


## Summary by Sourcery

Migrate Storybook to use the react-native-web-vite framework and reorganize story sourcing, configuration, and asset handling for React Native and web components.

New Features:
- Add a Vite plugin (appendReactQueryForRnSvg) to append “?react” to SVG imports in RN libraries
- Introduce tailwind/fonts-rn.css to declare Poppins font faces for React Native web

Enhancements:
- Switch Storybook framework to @storybook/react-native-web-vite and update main.ts to merge custom Vite plugins, base path, and workspace root settings
- Define separate story specifiers (Platform icons, Web icons, Web components, RN components) and consolidate story file globs in config.ts
- Refactor story files across multiple libraries to use Meta/StoryObj from @storybook/react-native-web-vite, standardize titles, exports, and default args
- Update tailwind.config.ts to use new content globs for Tailwind class generation

Build:
- Update package.json scripts to use storybook-react commands and add @storybook/react-native-web-vite dependency

Chores:
- Clean up type exports in libs/expo/shared/static index and remove stale tsconfig references in shelter-e2e