### PR TITLE
Wait for build e2e

### DIFF
--- a/apps/betterangels/.eas/workflows/e2e-test.yml
+++ b/apps/betterangels/.eas/workflows/e2e-test.yml
@@ -4,8 +4,8 @@
 # GitHub Actions handles orchestration (fingerprint computation, build triggering,
 # update publishing) where GitHub Secrets and NX monorepo tooling are available.
 #
-# Build IDs are passed directly. If a build is still in progress, Maestro will
-# wait for it to complete before running tests.
+# get-build jobs with wait_for_in_progress gate the Maestro tests,
+# ensuring builds have finished before tests begin.
 #
 # GitHub commit status is posted at the start (pending) and end (success/failure)
 # using metadata from .env written by eas-e2e.ts.
@@ -30,6 +30,18 @@ on:
         type: string
         required: true
         description: 'EAS Update group ID'
+      runtime_version:
+        type: string
+        required: true
+        description: 'Runtime version (fingerprint hash) for the builds'
+      android_profile:
+        type: string
+        required: true
+        description: 'EAS build profile used for Android'
+      ios_profile:
+        type: string
+        required: true
+        description: 'EAS build profile used for iOS'
 
 jobs:
   set_pending_github_status:
@@ -91,8 +103,26 @@ jobs:
 
           echo "Posted pending status ${GITHUB_STATUS_CONTEXT} for ${GITHUB_REPOSITORY}@${GITHUB_STATUS_SHA}"
 
-  maestro_android_test:
+  wait_android_build:
     needs: [set_pending_github_status]
+    type: get-build
+    params:
+      platform: android
+      profile: ${{ inputs.android_profile }}
+      runtime_version: ${{ inputs.runtime_version }}
+      wait_for_in_progress: true
+
+  wait_ios_build:
+    needs: [set_pending_github_status]
+    type: get-build
+    params:
+      platform: ios
+      profile: ${{ inputs.ios_profile }}
+      runtime_version: ${{ inputs.runtime_version }}
+      wait_for_in_progress: true
+
+  maestro_android_test:
+    needs: [wait_android_build]
     type: maestro
     env:
       MAESTRO_DEEPLINK: betterangels-dev://expo-development-client/?url=https://u.expo.dev/53171ba4-60ca-40cb-b3e6-b0c2393677b8/group/${{ inputs.update_group_id }}?platform=android%26disableOnboarding%3D1
@@ -101,7 +131,7 @@ jobs:
       flow_path: ['.maestro/tests/landing.yml']
 
   maestro_ios_test:
-    needs: [set_pending_github_status]
+    needs: [wait_ios_build]
     type: maestro
     env:
       MAESTRO_DEEPLINK: betterangels-dev://expo-development-client/?url=https://u.expo.dev/53171ba4-60ca-40cb-b3e6-b0c2393677b8/group/${{ inputs.update_group_id }}?platform=ios%26disableOnboarding%3D1
@@ -110,7 +140,7 @@ jobs:
       flow_path: ['.maestro/tests/landing.yml']
 
   set_final_github_status:
-    after: [maestro_android_test, maestro_ios_test]
+    after: [wait_android_build, wait_ios_build, maestro_android_test, maestro_ios_test]
     env:
       IOS_STATUS: ${{ after.maestro_ios_test.status }}
       ANDROID_STATUS: ${{ after.maestro_android_test.status }}

--- a/tools/scripts/eas-e2e.ts
+++ b/tools/scripts/eas-e2e.ts
@@ -5,8 +5,9 @@
  *   1. Setup env and compute fingerprint (same as deploy pipeline)
  *   2. Ensure preview builds exist for this fingerprint (trigger if missing)
  *   3. Publish an EAS Update for the branch
- *   4. Trigger the EAS workflow with fingerprint + update group
- *      (EAS workflow uses get-build with wait_for_in_progress to wait for builds)
+ *   4. Trigger the EAS workflow with build IDs, update group, and build filter
+ *      params (the workflow uses get-build with wait_for_in_progress to wait
+ *      for builds to complete before running Maestro tests)
  *
  * Usage:
  *   npx ts-node tools/scripts/eas-e2e.ts --project betterangels
@@ -134,13 +135,16 @@ if (githubRepository && githubStatusSha) {
   );
 }
 
-// 5. Trigger EAS workflow with build IDs + update group
+// 5. Trigger EAS workflow with build IDs + update group + filter params for wait
 console.log('\nTriggering EAS Maestro workflow...');
 run(
   `npx eas workflow:run .eas/workflows/e2e-test.yml ` +
     `-F android_build_id=${androidBuildId} ` +
     `-F ios_build_id=${iosBuildId} ` +
     `-F update_group_id=${groupId} ` +
+    `-F runtime_version=${fingerprint} ` +
+    `-F android_profile=${androidProfile} ` +
+    `-F ios_profile=${iosProfile} ` +
     `--non-interactive`,
   { cwd: projectDir }
 );


### PR DESCRIPTION
## Summary by Sourcery

Gate BetterAngels EAS e2e Maestro tests on completed platform builds using runtime/profile filters and propagate the new filter parameters through the e2e trigger script.

New Features:
- Add explicit Android and iOS get-build wait jobs to the BetterAngels e2e workflow to block Maestro tests until builds finish.

Enhancements:
- Extend the BetterAngels e2e EAS workflow inputs and documentation to include runtime version and platform-specific build profiles for filtered get-build queries.
- Update the eas-e2e helper script to pass runtime version and build profile parameters when triggering the EAS e2e workflow, ensuring get-build waits on the correct builds.
- Adjust final GitHub status aggregation to depend on both build wait and Maestro test jobs.