### PR TITLE
hmis update client (DEV-2135)

### DIFF
--- a/apps/betterangels-backend/hmis/api_bridge.py
+++ b/apps/betterangels-backend/hmis/api_bridge.py
@@ -250,3 +250,44 @@ class HmisApiBridge:
             return {"errors": errors}
 
         return data.get("data", {}).get("createClient") or {}
+
+    def update_client(
+        self,
+        client_input: dict[str, Any],
+        client_sub_items_input: dict[str, Any],
+    ) -> Optional[dict[str, Any]]:
+
+        mutation_body = json.loads(self.request.body.decode("utf-8"))["query"]
+        payload_body = self._extract_response_body_from_mutation(mutation_body)
+
+        mutation = f"""
+            mutation (
+                $clientInput: UpdateClientInput!,
+                $clientSubItemsInput: UpdateClientSubItemsInput!
+            ) {{
+                updateClient(
+                    client: $clientInput,
+                    data: $clientSubItemsInput,
+                ) {{
+                    {payload_body}
+                }}
+            }}
+        """
+
+        client_input_camel = dict_keys_to_camel(client_input)
+        client_sub_items_input_camel = dict_keys_to_camel(client_sub_items_input)
+
+        data = self._make_request(
+            body={
+                "query": mutation,
+                "variables": {
+                    "clientInput": client_input_camel,
+                    "clientSubItemsInput": client_sub_items_input_camel,
+                },
+            }
+        )
+
+        if errors := data.get("errors"):
+            return {"errors": errors}
+
+        return data.get("data", {}).get("updateClient") or {}

--- a/apps/betterangels-backend/hmis/schema.py
+++ b/apps/betterangels-backend/hmis/schema.py
@@ -26,6 +26,10 @@ from .types import (
     HmisLoginError,
     HmisLoginResult,
     HmisPaginationInput,
+    HmisUpdateClientError,
+    HmisUpdateClientInput,
+    HmisUpdateClientResult,
+    HmisUpdateClientSubItemsInput,
 )
 
 User = get_user_model()
@@ -164,6 +168,31 @@ class Mutation:
 
         if errors := response.get("errors"):
             return HmisCreateClientError(message=errors[0]["message"])
+
+        client = get_client_from_response(response)
+
+        return client
+
+    @strawberry.mutation
+    def hmis_update_client(
+        self,
+        info: Info,
+        client_input: HmisUpdateClientInput,
+        client_sub_items_input: HmisUpdateClientSubItemsInput,
+    ) -> HmisUpdateClientResult:
+        request = info.context["request"]
+        hmis_api_bridge = HmisApiBridge(request=request)
+
+        response = hmis_api_bridge.update_client(
+            client_input=strawberry.asdict(client_input),
+            client_sub_items_input=strawberry.asdict(client_sub_items_input),
+        )
+
+        if not response:
+            return HmisUpdateClientError(message="Something went wrong")
+
+        if errors := response.get("errors"):
+            return HmisUpdateClientError(message=errors[0]["message"])
 
         client = get_client_from_response(response)
 

--- a/apps/betterangels-backend/hmis/tests/test_mutations.py
+++ b/apps/betterangels-backend/hmis/tests/test_mutations.py
@@ -466,7 +466,7 @@ class HmisCreateClientMutationTests(GraphQLBaseTestCase, TestCase):
             "ssn2": "**",
             "ssn3": "6789",
             "ssnDataQuality": HmisSsnQualityEnum.PARTIAL.name,
-            "dob": "2001-01-01",
+            "dob": "2002-02-02",
             "dobDataQuality": HmisDobQualityEnum.PARTIAL.name,
             "data": expected_data,
         }

--- a/apps/betterangels-backend/hmis/tests/test_mutations.py
+++ b/apps/betterangels-backend/hmis/tests/test_mutations.py
@@ -60,6 +60,43 @@ CREATE_CLIENT_MUTATION = """
     }
 """
 
+UPDATE_CLIENT_MUTATION = """
+    mutation hmisUpdateClient(
+        $clientInput: HmisUpdateClientInput!,
+        $clientSubItemsInput: HmisUpdateClientSubItemsInput!
+    ) {
+        hmisUpdateClient(
+            clientInput: $clientInput,
+            clientSubItemsInput: $clientSubItemsInput,
+        ) {
+            ... on HmisClientType {
+                personalId
+                uniqueIdentifier
+                firstName
+                lastName
+                nameDataQuality
+                ssn1
+                ssn2
+                ssn3
+                ssnDataQuality
+                dob
+                dobDataQuality
+                data {
+                    middleName
+                    nameSuffix
+                    alias
+                    raceEthnicity
+                    additionalRaceEthnicity
+                    differentIdentityText
+                    gender
+                    veteranStatus
+                }
+            }
+            ... on HmisUpdateClientError { message field }
+        }
+    }
+"""
+
 
 @override_settings(AUTHENTICATION_BACKENDS=["django.contrib.auth.backends.ModelBackend"])
 class HmisLoginMutationTests(GraphQLBaseTestCase, TestCase):
@@ -344,3 +381,94 @@ class HmisCreateClientMutationTests(GraphQLBaseTestCase, TestCase):
         self.assertIsNone(resp.get("errors"))
         payload = resp["data"]["hmisCreateClient"]
         self.assertIn("Quality of SSN is invalid.", payload["message"])
+
+    def test_hmis_update_client_success(self) -> None:
+        client_input = {
+            "personalId": "1",
+            "firstName": "Firsty",
+            "lastName": "Lasty",
+            "nameDataQuality": 1,
+            "ssn1": "123",
+            "ssn2": "45",
+            "ssn3": "6789",
+            "ssnDataQuality": 2,
+            "dob": "2002-02-02",
+            "dobDataQuality": 2,
+        }
+        client_sub_items_input = {
+            "middleName": "Middly",
+            "nameSuffix": 2,
+            "alias": "Nicky",
+            "additionalRaceEthnicity": "add re",
+            "differentIdentityText": "diff id",
+            "raceEthnicity": [2],
+            "gender": [2],
+            "veteranStatus": 8,
+        }
+
+        return_value = {
+            "personalId": "1",
+            "uniqueIdentifier": "981C4E53A",
+            "firstName": "Firsty",
+            "lastName": "Lasty",
+            "nameDataQuality": 1,
+            "ssn1": "***",
+            "ssn2": "**",
+            "ssn3": "6789",
+            "ssnDataQuality": 2,
+            "dob": "2002-02-02",
+            "dobDataQuality": 2,
+            "data": {
+                "middleName": "Middly",
+                "nameSuffix": 2,
+                "alias": "Nicky",
+                "additionalRaceEthnicity": "add re",
+                "differentIdentityText": "diff id",
+                "raceEthnicity": [2],
+                "gender": [2],
+                "veteranStatus": 8,
+            },
+        }
+
+        with patch(
+            "hmis.api_bridge.HmisApiBridge.update_client",
+            return_value=return_value,
+        ):
+            resp = self.execute_graphql(
+                UPDATE_CLIENT_MUTATION,
+                variables={
+                    "clientInput": client_input,
+                    "clientSubItemsInput": client_sub_items_input,
+                },
+            )
+
+        self.assertIsNone(resp.get("errors"))
+
+        payload = resp["data"]["hmisUpdateClient"]
+
+        expected_data = {
+            "middleName": "Middly",
+            "nameSuffix": "SR",
+            "alias": "Nicky",
+            "additionalRaceEthnicity": "add re",
+            "differentIdentityText": "diff id",
+            "raceEthnicity": [HmisRaceEnum.ASIAN.name],
+            "gender": [HmisGenderEnum.SPECIFIC.name],
+            "veteranStatus": HmisVeteranStatusEnum.DONT_KNOW.name,
+        }
+        expected_client = {
+            "personalId": "1",
+            "uniqueIdentifier": "981C4E53A",
+            "firstName": "Firsty",
+            "lastName": "Lasty",
+            "nameDataQuality": HmisNameQualityEnum.FULL.name,
+            "ssn1": "***",
+            "ssn2": "**",
+            "ssn3": "6789",
+            "ssnDataQuality": HmisSsnQualityEnum.PARTIAL.name,
+            "dob": "2001-01-01",
+            "dobDataQuality": HmisDobQualityEnum.PARTIAL.name,
+            "data": expected_data,
+        }
+
+        self.assertEqual(payload, expected_client)

--- a/apps/betterangels-backend/hmis/types.py
+++ b/apps/betterangels-backend/hmis/types.py
@@ -51,6 +51,32 @@ class HmisCreateClientSubItemsInput:
 
 
 @strawberry.input
+class HmisUpdateClientInput:
+    personal_id: str
+    first_name: str
+    last_name: str
+    name_data_quality: int
+    ssn1: str
+    ssn2: str
+    ssn3: str
+    ssn_data_quality: int
+    dob: str
+    dob_data_quality: int
+
+
+@strawberry.input
+class HmisUpdateClientSubItemsInput:
+    middle_name: str
+    name_suffix: int
+    alias: str
+    additional_race_ethnicity: str
+    different_identity_text: str
+    race_ethnicity: list[int]
+    gender: list[int]
+    veteran_status: int
+
+
+@strawberry.input
 class HmisCreateReleaseOfInformationInput:
     permission: Optional[int]
     start_date: Optional[str]
@@ -149,6 +175,12 @@ class HmisCreateClientError:
 
 
 @strawberry.type
+class HmisUpdateClientError:
+    message: str
+    field: Optional[str] = None
+
+
+@strawberry.type
 class HmisGetClientError:
     message: str
     field: Optional[str] = None
@@ -162,4 +194,5 @@ class HmisListClientsError:
 
 HmisGetClientResult = Union[HmisClientType, HmisGetClientError]
 HmisCreateClientResult = Union[HmisClientType, HmisCreateClientError]
+HmisUpdateClientResult = Union[HmisClientType, HmisUpdateClientError]
 HmisListClientsResult = Union[HmisClientListType, HmisListClientsError]

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -936,6 +936,7 @@ type HmisUpdateClientError {
 }
 
 input HmisUpdateClientInput {
+  personalId: String!
   firstName: String!
   lastName: String!
   nameDataQuality: Int!

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -787,6 +787,8 @@ union HmisClientTypeHmisCreateClientError = HmisClientType | HmisCreateClientErr
 
 union HmisClientTypeHmisGetClientError = HmisClientType | HmisGetClientError
 
+union HmisClientTypeHmisUpdateClientError = HmisClientType | HmisUpdateClientError
+
 type HmisCreateClientError {
   message: String!
   field: String
@@ -926,6 +928,34 @@ enum HmisSuffixEnum {
   SIXTH
   DONT_KNOW
   NO_ANSWER
+}
+
+type HmisUpdateClientError {
+  message: String!
+  field: String
+}
+
+input HmisUpdateClientInput {
+  firstName: String!
+  lastName: String!
+  nameDataQuality: Int!
+  ssn1: String!
+  ssn2: String!
+  ssn3: String!
+  ssnDataQuality: Int!
+  dob: String!
+  dobDataQuality: Int!
+}
+
+input HmisUpdateClientSubItemsInput {
+  middleName: String!
+  nameSuffix: Int!
+  alias: String!
+  additionalRaceEthnicity: String!
+  differentIdentityText: String!
+  raceEthnicity: [Int!]!
+  gender: [Int!]!
+  veteranStatus: Int!
 }
 
 enum HmisVeteranStatusEnum {
@@ -1126,6 +1156,7 @@ type Mutation {
   importClientProfile(data: ImportClientProfileInput!): ImportClientProfilePayload! @hasPerm(permissions: [{app: "clients", permission: "add_clientprofileimportrecord"}], any: true)
   hmisLogin(email: String!, password: String!): UserTypeHmisLoginError!
   hmisCreateClient(clientInput: HmisCreateClientInput!, clientSubItemsInput: HmisCreateClientSubItemsInput!): HmisClientTypeHmisCreateClientError!
+  hmisUpdateClient(clientInput: HmisUpdateClientInput!, clientSubItemsInput: HmisUpdateClientSubItemsInput!): HmisClientTypeHmisUpdateClientError!
   deleteNote(data: DeleteDjangoObjectInput!): DeleteNotePayload! @hasRetvalPerm(permissions: [{app: "notes", permission: "delete_note"}], any: true)
   createNote(data: CreateNoteInput!): CreateNotePayload! @hasPerm(permissions: [{app: "notes", permission: "add_note"}], any: true)
   updateNote(data: UpdateNoteInput!): UpdateNotePayload! @permissionedQuerySet(permissions: [{app: "notes", permission: "change_note"}], any: true)

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -957,6 +957,7 @@ export type HmisUpdateClientInput = {
   firstName: Scalars['String']['input'];
   lastName: Scalars['String']['input'];
   nameDataQuality: Scalars['Int']['input'];
+  personalId: Scalars['String']['input'];
   ssn1: Scalars['String']['input'];
   ssn2: Scalars['String']['input'];
   ssn3: Scalars['String']['input'];

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -797,6 +797,8 @@ export type HmisClientTypeHmisCreateClientError = HmisClientType | HmisCreateCli
 
 export type HmisClientTypeHmisGetClientError = HmisClientType | HmisGetClientError;
 
+export type HmisClientTypeHmisUpdateClientError = HmisClientType | HmisUpdateClientError;
+
 export type HmisCreateClientError = {
   __typename?: 'HmisCreateClientError';
   field?: Maybe<Scalars['String']['output']>;
@@ -942,6 +944,35 @@ export enum HmisSuffixEnum {
   Sr = 'SR',
   Third = 'THIRD'
 }
+
+export type HmisUpdateClientError = {
+  __typename?: 'HmisUpdateClientError';
+  field?: Maybe<Scalars['String']['output']>;
+  message: Scalars['String']['output'];
+};
+
+export type HmisUpdateClientInput = {
+  dob: Scalars['String']['input'];
+  dobDataQuality: Scalars['Int']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  nameDataQuality: Scalars['Int']['input'];
+  ssn1: Scalars['String']['input'];
+  ssn2: Scalars['String']['input'];
+  ssn3: Scalars['String']['input'];
+  ssnDataQuality: Scalars['Int']['input'];
+};
+
+export type HmisUpdateClientSubItemsInput = {
+  additionalRaceEthnicity: Scalars['String']['input'];
+  alias: Scalars['String']['input'];
+  differentIdentityText: Scalars['String']['input'];
+  gender: Array<Scalars['Int']['input']>;
+  middleName: Scalars['String']['input'];
+  nameSuffix: Scalars['Int']['input'];
+  raceEthnicity: Array<Scalars['Int']['input']>;
+  veteranStatus: Scalars['Int']['input'];
+};
 
 export enum HmisVeteranStatusEnum {
   DontKnow = 'DONT_KNOW',
@@ -1135,6 +1166,7 @@ export type Mutation = {
   googleAuth: AuthResponse;
   hmisCreateClient: HmisClientTypeHmisCreateClientError;
   hmisLogin: UserTypeHmisLoginError;
+  hmisUpdateClient: HmisClientTypeHmisUpdateClientError;
   importClientProfile: ImportClientProfilePayload;
   importNote: ImportNotePayload;
   login: AuthResponse;
@@ -1295,6 +1327,12 @@ export type MutationHmisCreateClientArgs = {
 export type MutationHmisLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+};
+
+
+export type MutationHmisUpdateClientArgs = {
+  clientInput: HmisUpdateClientInput;
+  clientSubItemsInput: HmisUpdateClientSubItemsInput;
 };
 
 

--- a/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
@@ -957,6 +957,7 @@ export type HmisUpdateClientInput = {
   firstName: Scalars['String']['input'];
   lastName: Scalars['String']['input'];
   nameDataQuality: Scalars['Int']['input'];
+  personalId: Scalars['String']['input'];
   ssn1: Scalars['String']['input'];
   ssn2: Scalars['String']['input'];
   ssn3: Scalars['String']['input'];

--- a/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
@@ -797,6 +797,8 @@ export type HmisClientTypeHmisCreateClientError = HmisClientType | HmisCreateCli
 
 export type HmisClientTypeHmisGetClientError = HmisClientType | HmisGetClientError;
 
+export type HmisClientTypeHmisUpdateClientError = HmisClientType | HmisUpdateClientError;
+
 export type HmisCreateClientError = {
   __typename?: 'HmisCreateClientError';
   field?: Maybe<Scalars['String']['output']>;
@@ -942,6 +944,35 @@ export enum HmisSuffixEnum {
   Sr = 'SR',
   Third = 'THIRD'
 }
+
+export type HmisUpdateClientError = {
+  __typename?: 'HmisUpdateClientError';
+  field?: Maybe<Scalars['String']['output']>;
+  message: Scalars['String']['output'];
+};
+
+export type HmisUpdateClientInput = {
+  dob: Scalars['String']['input'];
+  dobDataQuality: Scalars['Int']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  nameDataQuality: Scalars['Int']['input'];
+  ssn1: Scalars['String']['input'];
+  ssn2: Scalars['String']['input'];
+  ssn3: Scalars['String']['input'];
+  ssnDataQuality: Scalars['Int']['input'];
+};
+
+export type HmisUpdateClientSubItemsInput = {
+  additionalRaceEthnicity: Scalars['String']['input'];
+  alias: Scalars['String']['input'];
+  differentIdentityText: Scalars['String']['input'];
+  gender: Array<Scalars['Int']['input']>;
+  middleName: Scalars['String']['input'];
+  nameSuffix: Scalars['Int']['input'];
+  raceEthnicity: Array<Scalars['Int']['input']>;
+  veteranStatus: Scalars['Int']['input'];
+};
 
 export enum HmisVeteranStatusEnum {
   DontKnow = 'DONT_KNOW',
@@ -1135,6 +1166,7 @@ export type Mutation = {
   googleAuth: AuthResponse;
   hmisCreateClient: HmisClientTypeHmisCreateClientError;
   hmisLogin: UserTypeHmisLoginError;
+  hmisUpdateClient: HmisClientTypeHmisUpdateClientError;
   importClientProfile: ImportClientProfilePayload;
   importNote: ImportNotePayload;
   login: AuthResponse;
@@ -1295,6 +1327,12 @@ export type MutationHmisCreateClientArgs = {
 export type MutationHmisLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+};
+
+
+export type MutationHmisUpdateClientArgs = {
+  clientInput: HmisUpdateClientInput;
+  clientSubItemsInput: HmisUpdateClientSubItemsInput;
 };
 
 

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -957,6 +957,7 @@ export type HmisUpdateClientInput = {
   firstName: Scalars['String']['input'];
   lastName: Scalars['String']['input'];
   nameDataQuality: Scalars['Int']['input'];
+  personalId: Scalars['String']['input'];
   ssn1: Scalars['String']['input'];
   ssn2: Scalars['String']['input'];
   ssn3: Scalars['String']['input'];

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -797,6 +797,8 @@ export type HmisClientTypeHmisCreateClientError = HmisClientType | HmisCreateCli
 
 export type HmisClientTypeHmisGetClientError = HmisClientType | HmisGetClientError;
 
+export type HmisClientTypeHmisUpdateClientError = HmisClientType | HmisUpdateClientError;
+
 export type HmisCreateClientError = {
   __typename?: 'HmisCreateClientError';
   field?: Maybe<Scalars['String']['output']>;
@@ -942,6 +944,35 @@ export enum HmisSuffixEnum {
   Sr = 'SR',
   Third = 'THIRD'
 }
+
+export type HmisUpdateClientError = {
+  __typename?: 'HmisUpdateClientError';
+  field?: Maybe<Scalars['String']['output']>;
+  message: Scalars['String']['output'];
+};
+
+export type HmisUpdateClientInput = {
+  dob: Scalars['String']['input'];
+  dobDataQuality: Scalars['Int']['input'];
+  firstName: Scalars['String']['input'];
+  lastName: Scalars['String']['input'];
+  nameDataQuality: Scalars['Int']['input'];
+  ssn1: Scalars['String']['input'];
+  ssn2: Scalars['String']['input'];
+  ssn3: Scalars['String']['input'];
+  ssnDataQuality: Scalars['Int']['input'];
+};
+
+export type HmisUpdateClientSubItemsInput = {
+  additionalRaceEthnicity: Scalars['String']['input'];
+  alias: Scalars['String']['input'];
+  differentIdentityText: Scalars['String']['input'];
+  gender: Array<Scalars['Int']['input']>;
+  middleName: Scalars['String']['input'];
+  nameSuffix: Scalars['Int']['input'];
+  raceEthnicity: Array<Scalars['Int']['input']>;
+  veteranStatus: Scalars['Int']['input'];
+};
 
 export enum HmisVeteranStatusEnum {
   DontKnow = 'DONT_KNOW',
@@ -1135,6 +1166,7 @@ export type Mutation = {
   googleAuth: AuthResponse;
   hmisCreateClient: HmisClientTypeHmisCreateClientError;
   hmisLogin: UserTypeHmisLoginError;
+  hmisUpdateClient: HmisClientTypeHmisUpdateClientError;
   importClientProfile: ImportClientProfilePayload;
   importNote: ImportNotePayload;
   login: AuthResponse;
@@ -1295,6 +1327,12 @@ export type MutationHmisCreateClientArgs = {
 export type MutationHmisLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+};
+
+
+export type MutationHmisUpdateClientArgs = {
+  clientInput: HmisUpdateClientInput;
+  clientSubItemsInput: HmisUpdateClientSubItemsInput;
 };
 
 


### PR DESCRIPTION
DEV-2135

## Summary by Sourcery

Add support for updating HMIS clients by introducing a new hmisUpdateClient GraphQL mutation backed by a bridge method, associated types, schema definitions, and tests.

New Features:
- Introduce hmis_update_client Strawberry mutation and GraphQL schema entry for updating HMIS client records
- Implement HmisApiBridge.update_client to relay updateClient calls to the external HMIS API
- Define HmisUpdateClientInput, HmisUpdateClientSubItemsInput, and HmisUpdateClientError types along with the HmisClientTypeHmisUpdateClientError union
- Regenerate frontend GraphQL type definitions to include the new update client mutation

Tests:
- Add unit test for hmisUpdateClient mutation to verify successful client updates