### PR TITLE
add client id to self str (DEV-2427)

### DIFF
--- a/apps/betterangels-backend/clients/models.py
+++ b/apps/betterangels-backend/clients/models.py
@@ -212,7 +212,7 @@ class ClientProfile(AbstractClientProfile):
         return " ".join(name_parts).strip()
 
     def __str__(self: "ClientProfile") -> str:
-        return f"{self.full_name if self.full_name else self.pk}"
+        return f"{self.full_name} ({self.pk})" if self.full_name else str(self.pk)
 
     class Meta:
         ordering = ["first_name"]


### PR DESCRIPTION
DEV-2427

## Summary by Sourcery

Enhancements:
- Adjust client profile string representation to append the primary key to the full name, falling back to just the ID when no name is present.