### PR TITLE
add tasks clients filter (DEV-2155)

### DIFF
--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -52,7 +52,7 @@ class OrganizationServiceCategoryOrdering:
 )
 class OrganizationServiceType:
     id: auto
-    category: "OrganizationServiceCategoryType"
+    category: Optional["OrganizationServiceCategoryType"]
     priority: auto
     label: auto
 

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1188,7 +1188,7 @@ input OrganizationServiceOrdering {
 
 type OrganizationServiceType {
   id: ID!
-  category: OrganizationServiceCategoryType!
+  category: OrganizationServiceCategoryType
   priority: Int
   label: String!
 }
@@ -1702,6 +1702,7 @@ input TaskFilter {
   OR: TaskFilter
   NOT: TaskFilter
   DISTINCT: Boolean
+  clientProfiles: [ID!]
   authors: [ID!]
   organizations: [ID!]
   status: [TaskStatusEnum!]

--- a/apps/betterangels-backend/tasks/types.py
+++ b/apps/betterangels-backend/tasks/types.py
@@ -16,6 +16,7 @@ from . import models
 class TaskFilter:
     client_profile: Optional[ID]
     created_by: Optional[ID]
+    client_profiles = make_in_filter("client_profile", ID)
     authors = make_in_filter("created_by", ID)
     organizations = make_in_filter("organization", ID)
     status = make_in_filter("status", TaskStatusEnum)

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -1435,7 +1435,7 @@ export type OrganizationServiceOrdering = {
 
 export type OrganizationServiceType = {
   __typename?: 'OrganizationServiceType';
-  category: OrganizationServiceCategoryType;
+  category?: Maybe<OrganizationServiceCategoryType>;
   id: Scalars['ID']['output'];
   label: Scalars['String']['output'];
   priority?: Maybe<Scalars['Int']['output']>;
@@ -2112,6 +2112,7 @@ export type TaskFilter = {
   OR?: InputMaybe<TaskFilter>;
   authors?: InputMaybe<Array<Scalars['ID']['input']>>;
   clientProfile?: InputMaybe<Scalars['ID']['input']>;
+  clientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
   organizations?: InputMaybe<Array<Scalars['ID']['input']>>;
   search?: InputMaybe<Scalars['String']['input']>;

--- a/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
@@ -1435,7 +1435,7 @@ export type OrganizationServiceOrdering = {
 
 export type OrganizationServiceType = {
   __typename?: 'OrganizationServiceType';
-  category: OrganizationServiceCategoryType;
+  category?: Maybe<OrganizationServiceCategoryType>;
   id: Scalars['ID']['output'];
   label: Scalars['String']['output'];
   priority?: Maybe<Scalars['Int']['output']>;
@@ -2112,6 +2112,7 @@ export type TaskFilter = {
   OR?: InputMaybe<TaskFilter>;
   authors?: InputMaybe<Array<Scalars['ID']['input']>>;
   clientProfile?: InputMaybe<Scalars['ID']['input']>;
+  clientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
   organizations?: InputMaybe<Array<Scalars['ID']['input']>>;
   search?: InputMaybe<Scalars['String']['input']>;

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -1435,7 +1435,7 @@ export type OrganizationServiceOrdering = {
 
 export type OrganizationServiceType = {
   __typename?: 'OrganizationServiceType';
-  category: OrganizationServiceCategoryType;
+  category?: Maybe<OrganizationServiceCategoryType>;
   id: Scalars['ID']['output'];
   label: Scalars['String']['output'];
   priority?: Maybe<Scalars['Int']['output']>;
@@ -2112,6 +2112,7 @@ export type TaskFilter = {
   OR?: InputMaybe<TaskFilter>;
   authors?: InputMaybe<Array<Scalars['ID']['input']>>;
   clientProfile?: InputMaybe<Scalars['ID']['input']>;
+  clientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
   organizations?: InputMaybe<Array<Scalars['ID']['input']>>;
   search?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
DEV-2155

unrelated sneak fix: make service category optional 

## Summary by Sourcery

Enable filtering of tasks by client profile IDs through the GraphQL API by introducing a new clientProfiles filter and corresponding support in the TaskFilter type.

New Features:
- Add clientProfiles filter to tasks query to allow filtering by multiple client profile IDs

Enhancements:
- Extend TaskFilter with a client_profiles in-filter for GraphQL types

Tests:
- Add test to verify tasks query filtering by clientProfiles returns the correct tasks and maintains expected query count