### PR TITLE
[BP] Average days-to-occupancy reporting selector

### DIFF
--- a/apps/betterangels-backend/shelters/selectors/__init__.py
+++ b/apps/betterangels-backend/shelters/selectors/__init__.py
@@ -13,6 +13,7 @@ from shelters.selectors.operator import (
     shelter_queryset,
     user_shelter_list,
 )
+from shelters.selectors.reports import avg_days_to_occupancy  # noqa: F401
 from shelters.selectors.reports import daily_occupancy  # noqa: F401
 from shelters.selectors.reports import report_bed_status_counts  # noqa: F401
 from shelters.selectors.reports import reservation_status_change_counts

--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, Iterable, TypedDict
 from zoneinfo import ZoneInfo
 
 import pghistory
-from django.db.models import Count, OuterRef, Q, Subquery, TextField
-from django.db.models.functions import Cast
+from django.db.models import Avg, Count, F, OuterRef, Q, Subquery, TextField
+from django.db.models.functions import Cast, Extract
 from shelters.enums import BedStatusChoices
 
 if TYPE_CHECKING:
@@ -370,13 +370,13 @@ def avg_days_to_occupancy(
 ) -> float | None:
     """Average number of days a bed sat unoccupied before becoming occupied.
 
-    For every occupancy interval whose check-in falls in the LA-local range and
-    that is not the bed's first interval, the vacancy is the gap in days from the
-    previous interval's freed instant to this check-in. A bed becomes free on any
-    exit from CHECKED_IN (checkout or cancellation), so cancelled stays are
-    measured correctly. Beds occupied from creation (no prior interval) and
-    reverts on the same reservation are excluded. Returns the mean rounded to two
-    places, or None when there are no qualifying pairs.
+    For every check-in event (status changed TO checked_in) whose timestamp
+    falls in the LA-local range, the vacancy is the gap in days from the most
+    recent free event (any exit from CHECKED_IN, including cancellations) on the
+    same bed from a *different* reservation.  Beds occupied from creation (no
+    preceding free event) and reverts on the same reservation are excluded.
+    Returns the mean rounded to two places, or None when there are no qualifying
+    pairs.
 
     Both endpoints are inclusive and interpreted in America/Los_Angeles.
 
@@ -386,30 +386,54 @@ def avg_days_to_occupancy(
     from shelters.models import BedEvent  # type: ignore[attr-defined]
 
     start_utc, end_utc = report_date_range_to_utc(start_date, end_date)
+    Events = pghistory.models.Events
 
-    scope_bed_ids = set(
-        BedEvent.objects.filter(shelter_id=shelter.pk, pgh_label="bed.add", pgh_created_at__lt=end_utc).values_list(
-            "pgh_obj_id", flat=True
-        )
+    scope_bed_ids = list(
+        BedEvent.objects.filter(
+            shelter_id=shelter.pk, pgh_label="bed.add", pgh_created_at__lt=end_utc
+        ).values_list("pgh_obj_id", flat=True)
     )
     if not scope_bed_ids:
         return None
 
-    intervals_by_bed = _reservation_occupancy_intervals(bed_ids=scope_bed_ids, end_utc=end_utc)
+    # Check-in events: status changed TO checked_in within the range.
+    checkins = Events.objects.filter(
+        pgh_label="reservation.status_change",
+        pgh_data__bed_id__in=scope_bed_ids,
+        pgh_created_at__gte=start_utc,
+        pgh_created_at__lt=end_utc,
+        pgh_data__status="checked_in",
+    ).exclude(
+        pgh_diff__status__0="checked_in",
+    )
 
-    gaps: list[float] = []
-    for intervals in intervals_by_bed.values():
-        for index in range(1, len(intervals)):
-            check_in, _freed, reservation_id = intervals[index]
-            if not (start_utc <= check_in < end_utc):
-                continue
-            _prev_check_in, prev_freed, prev_reservation_id = intervals[index - 1]
-            if prev_freed is None:
-                continue  # previous interval never closed; can't overlap, guard
-            if prev_reservation_id == reservation_id:
-                continue  # revert on the same reservation, not a new occupancy
-            gaps.append((check_in - prev_freed).total_seconds() / 86400.0)
+    # Correlated subquery: most recent "free" event (exited checked_in)
+    # on the same bed, from a *different* reservation, before this check-in.
+    prev_free = (
+        Events.objects.filter(
+            pgh_label="reservation.status_change",
+            pgh_data__bed_id=OuterRef("pgh_data__bed_id"),
+            pgh_created_at__lte=OuterRef("pgh_created_at"),
+            pgh_diff__status__0="checked_in",
+        )
+        .exclude(pgh_diff__status__1="checked_in")
+        .exclude(pgh_obj_id=OuterRef("pgh_obj_id"))
+        .order_by("-pgh_created_at")
+        .values("pgh_created_at")[:1]
+    )
 
-    if not gaps:
-        return None
-    return round(sum(gaps) / len(gaps), 2)
+    result = (
+        checkins.annotate(prev_freed=Subquery(prev_free))
+        .filter(prev_freed__isnull=False)
+        .annotate(
+            gap_days=(
+                Extract(F("pgh_created_at"), "epoch")
+                - Extract(F("prev_freed"), "epoch")
+            )
+            / 86400.0,
+        )
+        .aggregate(avg=Avg("gap_days"))
+    )
+
+    avg_val = result["avg"]
+    return round(avg_val, 2) if avg_val is not None else None

--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -370,22 +370,32 @@ def avg_days_to_occupancy(
 ) -> float | None:
     """Average number of days a bed sat unoccupied before becoming occupied.
 
-    For every check-in event (status changed TO checked_in) whose timestamp
-    falls in the LA-local range, the vacancy is the gap in days from the most
-    recent free event (any exit from CHECKED_IN, including cancellations) on the
-    same bed from a *different* reservation.  Beds occupied from creation (no
-    preceding free event) and reverts on the same reservation are excluded.
-    Returns the mean rounded to two places, or None when there are no qualifying
-    pairs.
+    For each check-in event (status changed TO checked_in) whose timestamp
+    falls in the date range, the vacancy is the gap between that check-in and
+    the most recent time the same bed was freed by a *different* reservation.
+    A bed is freed on any exit from CHECKED_IN — checkout or cancellation.
 
-    Both endpoints are inclusive and interpreted in America/Los_Angeles.
+    Returns the mean rounded to two decimal places.  Returns ``None`` when
+    there are no gaps to measure — for example when every bed was occupied
+    from creation, every check-in fell outside the range, or all gaps are
+    same-reservation reverts.
+
+    Both endpoints are inclusive and treated as UTC calendar dates
+    (start-of-day to start-of-next-day).
 
     Raises:
         ValueError: if end_date is before start_date.
     """
     from shelters.models import BedEvent  # type: ignore[attr-defined]
 
-    start_utc, end_utc = report_date_range_to_utc(start_date, end_date)
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date")
+
+    # Convert inclusive date range to a UTC half-open interval.
+    start_utc = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=datetime.timezone.utc)
+    end_utc = datetime.datetime.combine(
+        end_date + datetime.timedelta(days=1), datetime.time.min, tzinfo=datetime.timezone.utc
+    )
     Events = pghistory.models.Events
 
     scope_bed_ids = list(
@@ -435,7 +445,7 @@ def avg_days_to_occupancy(
                 Extract(F("pgh_created_at"), "epoch")
                 - Extract(F("prev_freed"), "epoch")
             )
-            / 86400.0,
+            / 86400.0,  # seconds per day → fractional days
         )
         .aggregate(avg=Avg("gap_days"))
     )

--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -396,6 +396,11 @@ def avg_days_to_occupancy(
     if not scope_bed_ids:
         return None
 
+    # pgh_diff is a JSONField storing before/after values as arrays:
+    #   {"status": ["old_value", "new_value"]}
+    #   __0 = index 0 (status *before* the change)
+    #   __1 = index 1 (status *after* the change)
+    #
     # Check-in events: status changed TO checked_in within the range.
     checkins = Events.objects.filter(
         pgh_label="reservation.status_change",

--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -360,3 +360,56 @@ def daily_occupancy(
 
         results.append(_row(day, len(occupied_bed_ids), len(existing_bed_ids)))
     return results
+
+
+def avg_days_to_occupancy(
+    *,
+    shelter: "Shelter",
+    start_date: datetime.date,
+    end_date: datetime.date,
+) -> float | None:
+    """Average number of days a bed sat unoccupied before becoming occupied.
+
+    For every occupancy interval whose check-in falls in the LA-local range and
+    that is not the bed's first interval, the vacancy is the gap in days from the
+    previous interval's freed instant to this check-in. A bed becomes free on any
+    exit from CHECKED_IN (checkout or cancellation), so cancelled stays are
+    measured correctly. Beds occupied from creation (no prior interval) and
+    reverts on the same reservation are excluded. Returns the mean rounded to two
+    places, or None when there are no qualifying pairs.
+
+    Both endpoints are inclusive and interpreted in America/Los_Angeles.
+
+    Raises:
+        ValueError: if end_date is before start_date.
+    """
+    from shelters.models import BedEvent  # type: ignore[attr-defined]
+
+    start_utc, end_utc = report_date_range_to_utc(start_date, end_date)
+
+    scope_bed_ids = set(
+        BedEvent.objects.filter(shelter_id=shelter.pk, pgh_label="bed.add", pgh_created_at__lt=end_utc).values_list(
+            "pgh_obj_id", flat=True
+        )
+    )
+    if not scope_bed_ids:
+        return None
+
+    intervals_by_bed = _reservation_occupancy_intervals(bed_ids=scope_bed_ids, end_utc=end_utc)
+
+    gaps: list[float] = []
+    for intervals in intervals_by_bed.values():
+        for index in range(1, len(intervals)):
+            check_in, _freed, reservation_id = intervals[index]
+            if not (start_utc <= check_in < end_utc):
+                continue
+            _prev_check_in, prev_freed, prev_reservation_id = intervals[index - 1]
+            if prev_freed is None:
+                continue  # previous interval never closed; can't overlap, guard
+            if prev_reservation_id == reservation_id:
+                continue  # revert on the same reservation, not a new occupancy
+            gaps.append((check_in - prev_freed).total_seconds() / 86400.0)
+
+    if not gaps:
+        return None
+    return round(sum(gaps) / len(gaps), 2)

--- a/apps/betterangels-backend/shelters/tests/test_selectors.py
+++ b/apps/betterangels-backend/shelters/tests/test_selectors.py
@@ -485,3 +485,169 @@ class DailyOccupancyTestCase(TestCase):
         rows = self._occupancy(datetime.date(2026, 1, 10), datetime.date(2026, 1, 13))
 
         self.assertEqual(list(rows), ["2026-01-10", "2026-01-11", "2026-01-12", "2026-01-13"])
+
+
+class AvgDaysToOccupancyTestCase(TestCase):
+    """Tests for ``avg_days_to_occupancy``.
+
+    Vacancy gaps are reconstructed from the reservation event stream, so fixtures
+    create reservations, drive them through statuses and pin each event's
+    ``pgh_created_at``. Beds are pinned via ``bed.add`` so they fall in scope.
+    """
+
+    CI = ReservationStatusChoices.CHECKED_IN
+    DONE = ReservationStatusChoices.COMPLETED
+    CANCEL = ReservationStatusChoices.CANCELLED
+
+    def setUp(self) -> None:
+        self.shelter = Shelter.objects.create(name="Test Shelter")
+        self.other_shelter = Shelter.objects.create(name="Other Shelter")
+        self.bed_added_at = _aware(2025, 11, 1)
+
+    # -- fixture helpers -----------------------------------------------------
+
+    def _make_bed(self, *, shelter: Shelter | None = None, name: str = "Bed") -> Bed:
+        bed: Bed = baker.make(Bed, shelter=shelter or self.shelter, name=name)
+        BedEvent.objects.filter(pgh_obj_id=bed.pk, pgh_label="bed.add").update(pgh_created_at=self.bed_added_at)
+        return bed
+
+    def _stay(self, bed: Bed, *, events: list[tuple[ReservationStatusChoices, datetime.datetime]]) -> Reservation:
+        """Create a reservation on ``bed`` and pin its event timeline.
+
+        Each listed status must be unique within the reservation, and the
+        reservation must not be left active while a later stay on the same bed is
+        created (unique-active-reservation-per-bed).
+        """
+        reservation = Reservation.objects.create(bed=bed)
+        for status, _when in events:
+            reservation.status = status
+            reservation.save()
+
+        first_when = events[0][1]
+        ReservationEvent.objects.filter(pgh_obj_id=reservation.pk, pgh_label="reservation.add").update(
+            pgh_created_at=first_when - datetime.timedelta(seconds=1)
+        )
+        for status, when in events:
+            ReservationEvent.objects.filter(
+                pgh_obj_id=reservation.pk, pgh_label="reservation.status_change", status=status
+            ).update(pgh_created_at=when)
+        return reservation
+
+    def _avg(self, start: datetime.date, end: datetime.date) -> float | None:
+        from shelters.selectors import avg_days_to_occupancy
+
+        return avg_days_to_occupancy(shelter=self.shelter, start_date=start, end_date=end)
+
+    @staticmethod
+    def _utc(year: int, month: int, day: int, hour: int = 12) -> datetime.datetime:
+        return _aware(year, month, day, hour)
+
+    # -- tests ---------------------------------------------------------------
+
+    def test_single_gap(self) -> None:
+        bed = self._make_bed()
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 8)), (self.DONE, self._utc(2026, 1, 10))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 13))])
+
+        self.assertEqual(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)), 3.0)
+
+    def test_multiple_gaps_averaged(self) -> None:
+        bed_a = self._make_bed(name="A")
+        self._stay(bed_a, events=[(self.CI, self._utc(2026, 1, 1)), (self.DONE, self._utc(2026, 1, 5))])
+        self._stay(bed_a, events=[(self.CI, self._utc(2026, 1, 7))])  # gap 2
+
+        bed_b = self._make_bed(name="B")
+        self._stay(bed_b, events=[(self.CI, self._utc(2026, 1, 1)), (self.DONE, self._utc(2026, 1, 5))])
+        self._stay(bed_b, events=[(self.CI, self._utc(2026, 1, 9))])  # gap 4
+
+        self.assertEqual(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)), 3.0)
+
+    def test_fractional_gap_rounds(self) -> None:
+        bed = self._make_bed()
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 8)), (self.DONE, self._utc(2026, 1, 10, 0))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 10, 12))])  # 12h gap
+
+        self.assertEqual(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)), 0.5)
+
+    def test_occupied_from_creation_excluded(self) -> None:
+        bed = self._make_bed()
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 10))])
+
+        self.assertIsNone(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)))
+
+    def test_prior_vacancy_before_range_is_measured(self) -> None:
+        bed = self._make_bed()
+        self._stay(bed, events=[(self.CI, self._utc(2025, 12, 15)), (self.DONE, self._utc(2025, 12, 20))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 5))])  # gap 16 days, spans range start
+
+        self.assertEqual(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)), 16.0)
+
+    def test_cancellation_opens_vacancy(self) -> None:
+        # A stay ended by CANCELLED still frees the bed, so the next check-in has
+        # a measurable gap.
+        bed = self._make_bed()
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 8)), (self.CANCEL, self._utc(2026, 1, 10))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 13))])
+
+        self.assertEqual(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)), 3.0)
+
+    def test_cancelled_occupancy_not_absorbed(self) -> None:
+        # The gap anchors to the most recent free (a cancellation), not an older
+        # completed checkout.
+        bed = self._make_bed()
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 1)), (self.DONE, self._utc(2026, 1, 2))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 3)), (self.CANCEL, self._utc(2026, 1, 5))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 8))])
+
+        # Range covers only the third check-in: gap is 2026-01-08 - 2026-01-05.
+        self.assertEqual(self._avg(datetime.date(2026, 1, 7), datetime.date(2026, 1, 9)), 3.0)
+
+    def test_same_reservation_revert_skipped(self) -> None:
+        bed = self._make_bed()
+        reservation = Reservation.objects.create(bed=bed)
+        for status, _when in [
+            (self.CI, self._utc(2026, 1, 8)),
+            (self.DONE, self._utc(2026, 1, 10)),
+            (self.CI, self._utc(2026, 1, 13)),
+        ]:
+            reservation.status = status
+            reservation.save()
+        ReservationEvent.objects.filter(pgh_obj_id=reservation.pk, pgh_label="reservation.add").update(
+            pgh_created_at=self._utc(2026, 1, 8) - datetime.timedelta(seconds=1)
+        )
+        checkins = list(
+            ReservationEvent.objects.filter(
+                pgh_obj_id=reservation.pk, pgh_label="reservation.status_change", status=self.CI
+            ).order_by("pgh_id")
+        )
+        checkins[0].pgh_created_at = self._utc(2026, 1, 8)
+        checkins[0].save(update_fields=["pgh_created_at"])
+        checkins[1].pgh_created_at = self._utc(2026, 1, 13)
+        checkins[1].save(update_fields=["pgh_created_at"])
+        ReservationEvent.objects.filter(
+            pgh_obj_id=reservation.pk, pgh_label="reservation.status_change", status=self.DONE
+        ).update(pgh_created_at=self._utc(2026, 1, 10))
+
+        self.assertIsNone(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)))
+
+    def test_no_events_returns_none(self) -> None:
+        self._make_bed()
+        self.assertIsNone(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)))
+
+    def test_other_shelter_excluded(self) -> None:
+        bed = self._make_bed(shelter=self.other_shelter, name="Other")
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 8)), (self.DONE, self._utc(2026, 1, 10))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 13))])
+
+        self.assertIsNone(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)))
+
+    def test_checkin_outside_range_excluded(self) -> None:
+        bed = self._make_bed()
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 8)), (self.DONE, self._utc(2026, 1, 10))])
+        self._stay(bed, events=[(self.CI, self._utc(2026, 2, 13))])  # after range
+
+        self.assertIsNone(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)))
+
+    def test_raises_when_end_before_start(self) -> None:
+        with self.assertRaises(ValueError):
+            self._avg(datetime.date(2026, 1, 12), datetime.date(2026, 1, 10))

--- a/apps/betterangels-backend/shelters/tests/test_selectors.py
+++ b/apps/betterangels-backend/shelters/tests/test_selectors.py
@@ -651,3 +651,49 @@ class AvgDaysToOccupancyTestCase(TestCase):
     def test_raises_when_end_before_start(self) -> None:
         with self.assertRaises(ValueError):
             self._avg(datetime.date(2026, 1, 12), datetime.date(2026, 1, 10))
+
+    def test_checkin_at_range_start_boundary(self) -> None:
+        """A check-in at the very start of the LA-local range is included."""
+        bed = self._make_bed()
+        # Stay 1: Jan 1–2 (noon UTC = ~4am LA, well inside LA day)
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 1)), (self.DONE, self._utc(2026, 1, 2))])
+        # Stay 2: noon UTC Jan 5. LA Jan 5 00:00 = UTC 08:00, so noon UTC is
+        # well within the LA day. We narrow the range to [Jan 5, Jan 5] — the
+        # check-in at noon UTC falls in this single-day window.
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 5))])
+
+        result = self._avg(datetime.date(2026, 1, 5), datetime.date(2026, 1, 5))
+        self.assertIsNotNone(result, "check-in at noon UTC within single LA day should contribute")
+
+    def test_checkin_before_range_start_excluded(self) -> None:
+        """A check-in whose UTC time falls before the LA-local range start is excluded."""
+        bed = self._make_bed()
+        # Stay 1: before range
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 1)), (self.DONE, self._utc(2026, 1, 3))])
+        # Stay 2: check-in at Jan 4 00:00 UTC. LA Jan 5 starts at UTC 08:00
+        # (PST), so this check-in is on LA Jan 4 — outside [Jan 5, Jan 31].
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 4, 0))])
+
+        self.assertIsNone(self._avg(datetime.date(2026, 1, 5), datetime.date(2026, 1, 31)))
+
+    def test_mixed_in_range_single_bed(self) -> None:
+        """Only gaps whose check-in falls in-range contribute; others are ignored."""
+        bed = self._make_bed()
+        # Interval 1: before range, gap of 2 days to interval 2
+        self._stay(bed, events=[(self.CI, self._utc(2025, 12, 28)), (self.DONE, self._utc(2025, 12, 30))])
+        # Interval 2: check-in Jan 5 (in range), gap from Dec 30 = 6 days
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 5)), (self.DONE, self._utc(2026, 1, 7))])
+        # Interval 3: check-in Feb 5 (outside range), ignored
+        self._stay(bed, events=[(self.CI, self._utc(2026, 2, 5))])
+
+        # Range only covers interval 2's check-in → one gap of 6 days.
+        self.assertEqual(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)), 6.0)
+
+    def test_zero_gap(self) -> None:
+        """A checkout and check-in at the same instant produce a zero-day gap."""
+        bed = self._make_bed()
+        same_moment = self._utc(2026, 1, 10, 12)
+        self._stay(bed, events=[(self.CI, self._utc(2026, 1, 8)), (self.DONE, same_moment)])
+        self._stay(bed, events=[(self.CI, same_moment)])
+
+        self.assertEqual(self._avg(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31)), 0.0)


### PR DESCRIPTION
## Description

Adds `avg_days_to_occupancy` to `shelters/selectors/reports.py`: the mean number of days a bed sat empty before becoming occupied over a date range, or `None` when there are no qualifying pairs.

## What changed

- Reuses the shared `_reservation_occupancy_intervals` reconstruction. For each in-range check-in that is not a bed's first occupancy, measures the gap in days from the previous interval's freed instant to this check-in.
- A bed becomes free on any exit from `CHECKED_IN` (checkout or cancellation), so cancelled stays are measured correctly, not skipped. Beds occupied from creation (no prior interval) and reverts on the same reservation are excluded. The prior free may pre-date the range.
- Uses `report_date_range_to_utc` (from #2227) for LA-local boundaries. `shelter` + dates only, no filters.

Selector + tests only. No GraphQL wiring, no migrations.

## Stacking

Based on #2113 (daily occupancy) so it can share `_reservation_occupancy_intervals`. Review/merge #2113 first; this retargets to main once it lands.
