### PR TITLE
block ci on e2e (DEV-1936)

### DIFF
--- a/.github/actions/expo-update/action.yml
+++ b/.github/actions/expo-update/action.yml
@@ -116,3 +116,4 @@ runs:
         group_id="${{ steps.perform-eas-update.outputs.group-id }}"
         echo "PROJECT_ID=$project_id" >> .env
         echo "GROUP_ID=$group_id" >> .env
+

--- a/.github/workflows/eas-post-e2e.yml
+++ b/.github/workflows/eas-post-e2e.yml
@@ -1,0 +1,105 @@
+name: 📣 FE Post-E2E Notifications
+
+on:
+  repository_dispatch:
+    types: [eas_post_e2e]
+
+jobs:
+  post-e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: ⚠️ Fail if E2E tests failed
+        if: github.event.client_payload.status != 'success'
+        run: |
+          echo "E2E tests failed with status: ${{ github.event.client_payload.status }}"
+          exit 1
+
+      - name: 🏗 Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.client_payload['github-sha'] || github.event.client_payload['github-ref'] || github.ref }}
+
+      - name: 📝 Comment on PR
+        if: github.event.client_payload['pr-number'] != ''
+        uses: edumserrano/find-create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.client_payload['pr-number'] }}
+          body-includes: '<!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload[''project-id''] }} -->'
+          comment-author: 'github-actions[bot]'
+          body: |
+            <!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload['project-id'] }} -->
+            🚀 Expo continuous deployment is ready for **${{ github.event.client_payload['project'] }}**!
+
+            - Project → **${{ github.event.client_payload['project'] }}**
+            - Environment → **Preview**
+            - Platforms → **android**, **ios**
+            - Scheme → **${{ github.event.client_payload['slug'] }}**
+
+            &nbsp; | 🤖 Android | 🍎 iOS
+            --- | --- | ---
+            Runtime Version | `${{ github.event.client_payload['android-runtime-version'] }}` | `${{ github.event.client_payload['ios-runtime-version'] }}`
+            Build Details | [Build Permalink](${{ github.event.client_payload['android-build-link'] }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload['android-distribution'] }}`<br />Build profile: `${{ github.event.client_payload['android-build-profile'] }}`<br />Runtime version: `${{ github.event.client_payload['android-runtime-version'] }}`<br />App version: `${{ github.event.client_payload['android-app-version'] }}`<br />Git commit: `${{ github.event.client_payload['android-git-commit'] }}`</details> | [Build Permalink](${{ github.event.client_payload['ios-build-link'] }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload['ios-distribution'] }}`<br />Build profile: `${{ github.event.client_payload['ios-build-profile'] }}`<br />Runtime version: `${{ github.event.client_payload['ios-runtime-version'] }}`<br />App version: `${{ github.event.client_payload['ios-app-version'] }}`<br />Git commit: `${{ github.event.client_payload['ios-git-commit'] }}`</details>
+            Update Details | [Update Permalink](${{ github.event.client_payload['android-update-permalink'] }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload['android-branch'] }}`<br />Runtime version: `${{ github.event.client_payload['android-update-runtime-version'] }}`<br />Git commit: `${{ github.event.client_payload['android-update-commit'] }}`</details> | [Update Permalink](${{ github.event.client_payload['ios-update-permalink'] }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload['ios-branch'] }}`<br />Runtime version: `${{ github.event.client_payload['ios-update-runtime-version'] }}`<br />Git commit: `${{ github.event.client_payload['ios-update-commit'] }}`</details>
+            Update QR   | <a href="${{ github.event.client_payload['android-update-qr-url'] }}"><img src="${{ github.event.client_payload['android-update-qr-url'] }}" width="250px" height="250px" /></a> | <a href="${{ github.event.client_payload['ios-update-qr-url'] }}"><img src="${{ github.event.client_payload['ios-update-qr-url'] }}" width="250px" height="250px" /></a>
+
+            **iOS Simulator Build:** [Simulator Build Link](${{ github.event.client_payload['simulator-ios-build-link'] }})
+          edit-mode: replace
+
+      - name: 📝 Set Git Variables
+        id: set-git-vars
+        run: |
+          COMMIT_ID=$(git rev-parse HEAD)
+          COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s" HEAD)
+
+          {
+            echo "commit-id=${COMMIT_ID}"
+            echo "commit-message=${COMMIT_MESSAGE}"
+          } >> $GITHUB_OUTPUT
+
+      - name: 📣 Post to Slack
+        if: github.event.client_payload['github-ref'] == 'refs/heads/main'
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "channel": "#tech-outreach-main",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*New code has landed in main for project ${{ github.event.client_payload['project'] }}!* \n*Commit:* `${{ steps.set-git-vars.outputs.commit-id }}`\n*Message:* ${{ steps.set-git-vars.outputs.commit-message }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*📱 iOS*\n\n<${{ github.event.client_payload['ios-update-qr-url'] }}|Update>\n<${{ github.event.client_payload['ios-build-link'] }}|Build>\n<${{ github.event.client_payload['simulator-ios-build-link'] }}|Simulator Build>"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*🤖 Android*\n\n<${{ github.event.client_payload['android-update-qr-url'] }}|Update>\n<${{ github.event.client_payload['android-build-link'] }}|Build>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      - name: 🧼 Cleanup .env file
+        if: always()
+        run: |
+          rm -f .env
+        working-directory: apps/${{ github.event.client_payload['project'] }}

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -7,6 +7,8 @@ on:
     types: [opened, synchronize]
   push:
     branches: [main]
+  repository_dispatch:
+    types: [e2e-tests-complete]
 
 jobs:
   prepare:
@@ -147,35 +149,144 @@ jobs:
           slug: ${{ steps.preview-build.outputs.slug }}
           project-id: ${{ steps.preview-build.outputs.project-id }}
 
+      - name: 📦 Prepare Webhook Payload
+        id: prepare-webhook
+        run: |
+          # Create a JSON payload with all preview outputs for EAS to send back via webhook
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PAYLOAD=$(cat <<EOF
+          {
+            "project": "${{ matrix.project }}",
+            "project-id": "${{ steps.preview-build.outputs.project-id }}",
+            "slug": "${{ steps.preview-build.outputs.slug }}",
+            "android-runtime-version": "${{ steps.preview-build.outputs.android-runtime-version }}",
+            "ios-runtime-version": "${{ steps.preview-build.outputs.ios-runtime-version }}",
+            "android-build-link": "${{ steps.preview-build.outputs.android-build-link }}",
+            "ios-build-link": "${{ steps.preview-build.outputs.ios-build-link }}",
+            "android-distribution": "${{ steps.preview-build.outputs.android-distribution }}",
+            "android-build-profile": "${{ steps.preview-build.outputs.android-build-profile }}",
+            "android-app-version": "${{ steps.preview-build.outputs.android-app-version }}",
+            "android-git-commit": "${{ steps.preview-build.outputs.android-git-commit }}",
+            "ios-distribution": "${{ steps.preview-build.outputs.ios-distribution }}",
+            "ios-build-profile": "${{ steps.preview-build.outputs.ios-build-profile }}",
+            "ios-app-version": "${{ steps.preview-build.outputs.ios-app-version }}",
+            "ios-git-commit": "${{ steps.preview-build.outputs.ios-git-commit }}",
+            "android-update-permalink": "${{ steps.expo-update.outputs.android-update-permalink }}",
+            "android-branch": "${{ steps.expo-update.outputs.android-branch }}",
+            "android-update-runtime-version": "${{ steps.expo-update.outputs.android-runtime-version }}",
+            "android-update-commit": "${{ steps.expo-update.outputs.android-update-commit }}",
+            "android-update-qr-url": "${{ steps.expo-update.outputs.android-update-qr-url }}",
+            "ios-update-permalink": "${{ steps.expo-update.outputs.ios-update-permalink }}",
+            "ios-branch": "${{ steps.expo-update.outputs.ios-branch }}",
+            "ios-update-runtime-version": "${{ steps.expo-update.outputs.ios-runtime-version }}",
+            "ios-update-commit": "${{ steps.expo-update.outputs.ios-update-commit }}",
+            "ios-update-qr-url": "${{ steps.expo-update.outputs.ios-update-qr-url }}",
+            "simulator-ios-build-link": "${{ steps.simulator-build.outputs.ios-build-link }}",
+            "branch-name": "${{ github.head_ref || github.ref_name }}",
+            "github-ref": "${{ github.ref }}",
+            "github-sha": "${{ github.sha }}",
+            "pr-number": "${PR_NUMBER}"
+          }
+          EOF
+          )
+          echo "payload<<EOF" >> $GITHUB_OUTPUT
+          echo "$PAYLOAD" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: 🧪 Run E2E Tests
+        id: run-e2e-tests
         working-directory: apps/${{ matrix.project }}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_DISPATCH_TOKEN: ${{ secrets.GITHUB_DISPATCH_APP_TOKEN }}
+          PROJECT_NAME: ${{ matrix.project }}
+          WEBHOOK_PAYLOAD: ${{ steps.prepare-webhook.outputs.payload }}
         run: |
           eas workflow:run .eas/workflows/e2e-test.yml --non-interactive
 
+      - name: 🧼 Cleanup .env file
+        if: always()
+        run: |
+          rm -f .env
+        working-directory: apps/${{ matrix.project }}
+
+    outputs:
+      project: ${{ matrix.project }}
+      project-id: ${{ steps.preview-build.outputs.project-id }}
+      slug: ${{ steps.preview-build.outputs.slug }}
+      android-runtime-version: ${{ steps.preview-build.outputs.android-runtime-version }}
+      ios-runtime-version: ${{ steps.preview-build.outputs.ios-runtime-version }}
+      android-build-link: ${{ steps.preview-build.outputs.android-build-link }}
+      ios-build-link: ${{ steps.preview-build.outputs.ios-build-link }}
+      android-distribution: ${{ steps.preview-build.outputs.android-distribution }}
+      android-build-profile: ${{ steps.preview-build.outputs.android-build-profile }}
+      android-app-version: ${{ steps.preview-build.outputs.android-app-version }}
+      android-git-commit: ${{ steps.preview-build.outputs.android-git-commit }}
+      ios-distribution: ${{ steps.preview-build.outputs.ios-distribution }}
+      ios-build-profile: ${{ steps.preview-build.outputs.ios-build-profile }}
+      ios-app-version: ${{ steps.preview-build.outputs.ios-app-version }}
+      ios-git-commit: ${{ steps.preview-build.outputs.ios-git-commit }}
+      android-update-permalink: ${{ steps.expo-update.outputs.android-update-permalink }}
+      android-branch: ${{ steps.expo-update.outputs.android-branch }}
+      android-update-runtime-version: ${{ steps.expo-update.outputs.android-runtime-version }}
+      android-update-commit: ${{ steps.expo-update.outputs.android-update-commit }}
+      android-update-qr-url: ${{ steps.expo-update.outputs.android-update-qr-url }}
+      ios-update-permalink: ${{ steps.expo-update.outputs.ios-update-permalink }}
+      ios-branch: ${{ steps.expo-update.outputs.ios-branch }}
+      ios-update-runtime-version: ${{ steps.expo-update.outputs.ios-runtime-version }}
+      ios-update-commit: ${{ steps.expo-update.outputs.ios-update-commit }}
+      ios-update-qr-url: ${{ steps.expo-update.outputs.ios-update-qr-url }}
+      simulator-ios-build-link: ${{ steps.simulator-build.outputs.ios-build-link }}
+
+  preview-post-e2e:
+    environment: preview
+    env:
+      BRANCH_NAME: ${{ github.event.client_payload.branch_name || github.head_ref || github.ref_name }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'repository_dispatch' && github.event.action == 'e2e-tests-complete'
+    permissions:
+      pull-requests: write # REQUIRED: Allow comments on PRs
+      contents: read # Required for actions/checkout
+      actions: write # REQUIRED: Allow updating fingerprint in action caches
+    steps:
+      - name: ⚠️ Fail if E2E tests failed
+        if: github.event.client_payload.status != 'success'
+        run: |
+          echo "E2E tests failed with status: ${{ github.event.client_payload.status }}"
+          exit 1
+
+      - name: 🏗 Check out repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.client_payload.github-sha || github.event.client_payload.github-ref || github.ref }}
+
       - name: 📝 Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event.client_payload.pr-number != ''
         uses: edumserrano/find-create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-includes: '<!-- continuous-deploy-fingerprint-projectId:${{ steps.preview-build.outputs.project-id }} -->'
+          issue-number: ${{ github.event.client_payload.pr-number }}
+          body-includes: '<!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload.project-id }} -->'
           comment-author: 'github-actions[bot]'
           body: |
-            <!-- continuous-deploy-fingerprint-projectId:${{ steps.preview-build.outputs.project-id }} -->
-            🚀 Expo continuous deployment is ready for **${{ matrix.project }}**!
+            <!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload.project-id }} -->
+            🚀 Expo continuous deployment is ready for **${{ github.event.client_payload.project }}**!
 
-            - Project → **${{ matrix.project }}**
+            - Project → **${{ github.event.client_payload.project }}**
             - Environment → **Preview**
             - Platforms → **android**, **ios**
-            - Scheme → **${{ steps.preview-build.outputs.slug }}**
+            - Scheme → **${{ github.event.client_payload.slug }}**
 
             &nbsp; | 🤖 Android | 🍎 iOS
             --- | --- | ---
-            Runtime Version | `${{ steps.preview-build.outputs.android-runtime-version }}` | `${{ steps.preview-build.outputs.ios-runtime-version }}`
-            Build Details | [Build Permalink](${{ steps.preview-build.outputs.android-build-link }})<br /><details><summary>Details</summary>Distribution: `${{ steps.preview-build.outputs.android-distribution }}`<br />Build profile: `${{ steps.preview-build.outputs.android-build-profile }}`<br />Runtime version: `${{ steps.preview-build.outputs.android-runtime-version }}`<br />App version: `${{ steps.preview-build.outputs.android-app-version }}`<br />Git commit: `${{ steps.preview-build.outputs.android-git-commit }}`</details> | [Build Permalink](${{ steps.preview-build.outputs.ios-build-link }})<br /><details><summary>Details</summary>Distribution: `${{ steps.preview-build.outputs.ios-distribution }}`<br />Build profile: `${{ steps.preview-build.outputs.ios-build-profile }}`<br />Runtime version: `${{ steps.preview-build.outputs.ios-runtime-version }}`<br />App version: `${{ steps.preview-build.outputs.ios-app-version }}`<br />Git commit: `${{ steps.preview-build.outputs.ios-git-commit }}`</details>
-            Update Details | [Update Permalink](${{ steps.expo-update.outputs.android-update-permalink }})<br /><details><summary>Details</summary>Branch: `${{ steps.expo-update.outputs.android-branch }}`<br />Runtime version: `${{ steps.expo-update.outputs.android-runtime-version }}`<br />Git commit: `${{ steps.expo-update.outputs.android-update-commit }}`</details> | [Update Permalink](${{ steps.expo-update.outputs.ios-update-permalink }})<br /><details><summary>Details</summary>Branch: `${{ steps.expo-update.outputs.ios-branch }}`<br />Runtime version: `${{ steps.expo-update.outputs.ios-runtime-version }}`<br />Git commit: `${{ steps.expo-update.outputs.ios-update-commit }}`</details>
-            Update QR   | <a href="${{ steps.expo-update.outputs.android-update-qr-url }}"><img src="${{ steps.expo-update.outputs.android-update-qr-url }}" width="250px" height="250px" /></a> | <a href="${{ steps.expo-update.outputs.ios-update-qr-url }}"><img src="${{ steps.expo-update.outputs.ios-update-qr-url }}" width="250px" height="250px" /></a>
+            Runtime Version | `${{ github.event.client_payload.android-runtime-version }}` | `${{ github.event.client_payload.ios-runtime-version }}`
+            Build Details | [Build Permalink](${{ github.event.client_payload.android-build-link }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload.android-distribution }}`<br />Build profile: `${{ github.event.client_payload.android-build-profile }}`<br />Runtime version: `${{ github.event.client_payload.android-runtime-version }}`<br />App version: `${{ github.event.client_payload.android-app-version }}`<br />Git commit: `${{ github.event.client_payload.android-git-commit }}`</details> | [Build Permalink](${{ github.event.client_payload.ios-build-link }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload.ios-distribution }}`<br />Build profile: `${{ github.event.client_payload.ios-build-profile }}`<br />Runtime version: `${{ github.event.client_payload.ios-runtime-version }}`<br />App version: `${{ github.event.client_payload.ios-app-version }}`<br />Git commit: `${{ github.event.client_payload.ios-git-commit }}`</details>
+            Update Details | [Update Permalink](${{ github.event.client_payload.android-update-permalink }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload.android-branch }}`<br />Runtime version: `${{ github.event.client_payload.android-update-runtime-version }}`<br />Git commit: `${{ github.event.client_payload.android-update-commit }}`</details> | [Update Permalink](${{ github.event.client_payload.ios-update-permalink }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload.ios-branch }}`<br />Runtime version: `${{ github.event.client_payload.ios-update-runtime-version }}`<br />Git commit: `${{ github.event.client_payload.ios-update-commit }}`</details>
+            Update QR   | <a href="${{ github.event.client_payload.android-update-qr-url }}"><img src="${{ github.event.client_payload.android-update-qr-url }}" width="250px" height="250px" /></a> | <a href="${{ github.event.client_payload.ios-update-qr-url }}"><img src="${{ github.event.client_payload.ios-update-qr-url }}" width="250px" height="250px" /></a>
 
-            **iOS Simulator Build:** [Simulator Build Link](${{ steps.simulator-build.outputs.ios-build-link }})
+            **iOS Simulator Build:** [Simulator Build Link](${{ github.event.client_payload.simulator-ios-build-link }})
           edit-mode: replace
 
       - name: 📝 Set Git Variables
@@ -190,7 +301,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: 📣 Post to Slack
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event.client_payload.github-ref == 'refs/heads/main'
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
@@ -201,14 +312,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*New code has landed in main for project ${{ matrix.project }}!* \n*Commit:* `${{ steps.set-git-vars.outputs.commit-id }}`\n*Message:* ${{ steps.set-git-vars.outputs.commit-message }}"
+                    "text": "*New code has landed in main for project ${{ github.event.client_payload.project }}!* \n*Commit:* `${{ steps.set-git-vars.outputs.commit-id }}`\n*Message:* ${{ steps.set-git-vars.outputs.commit-message }}"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*📱 iOS*\n\n<${{ steps.expo-update.outputs.ios-update-qr-url }}|Update>\n<${{ steps.preview-build.outputs.ios-build-link }}|Build>\n<${{ steps.simulator-build.outputs.ios-build-link }}|Simulator Build>"
+                    "text": "*📱 iOS*\n\n<${{ github.event.client_payload.ios-update-qr-url }}|Update>\n<${{ github.event.client_payload.ios-build-link }}|Build>\n<${{ github.event.client_payload.simulator-ios-build-link }}|Simulator Build>"
                   }
                 },
                 {
@@ -218,7 +329,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*🤖 Android*\n\n<${{ steps.expo-update.outputs.android-update-qr-url }}|Update>\n<${{ steps.preview-build.outputs.android-build-link }}|Build>"
+                    "text": "*🤖 Android*\n\n<${{ github.event.client_payload.android-update-qr-url }}|Update>\n<${{ github.event.client_payload.android-build-link }}|Build>"
                   }
                 }
               ]
@@ -231,7 +342,7 @@ jobs:
         if: always()
         run: |
           rm -f .env
-        working-directory: apps/${{ matrix.project }}
+        working-directory: apps/${{ github.event.client_payload.project }}
 
   production:
     if: |

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -7,8 +7,6 @@ on:
     types: [opened, synchronize]
   push:
     branches: [main]
-  repository_dispatch:
-    types: [e2e-tests-complete]
 
 jobs:
   prepare:
@@ -170,7 +168,7 @@ jobs:
             "ios-distribution": "INTERNAL",
             "ios-build-profile": "preview",
             "ios-app-version": "1.0.58",
-            "ios-git-commit": "2a068de5c10a937c45e9dc25e04c33f1360be376",
+            "ios-git-commit": "${{ steps.preview-build.outputs.ios-git-commit }}",
             "android-update-permalink": "https://expo.dev/projects/53171ba4-60ca-40cb-b3e6-b0c2393677b8/updates/019bdd88-1a82-7424-9d2b-20788a63ecf4",
             "android-branch": "DEV-1936/block-on-e2e",
             "android-update-runtime-version": "84c9efb850e71475bdf5ca9270cca37229321e21",
@@ -258,6 +256,7 @@ jobs:
           rm -f .env
         working-directory: apps/${{ matrix.project }}
 
+    # probably not needed. will be provided by expo
     outputs:
       project: "betterangels"
       project-id: "53171ba4-60ca-40cb-b3e6-b0c2393677b8"
@@ -313,109 +312,6 @@ jobs:
       # ios-update-qr-url: ${{ steps.expo-update.outputs.ios-update-qr-url }}
       # simulator-ios-build-link: ${{ steps.simulator-build.outputs.ios-build-link }}
 
-  preview-post-e2e:
-    environment: preview
-    env:
-      BRANCH_NAME: ${{ github.event.client_payload['branch-name'] || github.head_ref || github.ref_name }}
-    runs-on: ubuntu-latest
-    if: github.event_name == 'repository_dispatch'
-    permissions:
-      pull-requests: write # REQUIRED: Allow comments on PRs
-      contents: read # Required for actions/checkout
-      actions: write # REQUIRED: Allow updating fingerprint in action caches
-    steps:
-      - name: ⚠️ Fail if E2E tests failed
-        if: github.event.client_payload.status != 'success'
-        run: |
-          echo "E2E tests failed with status: ${{ github.event.client_payload.status }}"
-          exit 1
-
-      - name: 🏗 Check out repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          ref: ${{ github.event.client_payload['github-sha'] || github.event.client_payload['github-ref'] || github.ref }}
-
-      - name: 📝 Comment on PR
-        if: github.event.client_payload['pr-number'] != ''
-        uses: edumserrano/find-create-or-update-comment@v3
-        with:
-          issue-number: ${{ github.event.client_payload['pr-number'] }}
-          body-includes: '<!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload[''project-id''] }} -->'
-          comment-author: 'github-actions[bot]'
-          body: |
-            <!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload['project-id'] }} -->
-            🚀 Expo continuous deployment is ready for **${{ github.event.client_payload['project'] }}**!
-
-            - Project → **${{ github.event.client_payload['project'] }}**
-            - Environment → **Preview**
-            - Platforms → **android**, **ios**
-            - Scheme → **${{ github.event.client_payload['slug'] }}**
-
-            &nbsp; | 🤖 Android | 🍎 iOS
-            --- | --- | ---
-            Runtime Version | `${{ github.event.client_payload['android-runtime-version'] }}` | `${{ github.event.client_payload['ios-runtime-version'] }}`
-            Build Details | [Build Permalink](${{ github.event.client_payload['android-build-link'] }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload['android-distribution'] }}`<br />Build profile: `${{ github.event.client_payload['android-build-profile'] }}`<br />Runtime version: `${{ github.event.client_payload['android-runtime-version'] }}`<br />App version: `${{ github.event.client_payload['android-app-version'] }}`<br />Git commit: `${{ github.event.client_payload['android-git-commit'] }}`</details> | [Build Permalink](${{ github.event.client_payload['ios-build-link'] }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload['ios-distribution'] }}`<br />Build profile: `${{ github.event.client_payload['ios-build-profile'] }}`<br />Runtime version: `${{ github.event.client_payload['ios-runtime-version'] }}`<br />App version: `${{ github.event.client_payload['ios-app-version'] }}`<br />Git commit: `${{ github.event.client_payload['ios-git-commit'] }}`</details>
-            Update Details | [Update Permalink](${{ github.event.client_payload['android-update-permalink'] }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload['android-branch'] }}`<br />Runtime version: `${{ github.event.client_payload['android-update-runtime-version'] }}`<br />Git commit: `${{ github.event.client_payload['android-update-commit'] }}`</details> | [Update Permalink](${{ github.event.client_payload['ios-update-permalink'] }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload['ios-branch'] }}`<br />Runtime version: `${{ github.event.client_payload['ios-update-runtime-version'] }}`<br />Git commit: `${{ github.event.client_payload['ios-update-commit'] }}`</details>
-            Update QR   | <a href="${{ github.event.client_payload['android-update-qr-url'] }}"><img src="${{ github.event.client_payload['android-update-qr-url'] }}" width="250px" height="250px" /></a> | <a href="${{ github.event.client_payload['ios-update-qr-url'] }}"><img src="${{ github.event.client_payload['ios-update-qr-url'] }}" width="250px" height="250px" /></a>
-
-            **iOS Simulator Build:** [Simulator Build Link](${{ github.event.client_payload['simulator-ios-build-link'] }})
-          edit-mode: replace
-
-      - name: 📝 Set Git Variables
-        id: set-git-vars
-        run: |
-          COMMIT_ID=$(git rev-parse HEAD)
-          COMMIT_MESSAGE=$(git log -1 --pretty=format:"%s" HEAD)
-
-          {
-            echo "commit-id=${COMMIT_ID}"
-            echo "commit-message=${COMMIT_MESSAGE}"
-          } >> $GITHUB_OUTPUT
-
-      - name: 📣 Post to Slack
-        if: github.event.client_payload['github-ref'] == 'refs/heads/main'
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          payload: |
-            {
-              "channel": "#tech-outreach-main",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*New code has landed in main for project ${{ github.event.client_payload['project'] }}!* \n*Commit:* `${{ steps.set-git-vars.outputs.commit-id }}`\n*Message:* ${{ steps.set-git-vars.outputs.commit-message }}"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*📱 iOS*\n\n<${{ github.event.client_payload['ios-update-qr-url'] }}|Update>\n<${{ github.event.client_payload['ios-build-link'] }}|Build>\n<${{ github.event.client_payload['simulator-ios-build-link'] }}|Simulator Build>"
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*🤖 Android*\n\n<${{ github.event.client_payload['android-update-qr-url'] }}|Update>\n<${{ github.event.client_payload['android-build-link'] }}|Build>"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-      - name: 🧼 Cleanup .env file
-        if: always()
-        run: |
-          rm -f .env
-        working-directory: apps/${{ github.event.client_payload['project'] }}
 
   production:
     if: |

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -205,7 +205,6 @@ jobs:
         id: run-e2e-tests
         working-directory: apps/${{ matrix.project }}
         env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
           PROJECT_NAME: ${{ matrix.project }}

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -193,6 +193,14 @@ jobs:
           echo "$PAYLOAD" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: 🧾 Write E2E dispatch payload into .env
+        working-directory: apps/${{ matrix.project }}
+        env:
+          WEBHOOK_PAYLOAD: ${{ steps.prepare-webhook.outputs.payload }}
+        run: |
+          set -euo pipefail
+          echo "WEBHOOK_PAYLOAD_B64=$(printf '%s' "$WEBHOOK_PAYLOAD" | base64 -w0)" >> .env
+
       - name: 🧪 Run E2E Tests
         id: run-e2e-tests
         working-directory: apps/${{ matrix.project }}
@@ -200,9 +208,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
-          GITHUB_DISPATCH_TOKEN: ${{ secrets.EXPO_REPO_DISPATCH_TOKEN }}
           PROJECT_NAME: ${{ matrix.project }}
-          WEBHOOK_PAYLOAD: ${{ steps.prepare-webhook.outputs.payload }}
         run: |
           eas workflow:run .eas/workflows/e2e-test.yml --non-interactive
 

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -140,14 +140,14 @@ jobs:
           platforms: ios
           runtime-version: ${{ steps.setup-secrets.outputs.runtime-version }}
 
-      - name: 🚀 Perform EAS Update
-        id: expo-update
-        uses: ./.github/actions/expo-update
-        with:
-          project: ${{ matrix.project }}
-          branch: ${{ github.head_ref || github.ref_name }}
-          slug: ${{ steps.preview-build.outputs.slug }}
-          project-id: ${{ steps.preview-build.outputs.project-id }}
+      # - name: 🚀 Perform EAS Update
+      #   id: expo-update
+      #   uses: ./.github/actions/expo-update
+      #   with:
+      #     project: ${{ matrix.project }}
+      #     branch: ${{ github.head_ref || github.ref_name }}
+      #     slug: ${{ steps.preview-build.outputs.slug }}
+      #     project-id: ${{ steps.preview-build.outputs.project-id }}
 
       - name: 📦 Prepare Webhook Payload
         id: prepare-webhook
@@ -156,42 +156,83 @@ jobs:
           PR_NUMBER="${{ github.event.pull_request.number }}"
           PAYLOAD=$(cat <<EOF
           {
-            "project": "${{ matrix.project }}",
-            "project-id": "${{ steps.preview-build.outputs.project-id }}",
-            "slug": "${{ steps.preview-build.outputs.slug }}",
-            "android-runtime-version": "${{ steps.preview-build.outputs.android-runtime-version }}",
-            "ios-runtime-version": "${{ steps.preview-build.outputs.ios-runtime-version }}",
-            "android-build-link": "${{ steps.preview-build.outputs.android-build-link }}",
-            "ios-build-link": "${{ steps.preview-build.outputs.ios-build-link }}",
-            "android-distribution": "${{ steps.preview-build.outputs.android-distribution }}",
-            "android-build-profile": "${{ steps.preview-build.outputs.android-build-profile }}",
-            "android-app-version": "${{ steps.preview-build.outputs.android-app-version }}",
-            "android-git-commit": "${{ steps.preview-build.outputs.android-git-commit }}",
-            "ios-distribution": "${{ steps.preview-build.outputs.ios-distribution }}",
-            "ios-build-profile": "${{ steps.preview-build.outputs.ios-build-profile }}",
-            "ios-app-version": "${{ steps.preview-build.outputs.ios-app-version }}",
-            "ios-git-commit": "${{ steps.preview-build.outputs.ios-git-commit }}",
-            "android-update-permalink": "${{ steps.expo-update.outputs.android-update-permalink }}",
-            "android-branch": "${{ steps.expo-update.outputs.android-branch }}",
-            "android-update-runtime-version": "${{ steps.expo-update.outputs.android-runtime-version }}",
-            "android-update-commit": "${{ steps.expo-update.outputs.android-update-commit }}",
-            "android-update-qr-url": "${{ steps.expo-update.outputs.android-update-qr-url }}",
-            "ios-update-permalink": "${{ steps.expo-update.outputs.ios-update-permalink }}",
-            "ios-branch": "${{ steps.expo-update.outputs.ios-branch }}",
-            "ios-update-runtime-version": "${{ steps.expo-update.outputs.ios-runtime-version }}",
-            "ios-update-commit": "${{ steps.expo-update.outputs.ios-update-commit }}",
-            "ios-update-qr-url": "${{ steps.expo-update.outputs.ios-update-qr-url }}",
-            "simulator-ios-build-link": "${{ steps.simulator-build.outputs.ios-build-link }}",
-            "branch-name": "${{ github.head_ref || github.ref_name }}",
-            "github-ref": "${{ github.ref }}",
-            "github-sha": "${{ github.sha }}",
-            "pr-number": "${PR_NUMBER}"
+            "project": "betterangels",
+            "project-id": "53171ba4-60ca-40cb-b3e6-b0c2393677b8",
+            "slug": "betterangels",
+            "android-runtime-version": "84c9efb850e71475bdf5ca9270cca37229321e21",
+            "ios-runtime-version": "84c9efb850e71475bdf5ca9270cca37229321e21",
+            "android-build-link": "https://expo.dev/accounts/better-angels/projects/betterangels/builds/6b3af6ab-9f4e-4e96-98bf-59a9730244ea",
+            "ios-build-link": "https://expo.dev/accounts/better-angels/projects/betterangels/builds/c2212b9e-2778-41c2-8a94-61a43605aedb",
+            "android-distribution": "INTERNAL",
+            "android-build-profile": "preview",
+            "android-app-version": "1.0.58",
+            "android-git-commit": "2a068de5c10a937c45e9dc25e04c33f1360be376",
+            "ios-distribution": "INTERNAL",
+            "ios-build-profile": "preview",
+            "ios-app-version": "1.0.58",
+            "ios-git-commit": "2a068de5c10a937c45e9dc25e04c33f1360be376",
+            "android-update-permalink": "https://expo.dev/projects/53171ba4-60ca-40cb-b3e6-b0c2393677b8/updates/019bdd88-1a82-7424-9d2b-20788a63ecf4",
+            "android-branch": "DEV-1936/block-on-e2e",
+            "android-update-runtime-version": "84c9efb850e71475bdf5ca9270cca37229321e21",
+            "android-update-commit": "6a698e1d6afb8f5c63d09e467595f9dd96fc9735",
+            "android-update-qr-url": "https://qr.expo.dev/eas-update?appScheme=betterangels&projectId=53171ba4-60ca-40cb-b3e6-b0c2393677b8&groupId=73d9832b-e617-4a2d-b478-63540e869202",
+            "ios-update-permalink": "https://expo.dev/projects/53171ba4-60ca-40cb-b3e6-b0c2393677b8/updates/019bdd88-1a82-7405-ae11-acb3d38c163e",
+            "ios-branch": "DEV-1936/block-on-e2e",
+            "ios-update-runtime-version": "84c9efb850e71475bdf5ca9270cca37229321e21",
+            "ios-update-commit": "6a698e1d6afb8f5c63d09e467595f9dd96fc9735",
+            "ios-update-qr-url": "https://qr.expo.dev/eas-update?appScheme=betterangels&projectId=53171ba4-60ca-40cb-b3e6-b0c2393677b8&groupId=73d9832b-e617-4a2d-b478-63540e869202",
+            "simulator-ios-build-link": "https://expo.dev/accounts/better-angels/projects/betterangels/builds/0626f53b-99cd-4e2b-972a-a7fe9e82d6eb",
+            "branch-name": "DEV-1936/block-on-e2e",
+            "github-ref": "refs/pull/1804/merge",
+            "github-sha": "a88bfd51e789cbd890fddbdb7b8b1a019f5143ff",
+            "pr-number": "1804"
           }
           EOF
           )
           echo "payload<<EOF" >> $GITHUB_OUTPUT
           echo "$PAYLOAD" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+        # run: |
+        #   # Create a JSON payload with all preview outputs for EAS to send back via webhook
+        #   PR_NUMBER="${{ github.event.pull_request.number }}"
+        #   PAYLOAD=$(cat <<EOF
+        #   {
+        #     "project": "${{ matrix.project }}",
+        #     "project-id": "${{ steps.preview-build.outputs.project-id }}",
+        #     "slug": "${{ steps.preview-build.outputs.slug }}",
+        #     "android-runtime-version": "${{ steps.preview-build.outputs.android-runtime-version }}",
+        #     "ios-runtime-version": "${{ steps.preview-build.outputs.ios-runtime-version }}",
+        #     "android-build-link": "${{ steps.preview-build.outputs.android-build-link }}",
+        #     "ios-build-link": "${{ steps.preview-build.outputs.ios-build-link }}",
+        #     "android-distribution": "${{ steps.preview-build.outputs.android-distribution }}",
+        #     "android-build-profile": "${{ steps.preview-build.outputs.android-build-profile }}",
+        #     "android-app-version": "${{ steps.preview-build.outputs.android-app-version }}",
+        #     "android-git-commit": "${{ steps.preview-build.outputs.android-git-commit }}",
+        #     "ios-distribution": "${{ steps.preview-build.outputs.ios-distribution }}",
+        #     "ios-build-profile": "${{ steps.preview-build.outputs.ios-build-profile }}",
+        #     "ios-app-version": "${{ steps.preview-build.outputs.ios-app-version }}",
+        #     "ios-git-commit": "${{ steps.preview-build.outputs.ios-git-commit }}",
+        #     "android-update-permalink": "${{ steps.expo-update.outputs.android-update-permalink }}",
+        #     "android-branch": "${{ steps.expo-update.outputs.android-branch }}",
+        #     "android-update-runtime-version": "${{ steps.expo-update.outputs.android-runtime-version }}",
+        #     "android-update-commit": "${{ steps.expo-update.outputs.android-update-commit }}",
+        #     "android-update-qr-url": "${{ steps.expo-update.outputs.android-update-qr-url }}",
+        #     "ios-update-permalink": "${{ steps.expo-update.outputs.ios-update-permalink }}",
+        #     "ios-branch": "${{ steps.expo-update.outputs.ios-branch }}",
+        #     "ios-update-runtime-version": "${{ steps.expo-update.outputs.ios-runtime-version }}",
+        #     "ios-update-commit": "${{ steps.expo-update.outputs.ios-update-commit }}",
+        #     "ios-update-qr-url": "${{ steps.expo-update.outputs.ios-update-qr-url }}",
+        #     "simulator-ios-build-link": "${{ steps.simulator-build.outputs.ios-build-link }}",
+        #     "branch-name": "${{ github.head_ref || github.ref_name }}",
+        #     "github-ref": "${{ github.ref }}",
+        #     "github-sha": "${{ github.sha }}",
+        #     "pr-number": "${PR_NUMBER}"
+        #   }
+        #   EOF
+        #   )
+        #   echo "payload<<EOF" >> $GITHUB_OUTPUT
+        #   echo "$PAYLOAD" >> $GITHUB_OUTPUT
+        #   echo "EOF" >> $GITHUB_OUTPUT
 
       - name: 🧾 Write E2E dispatch payload into .env
         working-directory: apps/${{ matrix.project }}
@@ -218,32 +259,59 @@ jobs:
         working-directory: apps/${{ matrix.project }}
 
     outputs:
-      project: ${{ matrix.project }}
-      project-id: ${{ steps.preview-build.outputs.project-id }}
-      slug: ${{ steps.preview-build.outputs.slug }}
-      android-runtime-version: ${{ steps.preview-build.outputs.android-runtime-version }}
-      ios-runtime-version: ${{ steps.preview-build.outputs.ios-runtime-version }}
-      android-build-link: ${{ steps.preview-build.outputs.android-build-link }}
-      ios-build-link: ${{ steps.preview-build.outputs.ios-build-link }}
-      android-distribution: ${{ steps.preview-build.outputs.android-distribution }}
-      android-build-profile: ${{ steps.preview-build.outputs.android-build-profile }}
-      android-app-version: ${{ steps.preview-build.outputs.android-app-version }}
-      android-git-commit: ${{ steps.preview-build.outputs.android-git-commit }}
-      ios-distribution: ${{ steps.preview-build.outputs.ios-distribution }}
-      ios-build-profile: ${{ steps.preview-build.outputs.ios-build-profile }}
-      ios-app-version: ${{ steps.preview-build.outputs.ios-app-version }}
-      ios-git-commit: ${{ steps.preview-build.outputs.ios-git-commit }}
-      android-update-permalink: ${{ steps.expo-update.outputs.android-update-permalink }}
-      android-branch: ${{ steps.expo-update.outputs.android-branch }}
-      android-update-runtime-version: ${{ steps.expo-update.outputs.android-runtime-version }}
-      android-update-commit: ${{ steps.expo-update.outputs.android-update-commit }}
-      android-update-qr-url: ${{ steps.expo-update.outputs.android-update-qr-url }}
-      ios-update-permalink: ${{ steps.expo-update.outputs.ios-update-permalink }}
-      ios-branch: ${{ steps.expo-update.outputs.ios-branch }}
-      ios-update-runtime-version: ${{ steps.expo-update.outputs.ios-runtime-version }}
-      ios-update-commit: ${{ steps.expo-update.outputs.ios-update-commit }}
-      ios-update-qr-url: ${{ steps.expo-update.outputs.ios-update-qr-url }}
-      simulator-ios-build-link: ${{ steps.simulator-build.outputs.ios-build-link }}
+      project: "betterangels"
+      project-id: "53171ba4-60ca-40cb-b3e6-b0c2393677b8"
+      slug: "betterangels"
+      android-runtime-version: "84c9efb850e71475bdf5ca9270cca37229321e21"
+      ios-runtime-version: "84c9efb850e71475bdf5ca9270cca37229321e21"
+      android-build-link: "https://expo.dev/accounts/better-angels/projects/betterangels/builds/6b3af6ab-9f4e-4e96-98bf-59a9730244ea"
+      ios-build-link: "https://expo.dev/accounts/better-angels/projects/betterangels/builds/c2212b9e-2778-41c2-8a94-61a43605aedb"
+      android-distribution: "INTERNAL"
+      android-build-profile: "preview"
+      android-app-version: "1.0.58"
+      android-git-commit: "2a068de5c10a937c45e9dc25e04c33f1360be376"
+      ios-distribution: "INTERNAL"
+      ios-build-profile: "preview"
+      ios-app-version: "1.0.58"
+      ios-git-commit: "2a068de5c10a937c45e9dc25e04c33f1360be376"
+      android-update-permalink: "https://expo.dev/projects/53171ba4-60ca-40cb-b3e6-b0c2393677b8/updates/019bdd88-1a82-7424-9d2b-20788a63ecf4"
+      android-branch: "DEV-1936/block-on-e2e"
+      android-update-runtime-version: "84c9efb850e71475bdf5ca9270cca37229321e21"
+      android-update-commit: "6a698e1d6afb8f5c63d09e467595f9dd96fc9735"
+      android-update-qr-url: "https://qr.expo.dev/eas-update?appScheme=betterangels&projectId=53171ba4-60ca-40cb-b3e6-b0c2393677b8&groupId=73d9832b-e617-4a2d-b478-63540e869202"
+      ios-update-permalink: "https://expo.dev/projects/53171ba4-60ca-40cb-b3e6-b0c2393677b8/updates/019bdd88-1a82-7405-ae11-acb3d38c163e"
+      ios-branch: "DEV-1936/block-on-e2e"
+      ios-update-runtime-version: "84c9efb850e71475bdf5ca9270cca37229321e21"
+      ios-update-commit: "6a698e1d6afb8f5c63d09e467595f9dd96fc9735"
+      ios-update-qr-url: "https://qr.expo.dev/eas-update?appScheme=betterangels&projectId=53171ba4-60ca-40cb-b3e6-b0c2393677b8&groupId=73d9832b-e617-4a2d-b478-63540e869202"
+      simulator-ios-build-link: "https://expo.dev/accounts/better-angels/projects/betterangels/builds/0626f53b-99cd-4e2b-972a-a7fe9e82d6eb"
+
+      # project: ${{ matrix.project }}
+      # project-id: ${{ steps.preview-build.outputs.project-id }}
+      # slug: ${{ steps.preview-build.outputs.slug }}
+      # android-runtime-version: ${{ steps.preview-build.outputs.android-runtime-version }}
+      # ios-runtime-version: ${{ steps.preview-build.outputs.ios-runtime-version }}
+      # android-build-link: ${{ steps.preview-build.outputs.android-build-link }}
+      # ios-build-link: ${{ steps.preview-build.outputs.ios-build-link }}
+      # android-distribution: ${{ steps.preview-build.outputs.android-distribution }}
+      # android-build-profile: ${{ steps.preview-build.outputs.android-build-profile }}
+      # android-app-version: ${{ steps.preview-build.outputs.android-app-version }}
+      # android-git-commit: ${{ steps.preview-build.outputs.android-git-commit }}
+      # ios-distribution: ${{ steps.preview-build.outputs.ios-distribution }}
+      # ios-build-profile: ${{ steps.preview-build.outputs.ios-build-profile }}
+      # ios-app-version: ${{ steps.preview-build.outputs.ios-app-version }}
+      # ios-git-commit: ${{ steps.preview-build.outputs.ios-git-commit }}
+      # android-update-permalink: ${{ steps.expo-update.outputs.android-update-permalink }}
+      # android-branch: ${{ steps.expo-update.outputs.android-branch }}
+      # android-update-runtime-version: ${{ steps.expo-update.outputs.android-runtime-version }}
+      # android-update-commit: ${{ steps.expo-update.outputs.android-update-commit }}
+      # android-update-qr-url: ${{ steps.expo-update.outputs.android-update-qr-url }}
+      # ios-update-permalink: ${{ steps.expo-update.outputs.ios-update-permalink }}
+      # ios-branch: ${{ steps.expo-update.outputs.ios-branch }}
+      # ios-update-runtime-version: ${{ steps.expo-update.outputs.ios-runtime-version }}
+      # ios-update-commit: ${{ steps.expo-update.outputs.ios-update-commit }}
+      # ios-update-qr-url: ${{ steps.expo-update.outputs.ios-update-qr-url }}
+      # simulator-ios-build-link: ${{ steps.simulator-build.outputs.ios-build-link }}
 
   preview-post-e2e:
     environment: preview

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -200,7 +200,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
-          GITHUB_DISPATCH_TOKEN: ${{ secrets.GITHUB_DISPATCH_APP_TOKEN }}
+          GITHUB_DISPATCH_TOKEN: ${{ secrets.EXPO_REPO_DISPATCH_TOKEN }}
           PROJECT_NAME: ${{ matrix.project }}
           WEBHOOK_PAYLOAD: ${{ steps.prepare-webhook.outputs.payload }}
         run: |
@@ -243,7 +243,7 @@ jobs:
   preview-post-e2e:
     environment: preview
     env:
-      BRANCH_NAME: ${{ github.event.client_payload.branch_name || github.head_ref || github.ref_name }}
+      BRANCH_NAME: ${{ github.event.client_payload['branch-name'] || github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
     if: github.event_name == 'repository_dispatch' && github.event.action == 'e2e-tests-complete'
     permissions:
@@ -261,32 +261,32 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          ref: ${{ github.event.client_payload.github-sha || github.event.client_payload.github-ref || github.ref }}
+          ref: ${{ github.event.client_payload['github-sha'] || github.event.client_payload['github-ref'] || github.ref }}
 
       - name: 📝 Comment on PR
-        if: github.event.client_payload.pr-number != ''
+        if: github.event.client_payload['pr-number'] != ''
         uses: edumserrano/find-create-or-update-comment@v3
         with:
-          issue-number: ${{ github.event.client_payload.pr-number }}
-          body-includes: '<!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload.project-id }} -->'
+          issue-number: ${{ github.event.client_payload['pr-number'] }}
+          body-includes: '<!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload[''project-id''] }} -->'
           comment-author: 'github-actions[bot]'
           body: |
-            <!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload.project-id }} -->
-            🚀 Expo continuous deployment is ready for **${{ github.event.client_payload.project }}**!
+            <!-- continuous-deploy-fingerprint-projectId:${{ github.event.client_payload['project-id'] }} -->
+            🚀 Expo continuous deployment is ready for **${{ github.event.client_payload['project'] }}**!
 
-            - Project → **${{ github.event.client_payload.project }}**
+            - Project → **${{ github.event.client_payload['project'] }}**
             - Environment → **Preview**
             - Platforms → **android**, **ios**
-            - Scheme → **${{ github.event.client_payload.slug }}**
+            - Scheme → **${{ github.event.client_payload['slug'] }}**
 
             &nbsp; | 🤖 Android | 🍎 iOS
             --- | --- | ---
-            Runtime Version | `${{ github.event.client_payload.android-runtime-version }}` | `${{ github.event.client_payload.ios-runtime-version }}`
-            Build Details | [Build Permalink](${{ github.event.client_payload.android-build-link }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload.android-distribution }}`<br />Build profile: `${{ github.event.client_payload.android-build-profile }}`<br />Runtime version: `${{ github.event.client_payload.android-runtime-version }}`<br />App version: `${{ github.event.client_payload.android-app-version }}`<br />Git commit: `${{ github.event.client_payload.android-git-commit }}`</details> | [Build Permalink](${{ github.event.client_payload.ios-build-link }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload.ios-distribution }}`<br />Build profile: `${{ github.event.client_payload.ios-build-profile }}`<br />Runtime version: `${{ github.event.client_payload.ios-runtime-version }}`<br />App version: `${{ github.event.client_payload.ios-app-version }}`<br />Git commit: `${{ github.event.client_payload.ios-git-commit }}`</details>
-            Update Details | [Update Permalink](${{ github.event.client_payload.android-update-permalink }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload.android-branch }}`<br />Runtime version: `${{ github.event.client_payload.android-update-runtime-version }}`<br />Git commit: `${{ github.event.client_payload.android-update-commit }}`</details> | [Update Permalink](${{ github.event.client_payload.ios-update-permalink }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload.ios-branch }}`<br />Runtime version: `${{ github.event.client_payload.ios-update-runtime-version }}`<br />Git commit: `${{ github.event.client_payload.ios-update-commit }}`</details>
-            Update QR   | <a href="${{ github.event.client_payload.android-update-qr-url }}"><img src="${{ github.event.client_payload.android-update-qr-url }}" width="250px" height="250px" /></a> | <a href="${{ github.event.client_payload.ios-update-qr-url }}"><img src="${{ github.event.client_payload.ios-update-qr-url }}" width="250px" height="250px" /></a>
+            Runtime Version | `${{ github.event.client_payload['android-runtime-version'] }}` | `${{ github.event.client_payload['ios-runtime-version'] }}`
+            Build Details | [Build Permalink](${{ github.event.client_payload['android-build-link'] }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload['android-distribution'] }}`<br />Build profile: `${{ github.event.client_payload['android-build-profile'] }}`<br />Runtime version: `${{ github.event.client_payload['android-runtime-version'] }}`<br />App version: `${{ github.event.client_payload['android-app-version'] }}`<br />Git commit: `${{ github.event.client_payload['android-git-commit'] }}`</details> | [Build Permalink](${{ github.event.client_payload['ios-build-link'] }})<br /><details><summary>Details</summary>Distribution: `${{ github.event.client_payload['ios-distribution'] }}`<br />Build profile: `${{ github.event.client_payload['ios-build-profile'] }}`<br />Runtime version: `${{ github.event.client_payload['ios-runtime-version'] }}`<br />App version: `${{ github.event.client_payload['ios-app-version'] }}`<br />Git commit: `${{ github.event.client_payload['ios-git-commit'] }}`</details>
+            Update Details | [Update Permalink](${{ github.event.client_payload['android-update-permalink'] }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload['android-branch'] }}`<br />Runtime version: `${{ github.event.client_payload['android-update-runtime-version'] }}`<br />Git commit: `${{ github.event.client_payload['android-update-commit'] }}`</details> | [Update Permalink](${{ github.event.client_payload['ios-update-permalink'] }})<br /><details><summary>Details</summary>Branch: `${{ github.event.client_payload['ios-branch'] }}`<br />Runtime version: `${{ github.event.client_payload['ios-update-runtime-version'] }}`<br />Git commit: `${{ github.event.client_payload['ios-update-commit'] }}`</details>
+            Update QR   | <a href="${{ github.event.client_payload['android-update-qr-url'] }}"><img src="${{ github.event.client_payload['android-update-qr-url'] }}" width="250px" height="250px" /></a> | <a href="${{ github.event.client_payload['ios-update-qr-url'] }}"><img src="${{ github.event.client_payload['ios-update-qr-url'] }}" width="250px" height="250px" /></a>
 
-            **iOS Simulator Build:** [Simulator Build Link](${{ github.event.client_payload.simulator-ios-build-link }})
+            **iOS Simulator Build:** [Simulator Build Link](${{ github.event.client_payload['simulator-ios-build-link'] }})
           edit-mode: replace
 
       - name: 📝 Set Git Variables
@@ -301,7 +301,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: 📣 Post to Slack
-        if: github.event.client_payload.github-ref == 'refs/heads/main'
+        if: github.event.client_payload['github-ref'] == 'refs/heads/main'
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
@@ -312,14 +312,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*New code has landed in main for project ${{ github.event.client_payload.project }}!* \n*Commit:* `${{ steps.set-git-vars.outputs.commit-id }}`\n*Message:* ${{ steps.set-git-vars.outputs.commit-message }}"
+                    "text": "*New code has landed in main for project ${{ github.event.client_payload['project'] }}!* \n*Commit:* `${{ steps.set-git-vars.outputs.commit-id }}`\n*Message:* ${{ steps.set-git-vars.outputs.commit-message }}"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*📱 iOS*\n\n<${{ github.event.client_payload.ios-update-qr-url }}|Update>\n<${{ github.event.client_payload.ios-build-link }}|Build>\n<${{ github.event.client_payload.simulator-ios-build-link }}|Simulator Build>"
+                    "text": "*📱 iOS*\n\n<${{ github.event.client_payload['ios-update-qr-url'] }}|Update>\n<${{ github.event.client_payload['ios-build-link'] }}|Build>\n<${{ github.event.client_payload['simulator-ios-build-link'] }}|Simulator Build>"
                   }
                 },
                 {
@@ -329,7 +329,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*🤖 Android*\n\n<${{ github.event.client_payload.android-update-qr-url }}|Update>\n<${{ github.event.client_payload.android-build-link }}|Build>"
+                    "text": "*🤖 Android*\n\n<${{ github.event.client_payload['android-update-qr-url'] }}|Update>\n<${{ github.event.client_payload['android-build-link'] }}|Build>"
                   }
                 }
               ]
@@ -342,7 +342,7 @@ jobs:
         if: always()
         run: |
           rm -f .env
-        working-directory: apps/${{ github.event.client_payload.project }}
+        working-directory: apps/${{ github.event.client_payload['project'] }}
 
   production:
     if: |

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -245,7 +245,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.event.client_payload['branch-name'] || github.head_ref || github.ref_name }}
     runs-on: ubuntu-latest
-    if: github.event_name == 'repository_dispatch' && github.event.action == 'e2e-tests-complete'
+    if: github.event_name == 'repository_dispatch'
     permissions:
       pull-requests: write # REQUIRED: Allow comments on PRs
       contents: read # Required for actions/checkout

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -60,9 +60,10 @@ jobs:
         env:
           ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
           IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+
+          WORK_DIR="/home/expo/workingdir/temporary-custom-build/apps/betterangels"
 
           if [ -z "${GITHUB_DISPATCH_TOKEN:-}" ]; then
             echo "Missing GITHUB_DISPATCH_TOKEN"
@@ -74,10 +75,14 @@ jobs:
             exit 1
           fi
 
-          if [ -z "${WEBHOOK_PAYLOAD:-}" ]; then
-            echo "Missing WEBHOOK_PAYLOAD (expected JSON string)"
+          WEBHOOK_PAYLOAD_B64="$(grep '^WEBHOOK_PAYLOAD_B64=' ${WORK_DIR}/.env | cut -d '=' -f2- || true)"
+          if [ -z "${WEBHOOK_PAYLOAD_B64:-}" ]; then
+            echo "Missing WEBHOOK_PAYLOAD_B64 in ${WORK_DIR}/.env"
             exit 1
           fi
+
+          WEBHOOK_PAYLOAD="$(printf '%s' "$WEBHOOK_PAYLOAD_B64" | base64 -d)"
+          export WEBHOOK_PAYLOAD
 
           BODY="$(python3 - <<'PY'
           import json, os

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -60,6 +60,8 @@ jobs:
         env:
           ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
           IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
+          GITHUB_DISPATCH_TOKEN: ${{ secrets.GITHUB_DISPATCH_TOKEN }}
+          GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
         run: |
           set -euo pipefail
 

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -117,11 +117,15 @@ jobs:
           payload["ios-e2e-status"] = ios_status
 
           print(json.dumps({
-            "event_type": "e2e-tests-complete",
+            "event_type": "eas_post_e2e",
             "client_payload": payload
           }))
           PY
           )"
+
+          echo "BODY: ${BODY}"
+          echo "WEBHOOK_PAYLOAD: ${WEBHOOK_PAYLOAD}"
+          echo "ANDROID_E2E_STATUS: ${ANDROID_E2E_STATUS}"
 
           curl -fsSL \
             -X POST \

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -53,54 +53,55 @@ jobs:
       build_id: ${{ needs.get_ios_build.outputs.build_id }}
       flow_path: ['.maestro/landing.yml']
 
-  github_dispatch:
-    needs: [maestro_android_test, maestro_ios_test]
-    steps:
-      - id: dispatch
-        env:
-          ANDROID_E2E_RESULT: ${{ needs.maestro_android_test.result }}
-          IOS_E2E_RESULT: ${{ needs.maestro_ios_test.result }}
-        run: |
-          set -euo pipefail
+github_dispatch:
+  after: [maestro_android_test, maestro_ios_test]
+  steps:
+    - id: dispatch
+      env:
+        ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
+        IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        set -euo pipefail
 
-          if [ -z "${GITHUB_DISPATCH_TOKEN:-}" ]; then
-            echo "Missing GITHUB_DISPATCH_TOKEN"
-            exit 1
-          fi
+        if [ -z "${GITHUB_DISPATCH_TOKEN:-}" ]; then
+          echo "Missing GITHUB_DISPATCH_TOKEN"
+          exit 1
+        fi
 
-          if [ -z "${GITHUB_REPOSITORY:-}" ]; then
-            echo "Missing GITHUB_REPOSITORY (expected format: owner/repo)"
-            exit 1
-          fi
+        if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+          echo "Missing GITHUB_REPOSITORY (expected format: owner/repo)"
+          exit 1
+        fi
 
-          if [ -z "${WEBHOOK_PAYLOAD:-}" ]; then
-            echo "Missing WEBHOOK_PAYLOAD (expected JSON string)"
-            exit 1
-          fi
+        if [ -z "${WEBHOOK_PAYLOAD:-}" ]; then
+          echo "Missing WEBHOOK_PAYLOAD (expected JSON string)"
+          exit 1
+        fi
 
-          BODY="$(python3 - <<'PY'
-          import json, os
+        BODY="$(python3 - <<'PY'
+        import json, os
 
-          payload = json.loads(os.environ["WEBHOOK_PAYLOAD"])
-          android_result = os.environ.get("ANDROID_E2E_RESULT", "")
-          ios_result = os.environ.get("IOS_E2E_RESULT", "")
+        payload = json.loads(os.environ["WEBHOOK_PAYLOAD"])
+        android_status = os.environ.get("ANDROID_E2E_STATUS", "")
+        ios_status = os.environ.get("IOS_E2E_STATUS", "")
 
-          status = "success" if android_result == "success" and ios_result == "success" else "failure"
-          payload["status"] = status
-          payload["android-e2e-result"] = android_result
-          payload["ios-e2e-result"] = ios_result
+        status = "success" if android_status == "success" and ios_status == "success" else "failure"
+        payload["status"] = status
+        payload["android-e2e-status"] = android_status
+        payload["ios-e2e-status"] = ios_status
 
-          print(json.dumps({
-            "event_type": "e2e-tests-complete",
-            "client_payload": payload
-          }))
-          PY
-          )"
+        print(json.dumps({
+          "event_type": "e2e-tests-complete",
+          "client_payload": payload
+        }))
+        PY
+        )"
 
-          curl -fsSL \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GITHUB_DISPATCH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches" \
-            -d "${BODY}"
+        curl -fsSL \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${GITHUB_DISPATCH_TOKEN}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches" \
+          -d "${BODY}"

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -53,55 +53,55 @@ jobs:
       build_id: ${{ needs.get_ios_build.outputs.build_id }}
       flow_path: ['.maestro/landing.yml']
 
-github_dispatch:
-  after: [maestro_android_test, maestro_ios_test]
-  steps:
-    - id: dispatch
-      env:
-        ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
-        IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-      run: |
-        set -euo pipefail
+  github_dispatch:
+    after: [maestro_android_test, maestro_ios_test]
+    steps:
+      - id: dispatch
+        env:
+          ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
+          IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-        if [ -z "${GITHUB_DISPATCH_TOKEN:-}" ]; then
-          echo "Missing GITHUB_DISPATCH_TOKEN"
-          exit 1
-        fi
+          if [ -z "${GITHUB_DISPATCH_TOKEN:-}" ]; then
+            echo "Missing GITHUB_DISPATCH_TOKEN"
+            exit 1
+          fi
 
-        if [ -z "${GITHUB_REPOSITORY:-}" ]; then
-          echo "Missing GITHUB_REPOSITORY (expected format: owner/repo)"
-          exit 1
-        fi
+          if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+            echo "Missing GITHUB_REPOSITORY (expected format: owner/repo)"
+            exit 1
+          fi
 
-        if [ -z "${WEBHOOK_PAYLOAD:-}" ]; then
-          echo "Missing WEBHOOK_PAYLOAD (expected JSON string)"
-          exit 1
-        fi
+          if [ -z "${WEBHOOK_PAYLOAD:-}" ]; then
+            echo "Missing WEBHOOK_PAYLOAD (expected JSON string)"
+            exit 1
+          fi
 
-        BODY="$(python3 - <<'PY'
-        import json, os
+          BODY="$(python3 - <<'PY'
+          import json, os
 
-        payload = json.loads(os.environ["WEBHOOK_PAYLOAD"])
-        android_status = os.environ.get("ANDROID_E2E_STATUS", "")
-        ios_status = os.environ.get("IOS_E2E_STATUS", "")
+          payload = json.loads(os.environ["WEBHOOK_PAYLOAD"])
+          android_status = os.environ.get("ANDROID_E2E_STATUS", "")
+          ios_status = os.environ.get("IOS_E2E_STATUS", "")
 
-        status = "success" if android_status == "success" and ios_status == "success" else "failure"
-        payload["status"] = status
-        payload["android-e2e-status"] = android_status
-        payload["ios-e2e-status"] = ios_status
+          status = "success" if android_status == "success" and ios_status == "success" else "failure"
+          payload["status"] = status
+          payload["android-e2e-status"] = android_status
+          payload["ios-e2e-status"] = ios_status
 
-        print(json.dumps({
-          "event_type": "e2e-tests-complete",
-          "client_payload": payload
-        }))
-        PY
-        )"
+          print(json.dumps({
+            "event_type": "e2e-tests-complete",
+            "client_payload": payload
+          }))
+          PY
+          )"
 
-        curl -fsSL \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${GITHUB_DISPATCH_TOKEN}" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          "https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches" \
-          -d "${BODY}"
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -d "${BODY}"

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -53,9 +53,56 @@ jobs:
       build_id: ${{ needs.get_ios_build.outputs.build_id }}
       flow_path: ['.maestro/landing.yml']
 
-  call_webhook:
+  github_dispatch:
     needs: [maestro_android_test, maestro_ios_test]
-    type: call-webhook
-    params:
-      webhook_url: ${{ secrets.WEBHOOK_URL }}
-      payload: ${{ steps.prepare-webhook.outputs.payload }}
+    if: ${{ always() }}
+    steps:
+      - id: dispatch
+        env:
+          GITHUB_DISPATCH_TOKEN: ${{ secrets.GITHUB_DISPATCH_TOKEN }}
+          ANDROID_E2E_RESULT: ${{ needs.maestro_android_test.result }}
+          IOS_E2E_RESULT: ${{ needs.maestro_ios_test.result }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GITHUB_DISPATCH_TOKEN:-}" ]; then
+            echo "Missing GITHUB_DISPATCH_TOKEN"
+            exit 1
+          fi
+
+          if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+            echo "Missing GITHUB_REPOSITORY (expected format: owner/repo)"
+            exit 1
+          fi
+
+          if [ -z "${WEBHOOK_PAYLOAD:-}" ]; then
+            echo "Missing WEBHOOK_PAYLOAD (expected JSON string)"
+            exit 1
+          fi
+
+          BODY="$(python3 - <<'PY'
+          import json, os
+
+          payload = json.loads(os.environ["WEBHOOK_PAYLOAD"])
+          android_result = os.environ.get("ANDROID_E2E_RESULT", "")
+          ios_result = os.environ.get("IOS_E2E_RESULT", "")
+
+          status = "success" if android_result == "success" and ios_result == "success" else "failure"
+          payload["status"] = status
+          payload["android-e2e-result"] = android_result
+          payload["ios-e2e-result"] = ios_result
+
+          print(json.dumps({
+            "event_type": "e2e-tests-complete",
+            "client_payload": payload
+          }))
+          PY
+          )"
+
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_DISPATCH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -d "${BODY}"

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -59,7 +59,6 @@ jobs:
     steps:
       - id: dispatch
         env:
-          GITHUB_DISPATCH_TOKEN: ${{ secrets.GITHUB_DISPATCH_TOKEN }}
           ANDROID_E2E_RESULT: ${{ needs.maestro_android_test.result }}
           IOS_E2E_RESULT: ${{ needs.maestro_ios_test.result }}
         run: |

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -121,14 +121,12 @@ jobs:
           PY
           )"
 
-          echo "BODY: ${BODY}"
           echo "WEBHOOK_PAYLOAD: ${WEBHOOK_PAYLOAD}"
-          echo "ANDROID_E2E_STATUS: ${ANDROID_E2E_STATUS}"
+          echo "BODY: ${BODY}"
 
           curl -fsSL \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GITHUB_DISPATCH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/dispatches" \
             -d "${BODY}"

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -64,11 +64,11 @@ jobs:
     after: [dummy_test]
     steps:
       - id: dispatch
-        env:
-          ANDROID_E2E_STATUS: ${{ after.dummy_test.status }}
-          IOS_E2E_STATUS: ${{ after.dummy_test.status }}
-          # ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
-          # IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
+        # env:
+        #   ANDROID_E2E_STATUS: ${{ after.dummy_test.status }}
+        #   IOS_E2E_STATUS: ${{ after.dummy_test.status }}
+        #   # ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
+        #   # IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
         run: |
           set -euo pipefail
 
@@ -113,8 +113,6 @@ jobs:
 
           status = "success" if android_status == "success" and ios_status == "success" else "failure"
           payload["status"] = status
-          payload["android-e2e-status"] = android_status
-          payload["ios-e2e-status"] = ios_status
 
           print(json.dumps({
             "event_type": "eas_post_e2e",

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -17,59 +17,77 @@ jobs:
           set-output project_id "$PROJECT_ID"
           set-output runtime_version "$RUNTIME_VERSION"
 
-  get_android_build:
+  # get_android_build:
+  #   needs: [get_vars]
+  #   type: get-build
+  #   params:
+  #     runtime_version: ${{ needs.get_vars.outputs.runtime_version }}
+  #     platform: android
+
+  # get_ios_build:
+  #   needs: [get_vars]
+  #   type: get-build
+  #   params:
+  #     runtime_version: ${{ needs.get_vars.outputs.runtime_version }}
+  #     platform: ios
+
+  # maestro_android_test:
+  #   needs: [get_vars, get_android_build]
+  #   type: maestro
+  #   env:
+  #     MAESTRO_PLATFORM: android
+  #     MAESTRO_GROUP_ID: ${{ needs.get_vars.outputs.group_id }}
+  #     MAESTRO_PROJECT_ID: ${{ needs.get_vars.outputs.project_id }}
+  #   params:
+  #     build_id: ${{ needs.get_android_build.outputs.build_id }}
+  #     flow_path: ['.maestro/landing.yml']
+
+  # maestro_ios_test:
+  #   needs: [get_vars, get_ios_build]
+  #   type: maestro
+  #   env:
+  #     MAESTRO_PLATFORM: ios
+  #     MAESTRO_GROUP_ID: ${{ needs.get_vars.outputs.group_id }}
+  #     MAESTRO_PROJECT_ID: ${{ needs.get_vars.outputs.project_id }}
+  #   params:
+  #     build_id: ${{ needs.get_ios_build.outputs.build_id }}
+  #     flow_path: ['.maestro/landing.yml']
+  dummy_test:
     needs: [get_vars]
-    type: get-build
-    params:
-      runtime_version: ${{ needs.get_vars.outputs.runtime_version }}
-      platform: android
-
-  get_ios_build:
-    needs: [get_vars]
-    type: get-build
-    params:
-      runtime_version: ${{ needs.get_vars.outputs.runtime_version }}
-      platform: ios
-
-  maestro_android_test:
-    needs: [get_vars, get_android_build]
-    type: maestro
-    env:
-      MAESTRO_PLATFORM: android
-      MAESTRO_GROUP_ID: ${{ needs.get_vars.outputs.group_id }}
-      MAESTRO_PROJECT_ID: ${{ needs.get_vars.outputs.project_id }}
-    params:
-      build_id: ${{ needs.get_android_build.outputs.build_id }}
-      flow_path: ['.maestro/landing.yml']
-
-  maestro_ios_test:
-    needs: [get_vars, get_ios_build]
-    type: maestro
-    env:
-      MAESTRO_PLATFORM: ios
-      MAESTRO_GROUP_ID: ${{ needs.get_vars.outputs.group_id }}
-      MAESTRO_PROJECT_ID: ${{ needs.get_vars.outputs.project_id }}
-    params:
-      build_id: ${{ needs.get_ios_build.outputs.build_id }}
-      flow_path: ['.maestro/landing.yml']
-
+    steps:
+      - id: dummy_test
+        run: |
+          echo "Dummy test"
+          echo ""
   github_dispatch:
-    after: [maestro_android_test, maestro_ios_test]
+    # after: [maestro_android_test, maestro_ios_test]
+    after: [dummy_test]
     steps:
       - id: dispatch
         env:
-          ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
-          IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
-          GITHUB_DISPATCH_TOKEN: ${{ secrets.GITHUB_DISPATCH_TOKEN }}
-          GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+          ANDROID_E2E_STATUS: ${{ after.dummy_test.status }}
+          IOS_E2E_STATUS: ${{ after.dummy_test.status }}
+          # ANDROID_E2E_STATUS: ${{ after.maestro_android_test.status }}
+          # IOS_E2E_STATUS: ${{ after.maestro_ios_test.status }}
         run: |
           set -euo pipefail
 
           WORK_DIR="/home/expo/workingdir/temporary-custom-build/apps/betterangels"
+          echo "~~~~~~~~~~~~~~~~~~~~~~~~GITHUB_REPOSITORY: ${GITHUB_REPOSITORY}"
+          if [ -n "${GITHUB_DISPATCH_TOKEN:-}" ]; then
+            echo "~~~~~~~~~~~~~~~~~~~~~~~~GITHUB_DISPATCH_TOKEN (first 3 chars): ${GITHUB_DISPATCH_TOKEN:0:3}"
+          else
+            echo "~~~~~~~~~~~~~~~~~~~~~~~~GITHUB_DISPATCH_TOKEN is not set"
+          fi
 
           if [ -z "${GITHUB_DISPATCH_TOKEN:-}" ]; then
             echo "Missing GITHUB_DISPATCH_TOKEN"
             exit 1
+          fi
+
+          if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+            # This one is safe to store in .env as plaintext.
+            GITHUB_REPOSITORY="$(grep '^GITHUB_REPOSITORY=' ${WORK_DIR}/.env | cut -d '=' -f2- || true)"
           fi
 
           if [ -z "${GITHUB_REPOSITORY:-}" ]; then

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -52,3 +52,10 @@ jobs:
     params:
       build_id: ${{ needs.get_ios_build.outputs.build_id }}
       flow_path: ['.maestro/landing.yml']
+
+  call_webhook:
+    needs: [maestro_android_test, maestro_ios_test]
+    type: call-webhook
+    params:
+      webhook_url: ${{ secrets.WEBHOOK_URL }}
+      payload: ${{ steps.prepare-webhook.outputs.payload }}

--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -55,7 +55,6 @@ jobs:
 
   github_dispatch:
     needs: [maestro_android_test, maestro_ios_test]
-    if: ${{ always() }}
     steps:
       - id: dispatch
         env:


### PR DESCRIPTION
DEV-1936

## Summary by Sourcery

Integrate E2E test completion signals into the CI workflow and gate preview/notifications on their results.

Enhancements:
- Add structured webhook payload preparation in the preview job so downstream workflows and notifications can consume consistent build and update metadata.
- Ensure temporary environment files in app directories are always cleaned up after E2E-related steps complete.

CI:
- Trigger the main EAS workflow via a repository_dispatch event when E2E tests complete, including detailed preview metadata and test status in the payload.
- Add a post-E2E preview job that fails the workflow if E2E tests fail, updates the PR comment with build/update details from the dispatch payload, and sends Slack notifications based on the dispatched context.
- Extend the EAS e2e-test workflow to always send a GitHub repository_dispatch event back to the repo with aggregated Android/iOS E2E results and associated build metadata.