### PR TITLE
clickable carousel (SDB-161)

### DIFF
--- a/libs/react/components/src/lib/ImageCarousel/ImageCarousel.tsx
+++ b/libs/react/components/src/lib/ImageCarousel/ImageCarousel.tsx
@@ -15,10 +15,19 @@ export type TProps = {
   youtubeVideos?: TYouTubeVideo[];
   className?: string;
   imageClassName?: string;
+  onImageClick?: (imageSrc: string) => void;
+  onVideoClick?: (video: TYouTubeVideo) => void;
 };
 
 export function ImageCarousel(props: TProps) {
-  const { imageUrls, youtubeVideos = [], className, imageClassName } = props;
+  const {
+    imageUrls,
+    youtubeVideos = [],
+    className,
+    imageClassName,
+    onImageClick,
+    onVideoClick,
+  } = props;
 
   const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
   const [emblaRef, emblaApi] = useEmblaCarousel();
@@ -67,7 +76,12 @@ export function ImageCarousel(props: TProps) {
     >
       <div className={mergeCss(slideContainerCss)}>
         {imageUrls.map((src, i) => (
-          <ImageSlide key={i} imageSrc={src} imgClassName={imageClassName} />
+          <ImageSlide
+            key={i}
+            imageSrc={src}
+            imgClassName={imageClassName}
+            onClick={onImageClick ? () => onImageClick(src) : undefined}
+          />
         ))}
         {youtubeVideos.map((video) => (
           <YouTubeSlide
@@ -76,6 +90,7 @@ export function ImageCarousel(props: TProps) {
             title={video.title}
             onPrev={() => emblaApi?.scrollPrev()}
             onNext={() => emblaApi?.scrollNext()}
+            onClick={onVideoClick ? () => onVideoClick(video) : undefined}
           />
         ))}
       </div>

--- a/libs/react/components/src/lib/ImageCarousel/ImageSlide.tsx
+++ b/libs/react/components/src/lib/ImageCarousel/ImageSlide.tsx
@@ -5,6 +5,7 @@ type TProps = {
   className?: string;
   altText?: string;
   imgClassName?: string;
+  onClick?: () => void;
 };
 
 export function ImageSlide(props: TProps) {
@@ -13,14 +14,21 @@ export function ImageSlide(props: TProps) {
     className,
     imgClassName,
     altText = 'carousel image',
+    onClick,
   } = props;
 
-  const parentCss = ['flex-none', 'w-full', 'h-full', className];
+  const parentCss = [
+    'flex-none',
+    'w-full',
+    'h-full',
+    onClick && 'cursor-pointer',
+    className,
+  ];
 
   const imageCss = ['block', 'w-full', 'h-full', 'object-cover', imgClassName];
 
   return (
-    <div className={mergeCss(parentCss)}>
+    <div className={mergeCss(parentCss)} onClick={onClick}>
       <img
         src={imageSrc}
         className={mergeCss(imageCss)}

--- a/libs/react/components/src/lib/ImageCarousel/YouTubeSlide.tsx
+++ b/libs/react/components/src/lib/ImageCarousel/YouTubeSlide.tsx
@@ -8,12 +8,47 @@ type TProps = {
   className?: string;
   onPrev?: () => void;
   onNext?: () => void;
+  onClick?: () => void;
 };
 
 export function YouTubeSlide(props: TProps) {
-  const { videoId, title = 'YouTube video', className, onPrev, onNext } = props;
+  const {
+    videoId,
+    title = 'YouTube video',
+    className,
+    onPrev,
+    onNext,
+    onClick,
+  } = props;
 
   const parentCss = ['flex-none', 'w-full', 'h-full', 'relative', className];
+
+  if (onClick) {
+    return (
+      <div
+        className={mergeCss([...parentCss, 'cursor-pointer'])}
+        onClick={onClick}
+      >
+        <img
+          src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+          alt={title}
+          loading="lazy"
+          className="block w-full h-full object-cover"
+        />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="w-12 h-12 bg-black/60 rounded-full flex items-center justify-center">
+            <svg
+              className="w-6 h-6 text-white ml-1"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={mergeCss(parentCss)}>

--- a/libs/react/components/src/lib/ImageCarousel/YouTubeSlide.tsx
+++ b/libs/react/components/src/lib/ImageCarousel/YouTubeSlide.tsx
@@ -26,7 +26,7 @@ export function YouTubeSlide(props: TProps) {
   if (onClick) {
     return (
       <div
-        className={mergeCss([...parentCss, 'cursor-pointer'])}
+        className={mergeCss([parentCss, 'cursor-pointer'])}
         onClick={onClick}
       >
         <img

--- a/libs/react/components/src/lib/ImageCarousel/index.ts
+++ b/libs/react/components/src/lib/ImageCarousel/index.ts
@@ -1,1 +1,1 @@
-export { ImageCarousel } from './ImageCarousel';
+export { ImageCarousel, type TYouTubeVideo } from './ImageCarousel';

--- a/libs/react/shelter/src/lib/components/MediaLightbox/MediaLightbox.tsx
+++ b/libs/react/shelter/src/lib/components/MediaLightbox/MediaLightbox.tsx
@@ -1,0 +1,32 @@
+import { ArrowLeftIcon } from '@monorepo/react/icons';
+import { PropsWithChildren } from 'react';
+
+interface IProps extends PropsWithChildren {
+  onClose: () => void;
+  contentClassName?: string;
+}
+
+export function MediaLightbox(props: IProps) {
+  const { onClose, contentClassName = 'w-[90vw] max-w-md', children } = props;
+
+  return (
+    <div className="fixed inset-0 z-400 bg-black flex flex-col h-full">
+      <div className="bg-steel-blue flex items-center gap-8 py-2">
+        <div
+          onClick={onClose}
+          className="ml-5 flex items-center justify-center h-10 w-10 cursor-pointer"
+        >
+          <ArrowLeftIcon className="w-5 h-5 text-white" />
+        </div>
+      </div>
+      <div
+        onClick={onClose}
+        className="flex flex-1 items-center justify-center"
+      >
+        <div onClick={(e) => e.stopPropagation()} className={contentClassName}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/react/shelter/src/lib/components/MediaLightbox/index.ts
+++ b/libs/react/shelter/src/lib/components/MediaLightbox/index.ts
@@ -1,0 +1,1 @@
+export { MediaLightbox } from './MediaLightbox';

--- a/libs/react/shelter/src/lib/components/index.ts
+++ b/libs/react/shelter/src/lib/components/index.ts
@@ -2,6 +2,7 @@ export * from './Flyout';
 export * from './ImagePlaceholder';
 export * from './Input';
 export * from './Map';
+export * from './MediaLightbox';
 export * from './Modal';
 export * from './NavBar';
 export * from './ShelterCard';

--- a/libs/react/shelter/src/lib/pages/gallery/GalleryPage.tsx
+++ b/libs/react/shelter/src/lib/pages/gallery/GalleryPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftIcon } from '@monorepo/react/icons';
 import { mapMediaLinksToVideos } from '@monorepo/react/shared';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { MediaLightbox } from '../../components';
 import { ViewShelterDocument } from '../shelter/__generated__/shelter.generated';
 
 type TProps = {
@@ -92,58 +93,25 @@ export function GalleryPage(props: TProps) {
       </div>
 
       {selectedImage && (
-        <div className="fixed inset-0 z-400 bg-black flex flex-col h-full">
-          <div className="bg-steel-blue flex items-center gap-8 py-2">
-            <div
-              onClick={() => setSelectedImage(null)}
-              className="ml-5 flex items-center justify-center h-10 w-10"
-            >
-              <ArrowLeftIcon className="w-5 h-5 text-white" />
-            </div>
-          </div>
-          <div
-            onClick={() => setSelectedImage(null)}
-            className="flex flex-1 items-center justify-center"
-          >
-            <div
-              onClick={(e) => e.stopPropagation()}
-              className="w-[90vw] max-w-md aspect-square"
-            >
-              <img
-                src={selectedImage.url}
-                alt="Fullscreen"
-                className="w-full h-full object-contain"
-              />
-            </div>
-          </div>
-        </div>
+        <MediaLightbox
+          onClose={() => setSelectedImage(null)}
+          contentClassName="w-[90vw] max-w-md aspect-square"
+        >
+          <img
+            src={selectedImage.url}
+            alt="Fullscreen"
+            className="w-full h-full object-contain"
+          />
+        </MediaLightbox>
       )}
 
       {selectedVideo && (
-        <div className="fixed inset-0 z-400 bg-black flex flex-col h-full">
-          <div className="bg-steel-blue flex items-center gap-8 py-2">
-            <div
-              onClick={() => setSelectedVideo(null)}
-              className="ml-5 flex items-center justify-center h-10 w-10"
-            >
-              <ArrowLeftIcon className="w-5 h-5 text-white" />
-            </div>
-          </div>
-          <div
-            onClick={() => setSelectedVideo(null)}
-            className="flex flex-1 items-center justify-center"
-          >
-            <div
-              onClick={(e) => e.stopPropagation()}
-              className="w-[90vw] max-w-md"
-            >
-              <VideoEmbed
-                src={`https://www.youtube-nocookie.com/embed/${selectedVideo.videoId}`}
-                title={selectedVideo.title || 'YouTube video'}
-              />
-            </div>
-          </div>
-        </div>
+        <MediaLightbox onClose={() => setSelectedVideo(null)}>
+          <VideoEmbed
+            src={`https://www.youtube-nocookie.com/embed/${selectedVideo.videoId}`}
+            title={selectedVideo.title || 'YouTube video'}
+          />
+        </MediaLightbox>
       )}
     </>
   );

--- a/libs/react/shelter/src/lib/pages/shelter/partials/Header/HeroCarousel.tsx
+++ b/libs/react/shelter/src/lib/pages/shelter/partials/Header/HeroCarousel.tsx
@@ -1,5 +1,11 @@
-import { ImageCarousel } from '@monorepo/react/components';
+import {
+  ImageCarousel,
+  TYouTubeVideo,
+  VideoEmbed,
+} from '@monorepo/react/components';
+import { ArrowLeftIcon } from '@monorepo/react/icons';
 import { mapMediaLinksToVideos, mergeCss } from '@monorepo/react/shared';
+import { useState } from 'react';
 import { ImagePlaceholder } from '../../../../components';
 import { ViewShelterQuery } from '../../__generated__/shelter.generated';
 
@@ -17,6 +23,11 @@ export function HeroCarousel(props: TProps) {
 
   const youtubeVideos = mapMediaLinksToVideos(shelter.mediaLinks || []);
 
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [selectedVideo, setSelectedVideo] = useState<TYouTubeVideo | null>(
+    null
+  );
+
   const parentCss = ['bg-white', 'h-[200px]', className];
   const placeholderCss = ['h-[250px]', className];
 
@@ -31,10 +42,69 @@ export function HeroCarousel(props: TProps) {
   const imageUrls = shelter.heroImage ? [shelter.heroImage, ...rest] : rest;
 
   return (
-    <ImageCarousel
-      imageUrls={imageUrls}
-      youtubeVideos={youtubeVideos}
-      className={mergeCss(parentCss)}
-    />
+    <>
+      <ImageCarousel
+        imageUrls={imageUrls}
+        youtubeVideos={youtubeVideos}
+        className={mergeCss(parentCss)}
+        onImageClick={(src) => setSelectedImage(src)}
+        onVideoClick={(video) => setSelectedVideo(video)}
+      />
+
+      {selectedImage && (
+        <div className="fixed inset-0 z-400 bg-black flex flex-col h-full">
+          <div className="bg-steel-blue flex items-center gap-8 py-2">
+            <div
+              onClick={() => setSelectedImage(null)}
+              className="ml-5 flex items-center justify-center h-10 w-10 cursor-pointer"
+            >
+              <ArrowLeftIcon className="w-5 h-5 text-white" />
+            </div>
+          </div>
+          <div
+            onClick={() => setSelectedImage(null)}
+            className="flex flex-1 items-center justify-center"
+          >
+            <div
+              onClick={(e) => e.stopPropagation()}
+              className="w-[90vw] max-w-md aspect-square"
+            >
+              <img
+                src={selectedImage}
+                alt="Fullscreen"
+                className="w-full h-full object-contain"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {selectedVideo && (
+        <div className="fixed inset-0 z-400 bg-black flex flex-col h-full">
+          <div className="bg-steel-blue flex items-center gap-8 py-2">
+            <div
+              onClick={() => setSelectedVideo(null)}
+              className="ml-5 flex items-center justify-center h-10 w-10 cursor-pointer"
+            >
+              <ArrowLeftIcon className="w-5 h-5 text-white" />
+            </div>
+          </div>
+          <div
+            onClick={() => setSelectedVideo(null)}
+            className="flex flex-1 items-center justify-center"
+          >
+            <div
+              onClick={(e) => e.stopPropagation()}
+              className="w-[90vw] max-w-md"
+            >
+              <VideoEmbed
+                src={`https://www.youtube-nocookie.com/embed/${selectedVideo.videoId}`}
+                title={selectedVideo.title || 'YouTube video'}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/libs/react/shelter/src/lib/pages/shelter/partials/Header/HeroCarousel.tsx
+++ b/libs/react/shelter/src/lib/pages/shelter/partials/Header/HeroCarousel.tsx
@@ -3,10 +3,9 @@ import {
   TYouTubeVideo,
   VideoEmbed,
 } from '@monorepo/react/components';
-import { ArrowLeftIcon } from '@monorepo/react/icons';
 import { mapMediaLinksToVideos, mergeCss } from '@monorepo/react/shared';
 import { useState } from 'react';
-import { ImagePlaceholder } from '../../../../components';
+import { ImagePlaceholder, MediaLightbox } from '../../../../components';
 import { ViewShelterQuery } from '../../__generated__/shelter.generated';
 
 type TProps = {
@@ -52,58 +51,25 @@ export function HeroCarousel(props: TProps) {
       />
 
       {selectedImage && (
-        <div className="fixed inset-0 z-400 bg-black flex flex-col h-full">
-          <div className="bg-steel-blue flex items-center gap-8 py-2">
-            <div
-              onClick={() => setSelectedImage(null)}
-              className="ml-5 flex items-center justify-center h-10 w-10 cursor-pointer"
-            >
-              <ArrowLeftIcon className="w-5 h-5 text-white" />
-            </div>
-          </div>
-          <div
-            onClick={() => setSelectedImage(null)}
-            className="flex flex-1 items-center justify-center"
-          >
-            <div
-              onClick={(e) => e.stopPropagation()}
-              className="w-[90vw] max-w-md aspect-square"
-            >
-              <img
-                src={selectedImage}
-                alt="Fullscreen"
-                className="w-full h-full object-contain"
-              />
-            </div>
-          </div>
-        </div>
+        <MediaLightbox
+          onClose={() => setSelectedImage(null)}
+          contentClassName="w-[90vw] max-w-md aspect-square"
+        >
+          <img
+            src={selectedImage}
+            alt="Fullscreen"
+            className="w-full h-full object-contain"
+          />
+        </MediaLightbox>
       )}
 
       {selectedVideo && (
-        <div className="fixed inset-0 z-400 bg-black flex flex-col h-full">
-          <div className="bg-steel-blue flex items-center gap-8 py-2">
-            <div
-              onClick={() => setSelectedVideo(null)}
-              className="ml-5 flex items-center justify-center h-10 w-10 cursor-pointer"
-            >
-              <ArrowLeftIcon className="w-5 h-5 text-white" />
-            </div>
-          </div>
-          <div
-            onClick={() => setSelectedVideo(null)}
-            className="flex flex-1 items-center justify-center"
-          >
-            <div
-              onClick={(e) => e.stopPropagation()}
-              className="w-[90vw] max-w-md"
-            >
-              <VideoEmbed
-                src={`https://www.youtube-nocookie.com/embed/${selectedVideo.videoId}`}
-                title={selectedVideo.title || 'YouTube video'}
-              />
-            </div>
-          </div>
-        </div>
+        <MediaLightbox onClose={() => setSelectedVideo(null)}>
+          <VideoEmbed
+            src={`https://www.youtube-nocookie.com/embed/${selectedVideo.videoId}`}
+            title={selectedVideo.title || 'YouTube video'}
+          />
+        </MediaLightbox>
       )}
     </>
   );


### PR DESCRIPTION
SDB-161

## Summary by Sourcery

Make shelter hero image carousel items clickable to open full-screen media overlays.

New Features:
- Allow clicking carousel images to view them in a full-screen overlay within the shelter header.
- Allow clicking carousel YouTube thumbnails to open a dedicated full-screen video view in the shelter header.

Enhancements:
- Extend the generic ImageCarousel, image slide, and YouTube slide components with optional click handlers and reusable YouTube video typing, enabling interactive usage across the app.