### PR TITLE
truncate task card description (DEV-2152)

### DIFF
--- a/libs/expo/betterangels/src/lib/ui-components/TaskCard/TaskCardBody.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskCard/TaskCardBody.tsx
@@ -17,7 +17,13 @@ export default function TaskCardBody(props: TaskCardBodyProps) {
       {description && (
         <>
           <TextRegular size="xs">Description</TextRegular>
-          <TextBold mb="sm" size="sm">
+          <TextBold
+            style={{ flex: 1 }}
+            numberOfLines={2}
+            ellipsizeMode="tail"
+            mb="sm"
+            size="sm"
+          >
             {description}
           </TextBold>
         </>


### PR DESCRIPTION
DEV-2152

## Summary by Sourcery

Enhancements:
- Truncate task card descriptions to two lines with tail ellipsis to prevent overflow