### PR TITLE
tasks tab

### DIFF
--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1979,12 +1979,14 @@ type SwitchType {
 
 input TaskFilter {
   clientProfile: ID
+  hmisClientProfile: ID
   createdBy: ID
   AND: TaskFilter
   OR: TaskFilter
   NOT: TaskFilter
   DISTINCT: Boolean
   clientProfiles: [ID!]
+  hmisClientProfiles: [ID!]
   authors: [ID!]
   organizations: [ID!]
   status: [TaskStatusEnum!]

--- a/apps/betterangels-backend/tasks/types.py
+++ b/apps/betterangels-backend/tasks/types.py
@@ -15,8 +15,10 @@ from . import models
 @strawberry_django.filter_type(models.Task, lookups=True)
 class TaskFilter:
     client_profile: Optional[ID]
+    hmis_client_profile: Optional[ID]
     created_by: Optional[ID]
     client_profiles = make_in_filter("client_profile", ID)
+    hmis_client_profiles = make_in_filter("hmis_client_profile", ID)
     authors = make_in_filter("created_by", ID)
     organizations = make_in_filter("organization", ID)
     status = make_in_filter("status", TaskStatusEnum)

--- a/apps/betterangels/.env
+++ b/apps/betterangels/.env
@@ -1,2 +1,3 @@
-EXPO_PUBLIC_API_URL=https://api.dev.betterangels.la
+# EXPO_PUBLIC_API_URL=https://api.dev.betterangels.la
+EXPO_PUBLIC_API_URL=http://localhost:8000
 EXPO_PUBLIC_DEMO_API_URL=http://localhost:8000

--- a/apps/betterangels/src/app/(private-screens)/task/[id].tsx
+++ b/apps/betterangels/src/app/(private-screens)/task/[id].tsx
@@ -2,14 +2,13 @@ import { Task } from '@monorepo/expo/betterangels';
 import { useLocalSearchParams } from 'expo-router';
 
 export default function TaskScreen() {
-  const { id, arrivedFrom } = useLocalSearchParams<{
+  const { id } = useLocalSearchParams<{
     id: string;
-    arrivedFrom?: string;
   }>();
 
   if (!id) {
     throw new Error('Something went wrong. Please try again.');
   }
 
-  return <Task id={id} arrivedFrom={arrivedFrom} />;
+  return <Task id={id} />;
 }

--- a/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/__generated__/types.ts
@@ -2471,6 +2471,8 @@ export type TaskFilter = {
   clientProfile?: InputMaybe<Scalars['ID']['input']>;
   clientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
+  hmisClientProfile?: InputMaybe<Scalars['ID']['input']>;
+  hmisClientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   organizations?: InputMaybe<Array<Scalars['ID']['input']>>;
   search?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Array<TaskStatusEnum>>;

--- a/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
@@ -72,14 +72,12 @@ export function TasksTab(props: TProps) {
       presentation: 'modal',
       content: (
         <TaskForm
-          clientProfileId={client?.clientProfile.id}
           onCancel={() => {
             closeModalScreen();
           }}
-          onSuccess={() => {
+          onSubmit={() => {
             closeModalScreen();
           }}
-          arrivedFrom={currentPath || '/tasks'}
         />
       ),
       title: 'Follow-Up Task',

--- a/libs/expo/betterangels/src/lib/screens/ClientHMIS/ClientHMIS.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientHMIS/ClientHMIS.tsx
@@ -13,6 +13,7 @@ import { renderTabComponent } from './tabs/utils/renderTabComponent';
 const hmisTabs: ClientViewTabEnum[] = [
   ClientViewTabEnum.Profile,
   ClientViewTabEnum.Interactions,
+  ClientViewTabEnum.Tasks,
 ];
 
 type TProps = {

--- a/libs/expo/betterangels/src/lib/screens/ClientHMIS/tabs/ClientTasksHMISView/ClientTasksHMISView.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientHMIS/tabs/ClientTasksHMISView/ClientTasksHMISView.tsx
@@ -28,8 +28,6 @@ export function ClientTasksHMISView(props: TProps) {
   const [createTask] = useMutation(CreateTaskDocument);
   const { showSnackbar } = useSnackbar();
 
-  const currentPath = client ? `/client/${client?.id}?newTab=Tasks` : undefined;
-
   const onSubmit = async (task: TaskFormData) => {
     if (!client?.id) return;
     try {
@@ -49,7 +47,6 @@ export function ClientTasksHMISView(props: TProps) {
         console.log(result.data.createTask.messages);
       }
 
-      console.log('RESULT: ', result.data?.createTask);
       closeModalScreen();
     } catch (e) {
       showSnackbar({
@@ -63,7 +60,6 @@ export function ClientTasksHMISView(props: TProps) {
   const handleTaskPress = useCallback((task: TaskType) => {
     router.navigate({
       pathname: `/task/${task.id}`,
-      params: { arrivedFrom: currentPath },
     });
   }, []);
 
@@ -126,7 +122,7 @@ export function ClientTasksHMISView(props: TProps) {
       />
 
       <TaskList
-        filters={{ search, clientProfile: client.id }}
+        filters={{ search, hmisClientProfile: client.id }}
         renderItem={renderTaskItem}
         renderHeader={renderListHeaderText}
       />

--- a/libs/expo/betterangels/src/lib/screens/ClientHMIS/tabs/ClientTasksHMISView/index.ts
+++ b/libs/expo/betterangels/src/lib/screens/ClientHMIS/tabs/ClientTasksHMISView/index.ts
@@ -1,0 +1,1 @@
+export { ClientTasksHMISView } from './ClientTasksHMISView';

--- a/libs/expo/betterangels/src/lib/screens/ClientHMIS/tabs/utils/renderTabComponent.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientHMIS/tabs/utils/renderTabComponent.tsx
@@ -4,6 +4,7 @@ import { ClientProfileSectionEnum } from '../../../../screenRouting';
 import { ClientViewTabEnum } from '../../../Client/ClientTabs';
 import { ClientInteractionsHmisView } from '../ClientInteractionsHmisView';
 import { ClientProfileHMISView } from '../ClientProfileHMISView';
+import { ClientTasksHMISView } from '../ClientTasksHMISView';
 
 type RenderArgs = {
   client?: HmisClientProfileType;
@@ -18,6 +19,9 @@ const tabRendererMap: Partial<
   ),
   [ClientViewTabEnum.Interactions]: ({ client }) => (
     <ClientInteractionsHmisView client={client} />
+  ),
+  [ClientViewTabEnum.Tasks]: ({ client }) => (
+    <ClientTasksHMISView client={client} />
   ),
 };
 

--- a/libs/expo/betterangels/src/lib/screens/NotesHmis/HmisProgramNoteForm/constants.ts
+++ b/libs/expo/betterangels/src/lib/screens/NotesHmis/HmisProgramNoteForm/constants.ts
@@ -5,4 +5,5 @@ export const FORM_KEYS = {
   date: 'date',
   refClientProgram: 'refClientProgram',
   note: 'note',
+  draftTasks: 'draftTasks',
 } as const satisfies { [K in TFormKeys]: K };

--- a/libs/expo/betterangels/src/lib/screens/Task/TaskHeader.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Task/TaskHeader.tsx
@@ -1,41 +1,74 @@
+import { useMutation } from '@apollo/client/react';
 import { EditButton, TextRegular } from '@monorepo/expo/shared/ui-components';
-import { useLocalSearchParams } from 'expo-router';
 import { StyleSheet, View } from 'react-native';
+import { TaskStatusEnum } from '../../apollo';
+import { useSnackbar } from '../../hooks';
 import { useModalScreen } from '../../providers';
 import { TaskForm } from '../../ui-components';
+import { UpdateTaskDocument } from '../../ui-components/TaskForm/__generated__/updateTask.generated';
+import { TaskFormData } from '../../ui-components/TaskForm/TaskForm';
 import { TaskQuery } from './__generated__/Task.generated';
-
-type TSearchParams = {
-  arrivedFrom?: string;
-};
 
 type TTaskHeaderProps = {
   task: TaskQuery['task'];
+  id: string;
 };
 
 export default function TaskHeader(props: TTaskHeaderProps) {
-  const { task } = props;
+  const { task, id } = props;
 
-  const { arrivedFrom } = useLocalSearchParams<TSearchParams>();
+  const { showSnackbar } = useSnackbar();
 
-  const currentPath = arrivedFrom || '/tasks';
+  const [updateTask] = useMutation(UpdateTaskDocument);
 
   const { showModalScreen, closeModalScreen } = useModalScreen();
+
+  const onSubmit = async (task: TaskFormData) => {
+    console.log(id);
+    if (!id) return;
+
+    try {
+      const result = await updateTask({
+        variables: {
+          data: {
+            id,
+            summary: task.summary!,
+            description: task.description,
+            status: task.status,
+            team: task.team || null,
+          },
+        },
+      });
+
+      if (result.data?.updateTask.__typename === 'OperationInfo') {
+        console.log(result.data.updateTask.messages);
+      }
+
+      closeModalScreen();
+    } catch (e) {
+      showSnackbar({
+        message: 'Error uploading profile photo.',
+        type: 'error',
+      });
+      console.error(e);
+    }
+  };
 
   function openTaskForm() {
     showModalScreen({
       presentation: 'modal',
       content: (
         <TaskForm
-          clientProfileId={task.clientProfile?.id}
-          task={task}
+          initialValues={{
+            summary: task.summary || '',
+            team: task.team || '',
+            description: task.description || '',
+            status: task.status || TaskStatusEnum.ToDo,
+          }}
           onCancel={() => {
             closeModalScreen();
           }}
-          onSuccess={() => {
-            closeModalScreen();
-          }}
-          arrivedFrom={currentPath}
+          onSubmit={onSubmit}
         />
       ),
       title: 'Follow-Up Task',

--- a/libs/expo/betterangels/src/lib/screens/Task/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Task/index.tsx
@@ -11,7 +11,7 @@ import TaskHeader from './TaskHeader';
 import TaskUpdatedAt from './TaskUpdatedAt';
 import { TaskDocument } from './__generated__/Task.generated';
 
-export default function Task({ id }: { id: string; arrivedFrom?: string }) {
+export default function Task({ id }: { id: string }) {
   const { data, loading, error } = useQuery(TaskDocument, {
     variables: { id },
     fetchPolicy: 'cache-and-network',
@@ -30,7 +30,7 @@ export default function Task({ id }: { id: string; arrivedFrom?: string }) {
   return (
     <MainScrollContainer bg={Colors.NEUTRAL_EXTRA_LIGHT}>
       <View accessibilityRole="button" style={styles.body}>
-        <TaskHeader task={task} />
+        <TaskHeader id={id} task={task} />
         <TaskUpdatedAt updatedAt={task.updatedAt} />
         <View>
           {task.clientProfile && (

--- a/libs/expo/betterangels/src/lib/screens/Tasks/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Tasks/index.tsx
@@ -7,6 +7,7 @@ import {
 import { router } from 'expo-router';
 import { useCallback, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { TaskType } from '../../apollo';
 import { useUser } from '../../hooks';
 import { TUser } from '../../providers/user/UserContext';
 import { pagePaddingHorizontal } from '../../static';
@@ -18,9 +19,6 @@ import {
   nullTaskFilters,
   toTaskFilterValue,
 } from '../../ui-components';
-import { TasksQuery } from './__generated__/Tasks.generated';
-
-type TTask = TasksQuery['tasks']['results'][number];
 
 function getInitialFilterValues(user?: TUser) {
   return {
@@ -39,7 +37,7 @@ export default function Tasks() {
     getInitialFilterValues(user)
   );
 
-  const handleTaskPress = useCallback((task: TTask) => {
+  const handleTaskPress = useCallback((task: TaskType) => {
     router.navigate({
       pathname: `/task/${task.id}`,
       params: { arrivedFrom: '/tasks' },
@@ -47,7 +45,7 @@ export default function Tasks() {
   }, []);
 
   const renderTaskItem = useCallback(
-    (task: TTask) => <TaskCard task={task} onPress={handleTaskPress} />,
+    (task: TaskType) => <TaskCard task={task} onPress={handleTaskPress} />,
     [handleTaskPress]
   );
 

--- a/libs/expo/betterangels/src/lib/ui-components/TaskCard/TaskCard.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskCard/TaskCard.tsx
@@ -1,7 +1,7 @@
 import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
 import { TextBold } from '@monorepo/expo/shared/ui-components';
 import { Pressable, StyleSheet, View } from 'react-native';
-import { TasksQuery } from '../TaskList/__generated__/Tasks.generated';
+import { TaskType } from '../../apollo';
 import TaskStatusBtn from '../TaskStatusBtn';
 import TaskCardBody from './TaskCardBody';
 import TaskCardClient from './TaskCardClient';
@@ -10,8 +10,8 @@ import TaskCardCreatedBy from './TaskCardCreatedBy';
 type TaskCardVariant = 'default' | 'withoutClient';
 
 type TaskCardProps = {
-  task: TasksQuery['tasks']['results'][number];
-  onPress?: (task: TasksQuery['tasks']['results'][number]) => void;
+  task: TaskType;
+  onPress?: (task: TaskType) => void;
   variant?: TaskCardVariant;
 };
 

--- a/libs/expo/betterangels/src/lib/ui-components/TaskForm/TaskForm.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskForm/TaskForm.tsx
@@ -11,7 +11,6 @@ import {
   SubmitHandler,
   useForm,
 } from 'react-hook-form';
-import { UpdateTaskInput } from '../../apollo';
 import { enumDisplaySelahTeam, enumDisplayTaskStatus } from '../../static';
 
 import DeleteTask from './DeleteTask';
@@ -21,7 +20,6 @@ export type TaskFormData = TFormSchema;
 
 type TProps = {
   initialValues?: Partial<TaskFormData>;
-  task?: UpdateTaskInput;
   onCancel: () => void;
   onSubmit: (data: TaskFormData) => Promise<void> | void;
 

--- a/libs/expo/betterangels/src/lib/ui-components/TaskForm/formSchema.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskForm/formSchema.ts
@@ -4,6 +4,7 @@ import { SelahTeamEnum, TaskStatusEnum } from '../../apollo';
 export type TFormSchema = z.infer<typeof FormSchema>;
 
 export const emptyState: TFormSchema = {
+  id: '',
   summary: '',
   team: '',
   description: '',
@@ -11,6 +12,7 @@ export const emptyState: TFormSchema = {
 };
 
 export const FormSchema = z.object({
+  id: z.string(),
   summary: z.string().min(1, 'Title is required.'),
   team: z.enum(SelahTeamEnum).or(z.literal('')),
   description: z.string(),

--- a/libs/expo/betterangels/src/lib/ui-components/TaskList/TaskList.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskList/TaskList.tsx
@@ -7,7 +7,7 @@ import {
 } from '@monorepo/expo/shared/ui-components';
 import { ReactElement, ReactNode, useCallback } from 'react';
 import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
-import { InputMaybe, TaskFilter, TaskOrder } from '../../apollo';
+import { InputMaybe, TaskFilter, TaskOrder, TaskType } from '../../apollo';
 import {
   TasksDocument,
   TasksQuery,
@@ -19,10 +19,8 @@ import {
   DEFAULT_QUERY_ORDER,
 } from './constants';
 
-type TTask = TasksQuery['tasks']['results'][number];
-
 type TProps = {
-  renderItem: (task: TTask) => ReactElement | null;
+  renderItem: (task: TaskType) => ReactElement | null;
   style?: StyleProp<ViewStyle>;
   itemGap?: number;
   filters?: InputMaybe<TaskFilter>;
@@ -45,7 +43,7 @@ export function TaskList(props: TProps) {
   } = props;
 
   const { items, total, loading, loadMore, hasMore, error } =
-    useInfiniteScrollQuery<TTask, TasksQuery, TasksQueryVariables>({
+    useInfiniteScrollQuery<TaskType, TasksQuery, TasksQueryVariables>({
       document: TasksDocument,
       queryFieldName: 'tasks',
       variables: {
@@ -55,8 +53,10 @@ export function TaskList(props: TProps) {
       pageSize: paginationLimit,
     });
 
+  console.log('ITEMS: ', items);
+
   const renderItemFn = useCallback(
-    (item: TTask) => renderItem(item),
+    (item: TaskType) => renderItem(item),
     [renderItem]
   );
 
@@ -72,7 +72,7 @@ export function TaskList(props: TProps) {
 
   return (
     <View style={[styles.container, style]}>
-      <InfiniteList<TTask>
+      <InfiniteList<TaskType>
         data={items}
         keyExtractor={(item) => item.id}
         totalItems={total}

--- a/libs/expo/betterangels/src/lib/ui-components/TaskList/TaskList.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskList/TaskList.tsx
@@ -53,8 +53,6 @@ export function TaskList(props: TProps) {
       pageSize: paginationLimit,
     });
 
-  console.log('ITEMS: ', items);
-
   const renderItemFn = useCallback(
     (item: TaskType) => renderItem(item),
     [renderItem]

--- a/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/betterangels-admin/src/lib/apollo/graphql/__generated__/types.ts
@@ -2471,6 +2471,8 @@ export type TaskFilter = {
   clientProfile?: InputMaybe<Scalars['ID']['input']>;
   clientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
+  hmisClientProfile?: InputMaybe<Scalars['ID']['input']>;
+  hmisClientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   organizations?: InputMaybe<Array<Scalars['ID']['input']>>;
   search?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Array<TaskStatusEnum>>;

--- a/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
+++ b/libs/react/shelter/src/lib/apollo/graphql/__generated__/types.ts
@@ -2471,6 +2471,8 @@ export type TaskFilter = {
   clientProfile?: InputMaybe<Scalars['ID']['input']>;
   clientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   createdBy?: InputMaybe<Scalars['ID']['input']>;
+  hmisClientProfile?: InputMaybe<Scalars['ID']['input']>;
+  hmisClientProfiles?: InputMaybe<Array<Scalars['ID']['input']>>;
   organizations?: InputMaybe<Array<Scalars['ID']['input']>>;
   search?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<Array<TaskStatusEnum>>;


### PR DESCRIPTION
NOT ready to merge

## Summary by Sourcery

Add HMIS client tasks tab, unify task types across the app, and wire up task create/update flows to the task form and backend filters.

New Features:
- Introduce an HMIS client Tasks tab that lists, searches, and allows creation of tasks tied to an HMIS client profile.
- Enable editing of tasks from the task detail header using the shared task form and an update mutation.

Enhancements:
- Standardize task typing across task lists and cards to use the shared TaskType.
- Extend the task form schema to include task IDs for reuse in both create and update flows.
- Route client HMIS views to include the new Tasks tab and its corresponding component.

Chores:
- Expand backend TaskFilter to support filtering by HMIS client profile IDs and expose these filters through the generated GraphQL schema.
- Add a draftTasks field to HMIS program note form constants to track related draft tasks.