### PR TITLE
update strawberry Optional inputs to use Maybe (DEV-2426)

### DIFF
--- a/apps/betterangels-backend/accounts/types.py
+++ b/apps/betterangels-backend/accounts/types.py
@@ -10,7 +10,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import CharField, F, Q, QuerySet, Value
 from django.db.models.functions import Concat
 from organizations.models import Organization
-from strawberry import ID, Info, auto
+from strawberry import ID, Info, Maybe, auto
 from strawberry_django.auth.utils import get_current_user
 
 from .models import User
@@ -229,8 +229,8 @@ class OrgInvitationInput:
 
 @strawberry.input
 class UpdateUserProfileInput:
-    first_name: Optional[NonEmptyString] = strawberry.UNSET
-    last_name: Optional[NonEmptyString] = strawberry.UNSET
+    first_name: Maybe[NonEmptyString | None]
+    last_name: Maybe[NonEmptyString | None]
 
 
 @strawberry.input

--- a/apps/betterangels-backend/clients/types.py
+++ b/apps/betterangels-backend/clients/types.py
@@ -23,7 +23,7 @@ from common.graphql.types import (
 from common.models import Attachment
 from django.db.models import Exists, Max, OuterRef, Q, QuerySet
 from django.utils import timezone
-from strawberry import ID, Info, auto
+from strawberry import ID, Info, Maybe, auto
 from strawberry.file_uploads import Upload
 
 from .models import (
@@ -358,11 +358,11 @@ class CreateClientProfileInput(ClientProfileBaseType):
 @strawberry_django.input(ClientProfile, partial=True)
 class UpdateClientProfileInput(ClientProfileBaseType):
     id: ID
-    contacts: Optional[List[ClientContactInput]]
-    hmis_profiles: Optional[List[HmisProfileInput]]
-    household_members: Optional[List[ClientHouseholdMemberInput]]
-    phone_numbers: Optional[List[PhoneNumberInput]]
-    social_media_profiles: Optional[List[SocialMediaProfileInput]]
+    contacts: Maybe[List[ClientContactInput]]
+    hmis_profiles: Maybe[List[HmisProfileInput]]
+    household_members: Maybe[List[ClientHouseholdMemberInput]]
+    phone_numbers: Maybe[List[PhoneNumberInput]]
+    social_media_profiles: Maybe[List[SocialMediaProfileInput]]
 
 
 # Data Import

--- a/apps/betterangels-backend/hmis/api_bridge.py
+++ b/apps/betterangels-backend/hmis/api_bridge.py
@@ -541,7 +541,7 @@ class HmisApiBridge:
         note_data = {
             k: (v.strftime(NOTE_DATE_FORMAT) if isinstance(v, datetime.date) else v)
             for k, v in strawberry.asdict(data).items()
-            if v is not UNSET
+            if k != "id"
         }
 
         fields = self._get_field_dot_paths(

--- a/apps/betterangels-backend/hmis/types.py
+++ b/apps/betterangels-backend/hmis/types.py
@@ -34,7 +34,7 @@ from hmis.models import HmisClientProfile, HmisNote
 from notes.enums import ServiceRequestTypeEnum
 from notes.models import ServiceRequest
 from notes.types import ServiceRequestType
-from strawberry import ID, Info, auto
+from strawberry import ID, Info, Maybe, auto
 from tasks.types import TaskType
 
 
@@ -282,13 +282,13 @@ class ProgramEnrollmentType:
     ref_client_program: str
 
 
-@strawberry_django.input(HmisNote)
+@strawberry_django.input(HmisNote, partial=True)
 class UpdateHmisNoteInput:
     id: ID
-    title: Optional[str]
-    note: Optional[str]
-    date: Optional[datetime.date]
-    ref_client_program: Optional[str]
+    title: Maybe[str | None]
+    note: Maybe[str | None]
+    date: Maybe[datetime.date | None]
+    ref_client_program: Maybe[str | None]
 
 
 @strawberry_django.input(HmisNote)

--- a/apps/betterangels-backend/notes/schema.py
+++ b/apps/betterangels-backend/notes/schema.py
@@ -259,11 +259,14 @@ class Mutation:
                 f"Source ID {data.source_id} with source name '{data.source_name}' has already been imported successfully."
             )
 
-        note_input = strawberry.asdict(data.note)
+        note_input = data.note
+        client_profile_id: str | None = (
+            str(note_input.client_profile) if note_input.client_profile is not None else None
+        )
 
-        # Pop out the parentId so it doesn't get passed to CreateNoteInput.
-        parent_id = note_input.pop("parentId", None)
-        if parent_id:
+        # Legacy import payloads may send parentId instead of clientProfile.
+        parent_id = strawberry.asdict(note_input).get("parentId")
+        if parent_id and client_profile_id is None:
             cp_record = ClientProfileImportRecord.objects.filter(
                 source_id=parent_id,
                 source_name="SELAH",
@@ -271,7 +274,7 @@ class Mutation:
             ).first()
             if cp_record is None or cp_record.client_profile is None:
                 raise Exception(f"Client lookup failed for parentId '{parent_id}'")
-            note_input["client"] = str(cp_record.client_profile.id)
+            client_profile_id = str(cp_record.client_profile.id)
 
         import_job = NoteDataImport.objects.get(id=data.import_job_id)
         user = cast(User, get_current_user(info))
@@ -281,23 +284,13 @@ class Mutation:
                 note = note_create(
                     user=user,
                     permission_group=permission_group,
-                    purpose=data.note.purpose if data.note.purpose is not strawberry.UNSET else None,
-                    team=data.note.team if data.note.team is not strawberry.UNSET else None,
-                    public_details=data.note.public_details if data.note.public_details is not strawberry.UNSET else "",
-                    private_details=(
-                        data.note.private_details if data.note.private_details is not strawberry.UNSET else ""
-                    ),
-                    client_profile_id=(
-                        str(data.note.client_profile)
-                        if data.note.client_profile and data.note.client_profile is not strawberry.UNSET
-                        else None
-                    ),
-                    is_submitted=(
-                        bool(data.note.is_submitted) if data.note.is_submitted is not strawberry.UNSET else False
-                    ),
-                    interacted_at=(
-                        data.note.interacted_at if data.note.interacted_at is not strawberry.UNSET else None
-                    ),
+                    purpose=note_input.purpose,
+                    team=note_input.team,
+                    public_details=note_input.public_details or "",
+                    private_details=note_input.private_details or "",
+                    client_profile_id=client_profile_id,
+                    is_submitted=bool(note_input.is_submitted),
+                    interacted_at=note_input.interacted_at,
                 )
                 record = NoteImportRecord.objects.create(
                     import_job=import_job,

--- a/apps/betterangels-backend/notes/tests/test_mutations.py
+++ b/apps/betterangels-backend/notes/tests/test_mutations.py
@@ -239,7 +239,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
         self.assertEqual(note.tasks.count(), 0)
 
     def test_update_note_omitted_relations_unchanged(self) -> None:
-        """Test that omitting nested relations (UNSET) leaves existing ones untouched."""
+        """Test that omitting nested relations leaves existing ones untouched."""
         bag_svc = OrganizationService.objects.get(label="Bag(s)")
 
         # First: add a provided service

--- a/apps/betterangels-backend/notes/types.py
+++ b/apps/betterangels-backend/notes/types.py
@@ -8,26 +8,11 @@ from accounts.models import PermissionGroup, User
 from accounts.types import OrganizationType, UserType
 from clients.types import ClientProfileType
 from common.enums import SelahTeamEnum
-from common.graphql.types import (
-    LocationInput,
-    LocationType,
-    NonBlankString,
-    make_in_filter,
-)
-from django.db.models import (
-    BooleanField,
-    Case,
-    Exists,
-    F,
-    OuterRef,
-    Q,
-    QuerySet,
-    Value,
-    When,
-)
+from common.graphql.types import LocationInput, LocationType, NonBlankString, make_in_filter
+from django.db.models import BooleanField, Case, Exists, F, OuterRef, Q, QuerySet, Value, When
 from notes.enums import ServiceRequestTypeEnum
 from notes.permissions import NotePermissions, PrivateDetailsPermissions
-from strawberry import ID, Info, auto
+from strawberry import ID, Info, Maybe, auto
 from strawberry_django.utils.query import filter_for_user
 from tasks.types import TaskType
 
@@ -101,7 +86,7 @@ class CreateNoteServiceRequestInput:
 @strawberry_django.input(models.ServiceRequest, partial=True)
 class UpdateServiceRequestInput:
     id: ID
-    service_other: Optional[str]
+    service_other: Maybe[str | None]
     status: auto
     due_by: auto
 
@@ -236,23 +221,23 @@ class CreateNoteTaskInput:
 class UpdateNoteInput:
     """
     Input for updating a note with all nested relations.
-    Fields set to UNSET are left unchanged. Nested relation fields
-    use replace-all semantics (existing items are removed, new ones created).
+    Omitted fields are left unchanged. Nested relation fields use replace-all
+    semantics when provided (existing items are removed, new ones created).
     """
 
     id: ID
     purpose: Optional[NonBlankString] = strawberry.UNSET
-    team: Optional[SelahTeamEnum] = strawberry.UNSET
-    public_details: Optional[str] = strawberry.UNSET
-    private_details: Optional[str] = strawberry.UNSET
-    is_submitted: Optional[bool] = strawberry.UNSET
-    interacted_at: Optional[datetime] = strawberry.UNSET
+    team: Maybe[SelahTeamEnum | None]
+    public_details: Maybe[str | None]
+    private_details: Maybe[str | None]
+    is_submitted: Maybe[bool]
+    interacted_at: Maybe[datetime | None]
 
     # Nested relations (replace-all when provided)
-    location: Optional[LocationInput] = strawberry.UNSET
-    provided_services: Optional[List[CreateNoteServiceInput]] = strawberry.UNSET
-    requested_services: Optional[List[CreateNoteServiceInput]] = strawberry.UNSET
-    tasks: Optional[List[CreateNoteTaskInput]] = strawberry.UNSET
+    location: Maybe[LocationInput | None]
+    provided_services: Maybe[List[CreateNoteServiceInput] | None]
+    requested_services: Maybe[List[CreateNoteServiceInput] | None]
+    tasks: Maybe[List[CreateNoteTaskInput] | None]
 
 
 @strawberry_django.input(models.Note)

--- a/apps/betterangels-backend/shelters/services.py
+++ b/apps/betterangels-backend/shelters/services.py
@@ -237,8 +237,8 @@ def shelter_create(*, user: "User", data: Dict[str, Any]) -> Shelter:
     Validates that *user* belongs to the target organization before
     creating anything.
 
-    Accepts a plain dict (e.g. from ``strawberry.asdict(data)`` with
-    ``UNSET`` keys already removed).
+    Accepts a plain dict (e.g. from ``strawberry.asdict(data)`` with omitted
+    ``Maybe`` fields already removed).
 
     Raises:
         ``PermissionError`` when the user is not a member of the org.


### PR DESCRIPTION
DEV-2426

## Summary by Sourcery

Adopt Strawberry `Maybe`-based optional input handling and clearer partial-update semantics across GraphQL inputs, updating note import logic and HMIS bridge code to align with the new model.

Bug Fixes:
- Ensure legacy note import payloads using `parentId` correctly resolve a client profile only when no explicit client profile is provided.
- Preserve correct field updates when sending HMIS note changes by adjusting which fields are filtered out from serialized input data.

Enhancements:
- Migrate various GraphQL update input types from `Optional`+`UNSET` patterns to `Maybe` fields to distinguish omitted fields from explicit null values and clarify partial update behavior.
- Simplify note creation during import to rely on the structured input object and `Maybe` semantics instead of manual `UNSET` handling and defaulting.
- Document the new semantics for omitted fields and `Maybe` inputs in notes and shelters code and align related tests accordingly.