### PR TITLE
SDB-166 Exit Policy Should Not Be Wrapped

### DIFF
--- a/libs/react/shelter/src/lib/pages/shelter/partials/Restrictions.tsx
+++ b/libs/react/shelter/src/lib/pages/shelter/partials/Restrictions.tsx
@@ -34,36 +34,34 @@ export function Restrictions({
     <Card title="Restrictions">
       <div className="flex flex-col gap-2">
         {shelter.maxStay && (
-          <div className="flex gap-1">
-            <strong className="shrink-0 whitespace-nowrap">Max Stay:</strong>
+          <div className="grid grid-cols-[auto_1fr] gap-x-1">
+            <strong className="whitespace-nowrap">Max Stay:</strong>
             <span>{shelter.maxStay} days</span>
           </div>
         )}
 
         {shelter.exitPolicy?.length > 0 && (
-          <div className="flex gap-1">
-            <strong className="shrink-0 whitespace-nowrap">Exit Policy:</strong>
+          <div className="grid grid-cols-[auto_1fr] gap-x-1">
+            <strong className="whitespace-nowrap">Exit Policy:</strong>
             <span>{exitPolicyDisplay.join('; ')}</span>
           </div>
         )}
 
-        <div className="flex gap-1">
-          <strong className="shrink-0 whitespace-nowrap">Curfew:</strong>
+        <div className="grid grid-cols-[auto_1fr] gap-x-1">
+          <strong className="whitespace-nowrap">Curfew:</strong>
           <span>{hasCurfew ? formatCurfewTime(shelter.curfew) : 'No'}</span>
         </div>
 
         {shelter.visitorsAllowed != null && (
-          <div className="flex gap-1">
-            <strong className="shrink-0 whitespace-nowrap">Visitors:</strong>
+          <div className="grid grid-cols-[auto_1fr] gap-x-1">
+            <strong className="whitespace-nowrap">Visitors:</strong>
             <span>{shelter.visitorsAllowed ? 'Allowed' : 'Not Allowed'}</span>
           </div>
         )}
 
         {shelter.emergencySurge != null && (
-          <div className="flex gap-1">
-            <strong className="shrink-0 whitespace-nowrap">
-              Emergency Surge:
-            </strong>
+          <div className="grid grid-cols-[auto_1fr] gap-x-1">
+            <strong className="whitespace-nowrap">Emergency Surge:</strong>
             <span>{shelter.emergencySurge ? 'Yes' : 'No'}</span>
           </div>
         )}

--- a/libs/react/shelter/src/lib/pages/shelter/partials/Restrictions.tsx
+++ b/libs/react/shelter/src/lib/pages/shelter/partials/Restrictions.tsx
@@ -6,6 +6,7 @@ import {
   enumDisplayExitPolicyChoices,
 } from '../../../static';
 import { ViewShelterQuery } from '../__generated__/shelter.generated';
+import { InlineList } from '../common';
 
 function formatCurfewTime(curfew: string): string {
   const parsedTime = parse(curfew.trim(), 'HH:mm:ss', new Date());
@@ -34,35 +35,32 @@ export function Restrictions({
     <Card title="Restrictions">
       <div className="flex flex-col gap-2">
         {shelter.maxStay && (
-          <div className="grid grid-cols-[auto_1fr] gap-x-1">
-            <strong className="whitespace-nowrap">Max Stay:</strong>
-            <span>{shelter.maxStay} days</span>
+          <div className="flex gap-1">
+            <strong>Max Stay:</strong>
+            {shelter.maxStay} days
           </div>
         )}
 
         {shelter.exitPolicy?.length > 0 && (
-          <div className="grid grid-cols-[auto_1fr] gap-x-1">
-            <strong className="whitespace-nowrap">Exit Policy:</strong>
-            <span>{exitPolicyDisplay.join('; ')}</span>
-          </div>
+          <InlineList title="Exit Policy:" items={exitPolicyDisplay} />
         )}
 
-        <div className="grid grid-cols-[auto_1fr] gap-x-1">
-          <strong className="whitespace-nowrap">Curfew:</strong>
-          <span>{hasCurfew ? formatCurfewTime(shelter.curfew) : 'No'}</span>
+        <div className="flex gap-1">
+          <strong>Curfew:</strong>
+          {hasCurfew ? formatCurfewTime(shelter.curfew) : 'No'}
         </div>
 
         {shelter.visitorsAllowed != null && (
-          <div className="grid grid-cols-[auto_1fr] gap-x-1">
-            <strong className="whitespace-nowrap">Visitors:</strong>
-            <span>{shelter.visitorsAllowed ? 'Allowed' : 'Not Allowed'}</span>
+          <div className="flex gap-1">
+            <strong>Visitors:</strong>
+            {shelter.visitorsAllowed ? 'Allowed' : 'Not Allowed'}
           </div>
         )}
 
         {shelter.emergencySurge != null && (
-          <div className="grid grid-cols-[auto_1fr] gap-x-1">
-            <strong className="whitespace-nowrap">Emergency Surge:</strong>
-            <span>{shelter.emergencySurge ? 'Yes' : 'No'}</span>
+          <div className="flex gap-1">
+            <strong>Emergency Surge:</strong>
+            {shelter.emergencySurge ? 'Yes' : 'No'}
           </div>
         )}
       </div>

--- a/libs/react/shelter/src/lib/pages/shelter/partials/Restrictions.tsx
+++ b/libs/react/shelter/src/lib/pages/shelter/partials/Restrictions.tsx
@@ -35,34 +35,36 @@ export function Restrictions({
       <div className="flex flex-col gap-2">
         {shelter.maxStay && (
           <div className="flex gap-1">
-            <strong>Max Stay:</strong>
-            {shelter.maxStay} days
+            <strong className="shrink-0 whitespace-nowrap">Max Stay:</strong>
+            <span>{shelter.maxStay} days</span>
           </div>
         )}
 
         {shelter.exitPolicy?.length > 0 && (
           <div className="flex gap-1">
-            <strong>Exit Policy:</strong>
-            {exitPolicyDisplay.join('; ')}
+            <strong className="shrink-0 whitespace-nowrap">Exit Policy:</strong>
+            <span>{exitPolicyDisplay.join('; ')}</span>
           </div>
         )}
 
         <div className="flex gap-1">
-          <strong>Curfew:</strong>
-          {hasCurfew ? formatCurfewTime(shelter.curfew) : 'No'}
+          <strong className="shrink-0 whitespace-nowrap">Curfew:</strong>
+          <span>{hasCurfew ? formatCurfewTime(shelter.curfew) : 'No'}</span>
         </div>
 
         {shelter.visitorsAllowed != null && (
           <div className="flex gap-1">
-            <strong>Visitors:</strong>
-            {shelter.visitorsAllowed ? 'Allowed' : 'Not Allowed'}
+            <strong className="shrink-0 whitespace-nowrap">Visitors:</strong>
+            <span>{shelter.visitorsAllowed ? 'Allowed' : 'Not Allowed'}</span>
           </div>
         )}
 
         {shelter.emergencySurge != null && (
           <div className="flex gap-1">
-            <strong>Emergency Surge:</strong>
-            {shelter.emergencySurge ? 'Yes' : 'No'}
+            <strong className="shrink-0 whitespace-nowrap">
+              Emergency Surge:
+            </strong>
+            <span>{shelter.emergencySurge ? 'Yes' : 'No'}</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
[SBD-166](https://betterangels.atlassian.net/browse/SDB-166?atlOrigin=eyJpIjoiMTQwZjMxZGYyMzkxNDc5MjljNmMwNjY1MWMyZDAyMjMiLCJwIjoiaiJ9)

This story focuses on updating the styling on Exit Policy and removing the wrapping shown on mobile.

## Summary by Sourcery

Enhancements:
- Prevent wrapping of restriction labels (Max Stay, Exit Policy, Curfew, Visitors, Emergency Surge) by making labels non-wrapping and separating them from their values for better mobile layout.