### PR TITLE
Fix EAS branch cleanup by using `npx eas` instead of bare `eas`

### DIFF
--- a/.github/workflows/eas-branch-cleanup.yml
+++ b/.github/workflows/eas-branch-cleanup.yml
@@ -50,6 +50,6 @@ jobs:
           for project in $affected; do
             echo "Deleting EAS branch for project: $project"
             cd apps/$project
-            eas branch:delete --non-interactive "$BRANCH_NAME"
+            npx eas branch:delete --non-interactive "$BRANCH_NAME"
             cd -
           done


### PR DESCRIPTION
After migrating to Yarn, the `eas branch:delete` command in the cleanup workflow stopped resolving correctly when run from subdirectories (`apps/$project`). Changed to `npx eas` so it resolves the already-installed `eas-cli` from the root node_modules.

## Summary by Sourcery

CI:
- Change the EAS branch cleanup GitHub Actions workflow to use `npx eas` instead of the bare `eas` command when deleting branches.