### PR TITLE
Filter by Photo Count

### DIFF
--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -18,8 +18,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.files.base import ContentFile
 from django.db import models, transaction
-from django.db.models import Count, F, OuterRef, QuerySet, Subquery
-from django.db.models.functions import Cast, JSONObject
+from django.db.models import Count, F, OuterRef, QuerySet, Subquery, Value
+from django.db.models.functions import Cast, Coalesce, JSONObject
 from django.forms import BaseFormSet, TimeInput
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import redirect
@@ -821,7 +821,7 @@ class PhotoCountFilter(admin.ListFilter):
     def __init__(
         self,
         request: HttpRequest,
-        params: dict[str, list[str]],
+        params: dict[str, Any],
         model: type[models.Model],
         model_admin: admin.ModelAdmin,
     ) -> None:
@@ -833,7 +833,7 @@ class PhotoCountFilter(admin.ListFilter):
 
     def choices(self, changelist: Any) -> Iterator[dict[str, Any]]:  # type: ignore[override]
         fields = []
-        for (min_p, max_p), (_, label) in zip(self.PARAMS, self.FILTER_FIELDS):
+        for (min_p, max_p), (_field, label) in zip(self.PARAMS, self.FILTER_FIELDS):
             fields.append(
                 {
                     "label": label,
@@ -852,7 +852,7 @@ class PhotoCountFilter(admin.ListFilter):
         return True
 
     def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
-        for (min_p, max_p), (count_field, _) in zip(self.PARAMS, self.FILTER_FIELDS):
+        for (min_p, max_p), (count_field, _label) in zip(self.PARAMS, self.FILTER_FIELDS):
             min_val = self.used_parameters.get(min_p)
             max_val = self.used_parameters.get(max_p)
             if min_val is not None and min_val != "":
@@ -1129,13 +1129,16 @@ class ShelterAdmin(ImportExportModelAdmin):
             )
         )
 
+        interior_count = InteriorPhoto.objects.filter(shelter=OuterRef("pk")).order_by().values("shelter").annotate(c=Count("*")).values("c")
+        exterior_count = ExteriorPhoto.objects.filter(shelter=OuterRef("pk")).order_by().values("shelter").annotate(c=Count("*")).values("c")
+
         return qs.annotate(
             last_event=Subquery(
                 scoped_events.filter(pgh_obj_id=Cast(OuterRef("pk"), output_field=models.TextField())).values("obj")[:1]
             ),
-            interior_photo_count=Count("interior_photos", distinct=True),
-            exterior_photo_count=Count("exterior_photos", distinct=True),
-            total_photo_count=Count("interior_photos", distinct=True) + Count("exterior_photos", distinct=True),
+            interior_photo_count=Coalesce(Subquery(interior_count), Value(0)),
+            exterior_photo_count=Coalesce(Subquery(exterior_count), Value(0)),
+            total_photo_count=Coalesce(Subquery(interior_count), Value(0)) + Coalesce(Subquery(exterior_count), Value(0)),
         )
 
     def save_related(

--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections.abc import Iterator
 from typing import Any, Optional, Tuple, Type, TypeVar, Union, cast
 from urllib.parse import quote
 
@@ -17,7 +18,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.files.base import ContentFile
 from django.db import models, transaction
-from django.db.models import F, OuterRef, QuerySet, Subquery
+from django.db.models import Count, F, OuterRef, QuerySet, Subquery
 from django.db.models.functions import Cast, JSONObject
 from django.forms import BaseFormSet, TimeInput
 from django.http import HttpRequest, HttpResponseRedirect
@@ -800,6 +801,73 @@ class ShelterResource(resources.ModelResource):
         return bool(super().skip_row(instance, original, row, import_validation_errors))
 
 
+class PhotoCountFilter(admin.ListFilter):
+    """Combined filter for interior, exterior, and total photo counts with free-form min/max inputs."""
+
+    title = "photo counts"
+    template = "admin/photo_count_filter.html"
+
+    PARAMS = (
+        ("interior_min", "interior_max"),
+        ("exterior_min", "exterior_max"),
+        ("total_min", "total_max"),
+    )
+    FILTER_FIELDS = (
+        ("interior_photo_count", "Interior"),
+        ("exterior_photo_count", "Exterior"),
+        ("total_photo_count", "Total"),
+    )
+
+    def __init__(
+        self,
+        request: HttpRequest,
+        params: dict[str, list[str]],
+        model: type[models.Model],
+        model_admin: admin.ModelAdmin,
+    ) -> None:
+        super().__init__(request, params, model, model_admin)
+        for param in self.expected_parameters():
+            if param in params:
+                value_list = params.pop(param)
+                self.used_parameters[param] = value_list[-1] if value_list else ""  # type: ignore[assignment]
+
+    def choices(self, changelist: Any) -> Iterator[dict[str, Any]]:  # type: ignore[override]
+        fields = []
+        for (min_p, max_p), (_, label) in zip(self.PARAMS, self.FILTER_FIELDS):
+            fields.append(
+                {
+                    "label": label,
+                    "min_param": min_p,
+                    "max_param": max_p,
+                    "min_value": self.used_parameters.get(min_p, ""),
+                    "max_value": self.used_parameters.get(max_p, ""),
+                }
+            )
+        yield {"fields": fields, "all_params": set(self.expected_parameters())}
+
+    def expected_parameters(self) -> list[str | None]:
+        return [p for pair in self.PARAMS for p in pair]
+
+    def has_output(self) -> bool:
+        return True
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
+        for (min_p, max_p), (count_field, _) in zip(self.PARAMS, self.FILTER_FIELDS):
+            min_val = self.used_parameters.get(min_p)
+            max_val = self.used_parameters.get(max_p)
+            if min_val is not None and min_val != "":
+                try:
+                    queryset = queryset.filter(**{f"{count_field}__gte": int(str(min_val))})
+                except (ValueError, TypeError):
+                    pass
+            if max_val is not None and max_val != "":
+                try:
+                    queryset = queryset.filter(**{f"{count_field}__lte": int(str(max_val))})
+                except (ValueError, TypeError):
+                    pass
+        return queryset
+
+
 @admin.register(Shelter)
 class ShelterAdmin(ImportExportModelAdmin):
     form = ShelterForm
@@ -940,6 +1008,9 @@ class ShelterAdmin(ImportExportModelAdmin):
         "website",
         "total_beds",
         "max_stay",
+        "interior_photo_count",
+        "exterior_photo_count",
+        "total_photo_count",
         "status",
         "declined_ba_visit",
         "updated_at",
@@ -977,6 +1048,8 @@ class ShelterAdmin(ImportExportModelAdmin):
         "overall_rating",
         # Better Angels Administration
         "status",
+        # Photo Counts
+        PhotoCountFilter,
     )
     search_fields = ("name", "organization__name", "description", "subjective_review")
     resource_class = ShelterResource
@@ -1059,7 +1132,10 @@ class ShelterAdmin(ImportExportModelAdmin):
         return qs.annotate(
             last_event=Subquery(
                 scoped_events.filter(pgh_obj_id=Cast(OuterRef("pk"), output_field=models.TextField())).values("obj")[:1]
-            )
+            ),
+            interior_photo_count=Count("interior_photos", distinct=True),
+            exterior_photo_count=Count("exterior_photos", distinct=True),
+            total_photo_count=Count("interior_photos", distinct=True) + Count("exterior_photos", distinct=True),
         )
 
     def save_related(
@@ -1096,6 +1172,18 @@ class ShelterAdmin(ImportExportModelAdmin):
             return mark_safe(f'<img src="{url}" style="max-height: 200px;" />')
 
         return "No hero image selected"
+
+    @admin.display(ordering="interior_photo_count", description="Interior Photos")
+    def interior_photo_count(self, obj: Shelter) -> int:
+        return getattr(obj, "interior_photo_count", 0)
+
+    @admin.display(ordering="exterior_photo_count", description="Exterior Photos")
+    def exterior_photo_count(self, obj: Shelter) -> int:
+        return getattr(obj, "exterior_photo_count", 0)
+
+    @admin.display(ordering="total_photo_count", description="Total Photos")
+    def total_photo_count(self, obj: Shelter) -> int:
+        return getattr(obj, "total_photo_count", 0)
 
     def updated_by(self, obj: Shelter) -> str:
         data = getattr(obj, "last_event", None) or {}

--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -1129,16 +1129,28 @@ class ShelterAdmin(ImportExportModelAdmin):
             )
         )
 
-        interior_count = InteriorPhoto.objects.filter(shelter=OuterRef("pk")).order_by().values("shelter").annotate(c=Count("*")).values("c")
-        exterior_count = ExteriorPhoto.objects.filter(shelter=OuterRef("pk")).order_by().values("shelter").annotate(c=Count("*")).values("c")
+        interior_count = Subquery(
+            InteriorPhoto.objects.filter(shelter=OuterRef("pk"))
+            .order_by()
+            .values("shelter")
+            .annotate(c=Count("pk"))
+            .values("c")
+        )
+        exterior_count = Subquery(
+            ExteriorPhoto.objects.filter(shelter=OuterRef("pk"))
+            .order_by()
+            .values("shelter")
+            .annotate(c=Count("pk"))
+            .values("c")
+        )
 
         return qs.annotate(
             last_event=Subquery(
                 scoped_events.filter(pgh_obj_id=Cast(OuterRef("pk"), output_field=models.TextField())).values("obj")[:1]
             ),
-            interior_photo_count=Coalesce(Subquery(interior_count), Value(0)),
-            exterior_photo_count=Coalesce(Subquery(exterior_count), Value(0)),
-            total_photo_count=Coalesce(Subquery(interior_count), Value(0)) + Coalesce(Subquery(exterior_count), Value(0)),
+            interior_photo_count=Coalesce(interior_count, Value(0)),
+            exterior_photo_count=Coalesce(exterior_count, Value(0)),
+            total_photo_count=F("interior_photo_count") + F("exterior_photo_count"),
         )
 
     def save_related(

--- a/apps/betterangels-backend/shelters/templates/admin/photo_count_filter.html
+++ b/apps/betterangels-backend/shelters/templates/admin/photo_count_filter.html
@@ -1,0 +1,33 @@
+{% load i18n %}
+<style>
+.photo-count-filter { padding: 5px 10px; }
+.photo-count-filter .filter-row { display: flex; gap: 4px; margin-bottom: 4px; align-items: center; }
+.photo-count-filter .filter-row label { font-size: 0.8em; min-width: 28px; }
+.photo-count-filter input[type="number"] { width: 50px; padding: 3px; box-sizing: border-box; }
+.photo-count-filter .filter-group-label { font-weight: bold; font-size: 0.85em; margin: 6px 0 2px; }
+.photo-count-filter .filter-group-label:first-child { margin-top: 0; }
+.photo-count-filter .filter-submit { margin-top: 8px; }
+.photo-count-filter input[type="submit"] { width: 100%; padding: 4px; }
+</style>
+<h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
+{% for choice in choices %}
+<form method="get" class="photo-count-filter">
+  {% for key, value in request.GET.items %}
+    {% if key not in choice.all_params %}
+      <input type="hidden" name="{{ key }}" value="{{ value }}">
+    {% endif %}
+  {% endfor %}
+  {% for field in choice.fields %}
+    <div class="filter-group-label">{{ field.label }}:</div>
+    <div class="filter-row">
+      <label>Min</label>
+      <input type="number" name="{{ field.min_param }}" value="{{ field.min_value }}" min="0">
+      <label>Max</label>
+      <input type="number" name="{{ field.max_param }}" value="{{ field.max_value }}" min="0">
+    </div>
+  {% endfor %}
+  <div class="filter-submit">
+    <input type="submit" value="{% trans "Apply" %}">
+  </div>
+</form>
+{% endfor %}


### PR DESCRIPTION
## Summary by Sourcery

Add photo count annotations and admin UI to filter shelters by interior, exterior, and total photo counts.

New Features:
- Introduce a custom Django admin list filter that allows filtering shelters by minimum and maximum interior, exterior, and total photo counts using free-form numeric inputs.
- Display interior, exterior, and total photo counts as sortable columns in the shelter admin list.

Enhancements:
- Annotate shelter querysets with computed interior, exterior, and total photo counts based on related photo models to support sorting and filtering.