### PR TITLE
update seed_shelters names to reflect shelter db id (SDB-187)

### DIFF
--- a/apps/betterangels-backend/pyproject.toml
+++ b/apps/betterangels-backend/pyproject.toml
@@ -60,3 +60,6 @@ requests = "^2.32.5"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[dependency-groups]
+dev = ["faker (>=40.15.0,<41.0.0)"]

--- a/apps/betterangels-backend/pyproject.toml
+++ b/apps/betterangels-backend/pyproject.toml
@@ -60,6 +60,3 @@ requests = "^2.32.5"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[dependency-groups]
-dev = ["faker (>=40.15.0,<41.0.0)"]

--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -1068,6 +1068,7 @@ class ShelterAdmin(ImportExportModelAdmin):
     )
 
     list_display = (
+        "id",
         "name",
         "organization",
         "location",

--- a/apps/betterangels-backend/shelters/scripts/seed_shelters.py
+++ b/apps/betterangels-backend/shelters/scripts/seed_shelters.py
@@ -3,6 +3,11 @@ import random
 import sys
 from pathlib import Path
 
+import django
+from django.core.files import File
+from django.db import transaction
+from faker import Faker
+
 """Seed shelters with representative demo data.
 
 Usage:
@@ -16,15 +21,74 @@ environments surface realistic UI coverage.
 """
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "betterangels_backend.settings")
-import django  # noqa: E402
-from django.core.files import File  # noqa: E402
-from django.db import transaction  # noqa: E402
-
 django.setup()
 
 from shelters.enums import ShelterPhotoTypeChoices, StatusChoices  # noqa: E402
 from shelters.models import Shelter, ShelterPhoto  # noqa: E402
 from shelters.tests.baker_recipes import make_complete_shelters, shelter_contact_recipe  # noqa: E402
+
+fake = Faker()
+
+# Maximum allowed length for a generated shelter name (excludes the " id-N" suffix)
+SHELTER_NAME_MAX_LENGTH = 80
+
+# Probability that a generated name targets the "long" bucket (>70 chars). Long
+# names are rare in production but must be prominent in dev so UI can handle them.
+LONG_NAME_PROBABILITY = 0.10
+
+# Suffixes that make a randomly generated name read like a real shelter.
+_SHELTER_SUFFIXES = [
+    "Shelter",
+    "House",
+    "Refuge",
+    "Mission",
+    "Sanctuary",
+    "Center",
+    "Haven",
+    "Outreach",
+    "Lodge",
+    "Place",
+]
+
+# Qualifiers paired with a person's last name to mimic real shelter naming patterns.
+_NAME_QUALIFIERS = ["Memorial", "Family", "Community", "Foundation"]
+
+
+def generate_shelter_name() -> str:
+    """Return a plausible shelter name with controlled length variability.
+
+    Names are built as ``<last-name>[ & <last-name>...] <qualifier> <suffix>``,
+    which mirrors real partnership/coalition shelter naming. A small fraction
+    (see :data:`LONG_NAME_PROBABILITY`) intentionally targets the long bucket
+    (>70 chars, up to :data:`SHELTER_NAME_MAX_LENGTH`) so dev/UI workflows must
+    handle extreme cases. The rest are normal-length (~15-50 chars).
+    """
+    if random.random() < LONG_NAME_PROBABILITY:
+        target = random.randint(71, SHELTER_NAME_MAX_LENGTH)
+    else:
+        target = random.randint(15, 50)
+
+    qualifier = random.choice(_NAME_QUALIFIERS)
+    suffix = random.choice(_SHELTER_SUFFIXES)
+    joiner = random.choice([" & ", " - "])
+    tail = f" {qualifier} {suffix}"
+
+    # Keep chaining last names while the projected total stays within target.
+    last_names: list[str] = [fake.last_name()]
+
+    while True:
+        candidate = fake.last_name()
+        projected = len(joiner.join(last_names + [candidate])) + len(tail)
+        if projected > target:
+            break
+        last_names.append(candidate)
+
+    name = f"{joiner.join(last_names)}{tail}"
+    # Defensive cap: never exceed the hard limit, even if a single last name is huge.
+    if len(name) > SHELTER_NAME_MAX_LENGTH:
+        name = name[:SHELTER_NAME_MAX_LENGTH].rsplit(" ", 1)[0]
+
+    return name
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +145,13 @@ def main() -> None:
             status=StatusChoices.APPROVED,
             hero_image=None,
         )
+
+        # ---- Generate human readable shelter name name with a DB ID suffix
+        # Prefix length is randomized to surface UI breakage on unusually short/long names.
+        for shelter in shelters:
+            shelter.name = f"{generate_shelter_name()} (id-{shelter.id})"
+
+        Shelter.objects.bulk_update(shelters, ["name"])
 
         # ---- Images (1–10 per shelter) ----
         image_path = Path(__file__).with_name("shelter_seed_image.png")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1927,6 +1927,24 @@ files = [
 tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich ; python_version >= \"3.11\""]
 
 [[package]]
+name = "faker"
+version = "40.15.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "faker-40.15.0-py3-none-any.whl", hash = "sha256:71ab3c3370da9d2205ab74ffb0fd51273063ad562b3a3bb69d0026a20923e318"},
+    {file = "faker-40.15.0.tar.gz", hash = "sha256:20f3a6ec8c266b74d4c554e34118b21c3c2056c0b4a519d15c8decb3a4e6e795"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+tzdata = ["tzdata"]
+
+[[package]]
 name = "filelock"
 version = "3.25.0"
 description = "A platform independent file lock."
@@ -4101,7 +4119,7 @@ files = [
     {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
     {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
 ]
-markers = {dev = "sys_platform == \"win32\""}
+markers = {dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "tzlocal"
@@ -4379,4 +4397,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "3.14.2"
-content-hash = "3ccd9fdb79b5b03d182f6f848745e69bcdbe2594b5bf238b1f738e542881c4a3"
+content-hash = "c5599c214c3e919a11373a10c396344afc1a3c15021ed30515fdc9cb02131eba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ types-gevent = "^25.4.0.20250801"
 types-requests = "^2.32.0"
 pre-commit = "^4.3.1"
 virtualenv = "^21.1.0"
+faker = "^40.15.0"
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### [DEV Env] Simplify shelter detail access via Name/ID
SDB-187

This outputs names like below.
Also added `ID` column.

<img width="1100" height="752" alt="image" src="https://github.com/user-attachments/assets/f9d9ff64-c6f7-4bbb-9f25-bb9379ecaa6a" />



## Summary by Sourcery

Generate human-readable seeded shelter names that include their database IDs and surface more varied name lengths for UI testing.

New Features:
- Generate realistic, length-varied shelter names during seeding and append each shelter's database ID to its name.
- Display the shelter ID column in the Django admin shelter list view.

Build:
- Add Faker as a development dependency for generating seeded shelter names.