### PR TITLE
[DO NOT MERGE] Spike: client-side PDF export for shelter report (react-to-pdf)

### DIFF
--- a/libs/react/shelter-operator/src/lib/OperatorApp.tsx
+++ b/libs/react/shelter-operator/src/lib/OperatorApp.tsx
@@ -5,6 +5,7 @@ import { OperatorLayout } from './components/layout/OperatorLayout';
 import { UsersPage } from './pages';
 import { Dashboard } from './pages/dashboard/Dashboard';
 import ShelterDashboardPage from './pages/dashboard/ShelterDashboardPage';
+import { ShelterReportPage } from './pages/report/ShelterReportPage';
 import { CreateShelterForm } from './pages/dashboard/components/create-shelter-form';
 import { AddProfilePage } from './pages/reservation/AddProfilePage';
 import { CheckInByDate } from './pages/reservation/CheckInByDate';
@@ -98,6 +99,10 @@ export function OperatorApp() {
                 element={<ShelterDashboardPage tab="label" />}
               />
             </Route>
+            <Route
+              path={routePath(paths.shelterReport)}
+              element={<ShelterReportPage />}
+            />
             <Route
               path={`${routePath(paths.reservation)}/*`}
               element={<ReservationPage />}

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
@@ -1,0 +1,55 @@
+import { Download } from 'lucide-react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { usePDF } from 'react-to-pdf';
+import { Button } from '../../components/base-ui/buttons/buttons';
+import { ShelterReportPrint } from './ShelterReportPrint';
+import { mockReport } from './mockReport';
+
+/**
+ * Route wrapper for the shelter PDF report.
+ *
+ * Spike scope: renders mock data and proves the client-side react-to-pdf
+ * export works end-to-end. Real `useQuery` wiring (mirroring
+ * `GetAdminShelterOverview`) comes later.
+ */
+export function ShelterReportPage() {
+  const { shelterId } = useParams<{ shelterId: string }>();
+  const [isExporting, setIsExporting] = useState(false);
+
+  const { toPDF, targetRef } = usePDF({
+    filename: `shelter-report-${shelterId ?? 'unknown'}.pdf`,
+    page: { format: 'letter', orientation: 'portrait', margin: 10 },
+  });
+
+  async function handleExport() {
+    setIsExporting(true);
+    try {
+      await toPDF();
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  return (
+    <div className="px-6 py-8">
+      <div className="mx-auto mb-4 flex max-w-[800px] justify-end">
+        <Button
+          variant="primary"
+          color="blue"
+          leftIcon={<Download size={20} />}
+          onClick={handleExport}
+          disabled={isExporting}
+        >
+          {isExporting ? 'Exporting…' : 'Export PDF'}
+        </Button>
+      </div>
+
+      {/* targetRef marks the DOM captured into the PDF; the button above is
+          intentionally outside it so it isn't included in the output. */}
+      <ShelterReportPrint ref={targetRef} data={mockReport} />
+    </div>
+  );
+}
+
+export default ShelterReportPage;

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.tsx
@@ -1,0 +1,87 @@
+import { forwardRef } from 'react';
+import { Text } from '../../components/base-ui/text/text';
+import './report.css';
+import { ShelterReportData } from './types';
+
+// Matches the card styling used in components/overview/OverviewView.tsx so the
+// report reads consistently with the rest of the operator UI.
+const cardClassName = 'rounded-xl border border-[#E5E7EB] bg-white p-5';
+
+function SummaryRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="flex items-center justify-between py-2 text-sm">
+      <span className="text-[#6B7280]">{label}</span>
+      <span className="font-medium text-[#111827]">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Presentational, chrome-less report body — the DOM that react-to-pdf
+ * rasterizes into the PDF. Pure props in, no data fetching.
+ */
+export const ShelterReportPrint = forwardRef<
+  HTMLDivElement,
+  { data: ShelterReportData }
+>(function ShelterReportPrint({ data }, ref) {
+  const { bedsByStatus, roomsByStatus } = data;
+
+  return (
+    <div ref={ref} className="shelter-report-print p-8">
+      <div className="mb-6">
+        <Text variant="header-md" className="block text-[#111827]">
+          Shelter Report
+        </Text>
+        <Text variant="caption" className="block">
+          {data.name}
+        </Text>
+      </div>
+
+      <div className="grid gap-4">
+        <section className={cardClassName}>
+          <h3 className="text-base font-semibold text-[#111827]">
+            Shelter Summary
+          </h3>
+          <div className="mt-3 divide-y divide-[#F3F4F6]">
+            <SummaryRow label="Name" value={data.name} />
+            <SummaryRow label="Organization" value={data.organization.name} />
+            <SummaryRow label="Address" value={data.location.place} />
+          </div>
+        </section>
+
+        <section className={cardClassName}>
+          <h3 className="text-base font-semibold text-[#111827]">Bed Summary</h3>
+          <div className="mt-3 divide-y divide-[#F3F4F6]">
+            <SummaryRow label="Available" value={bedsByStatus.available} />
+            <SummaryRow label="Occupied" value={bedsByStatus.occupied} />
+            <SummaryRow label="Reserved" value={bedsByStatus.reserved} />
+            <SummaryRow
+              label="Out of Service"
+              value={bedsByStatus.outOfService}
+            />
+          </div>
+        </section>
+
+        <section className={cardClassName}>
+          <h3 className="text-base font-semibold text-[#111827]">
+            Room Summary
+          </h3>
+          <div className="mt-3 divide-y divide-[#F3F4F6]">
+            <SummaryRow label="Available" value={roomsByStatus.available} />
+            <SummaryRow label="Reserved" value={roomsByStatus.reserved} />
+            <SummaryRow
+              label="Needs Maintenance"
+              value={roomsByStatus.needsMaintenance}
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+});

--- a/libs/react/shelter-operator/src/lib/pages/report/mockReport.ts
+++ b/libs/react/shelter-operator/src/lib/pages/report/mockReport.ts
@@ -1,0 +1,23 @@
+import { ShelterReportData } from './types';
+
+/** Stand-in report data for the spike; replace with a real `useQuery` later. */
+export const mockReport: ShelterReportData = {
+  name: 'Riverside Emergency Shelter',
+  organization: {
+    name: 'City Outreach Network',
+  },
+  location: {
+    place: '482 Riverside Ave, Springfield',
+  },
+  bedsByStatus: {
+    available: 18,
+    occupied: 42,
+    reserved: 6,
+    outOfService: 4,
+  },
+  roomsByStatus: {
+    available: 5,
+    reserved: 2,
+    needsMaintenance: 1,
+  },
+};

--- a/libs/react/shelter-operator/src/lib/pages/report/report.css
+++ b/libs/react/shelter-operator/src/lib/pages/report/report.css
@@ -1,0 +1,14 @@
+/*
+ * Layout styles for the printable shelter report.
+ *
+ * For the client-side react-to-pdf (html2canvas) capture we only need a fixed,
+ * predictable width so the rasterized output fits one letter-size page. No
+ * @page / print-media rules are required here — those belong to the
+ * server-side Playwright approach, not this slice.
+ */
+.shelter-report-print {
+  width: 800px;
+  max-width: 800px;
+  margin: 0 auto;
+  background: #ffffff;
+}

--- a/libs/react/shelter-operator/src/lib/pages/report/types.ts
+++ b/libs/react/shelter-operator/src/lib/pages/report/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Shape of the data rendered into the shelter PDF report.
+ *
+ * Mirrors the `adminShelter` fields already fetched by
+ * `components/overview/OverviewView.tsx` so this can later be wired to the same
+ * `GetAdminShelterOverview` query instead of mock data.
+ */
+export interface ShelterReportData {
+  name: string;
+  organization: {
+    name: string;
+  };
+  location: {
+    place: string;
+  };
+  bedsByStatus: {
+    available: number;
+    occupied: number;
+    reserved: number;
+    outOfService: number;
+  };
+  roomsByStatus: {
+    available: number;
+    reserved: number;
+    needsMaintenance: number;
+  };
+}

--- a/libs/react/shelter-operator/src/lib/routing/routePaths.ts
+++ b/libs/react/shelter-operator/src/lib/routing/routePaths.ts
@@ -19,6 +19,7 @@ export const paths = {
   shelter: '/operator/shelter/:shelterId',
   shelterCreate: '/operator/shelter/create',
   shelterManage: '/operator/shelter/:shelterId/manage',
+  shelterReport: '/operator/shelter/:shelterId/report',
   shelterProfile: '/operator/shelter/:shelterId/profile',
   shelterReservation: '/operator/shelter/:shelterId/reservation',
   reservation: '/operator/reservation',

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-native-web": "0.21.2",
     "react-native-worklets": "0.7.4",
     "react-router-dom": "6.30.3",
+    "react-to-pdf": "^3.2.2",
     "remeda": "^2.20.0",
     "rxjs": "^7.8.2",
     "sanitize-html": "^2.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,6 +2296,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.28.6":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10/9883b4951787779fd382b121f22f92966d85f19434841f65fb00b2dfec232107e139683f47c6f252891826ad8ee18317b46c3a0e4819116a9885f47b46d7126a
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.0.0, @babel/template@npm:^7.18.10, @babel/template@npm:^7.20.7, @babel/template@npm:^7.25.0, @babel/template@npm:^7.28.6, @babel/template@npm:^7.3.3":
   version: 7.28.6
   resolution: "@babel/template@npm:7.28.6"
@@ -5966,6 +5973,7 @@ __metadata:
     react-refresh: "npm:^0.18.0"
     react-router-dom: "npm:6.30.3"
     react-test-renderer: "npm:19.2.0"
+    react-to-pdf: "npm:^3.2.2"
     remeda: "npm:^2.20.0"
     rxjs: "npm:^7.8.2"
     sanitize-html: "npm:^2.17.0"
@@ -11326,10 +11334,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pako@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "@types/pako@npm:2.0.4"
+  checksum: 10/9be5167f5cb45d405d92e8b320219e6d26f244880893425abb16b998cde0386185f048d60de609672f1e8654c44b77344e754138da3784460f4543fe8576fa62
+  languageName: node
+  linkType: hard
+
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.2
   resolution: "@types/parse-json@npm:4.0.2"
   checksum: 10/5bf62eec37c332ad10059252fc0dab7e7da730764869c980b0714777ad3d065e490627be9f40fc52f238ffa3ac4199b19de4127196910576c2fe34dd47c7a470
+  languageName: node
+  linkType: hard
+
+"@types/raf@npm:^3.4.0":
+  version: 3.4.3
+  resolution: "@types/raf@npm:3.4.3"
+  checksum: 10/70b0d8ce4ed1fdd60abbee8ff2a572bd2947bd764691f98ef948748375f5012db7ee39a037dd063cfbbb52c0b7479bec68111bbb95ce5de023ec581794c9b85f
   languageName: node
   linkType: hard
 
@@ -11442,6 +11464,13 @@ __metadata:
   version: 1.0.3
   resolution: "@types/treeify@npm:1.0.3"
   checksum: 10/777e579b30a916a781e7cbad2b7a76bc5473ff7bfe7167dd6de47f80f4386df5bf3d0dc34170afb75d52e75f6ed61cc109abf2324e093c1f9ecd4e79fec58d0c
+  languageName: node
+  linkType: hard
+
+"@types/trusted-types@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@types/trusted-types@npm:2.0.7"
+  checksum: 10/8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
   languageName: node
   linkType: hard
 
@@ -14451,6 +14480,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"canvg@npm:^3.0.11":
+  version: 3.0.11
+  resolution: "canvg@npm:3.0.11"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/raf": "npm:^3.4.0"
+    core-js: "npm:^3.8.3"
+    raf: "npm:^3.4.1"
+    regenerator-runtime: "npm:^0.13.7"
+    rgbcolor: "npm:^1.0.1"
+    stackblur-canvas: "npm:^2.0.0"
+    svg-pathdata: "npm:^6.0.3"
+  checksum: 10/2200a5f5e147a668d27205e27530d37433ee1ed55a619d192e11716c13295c133fcd7e0c7326b93201305d83e22e88f3d98acc05b43582f1d3ad63528e0b94ff
+  languageName: node
+  linkType: hard
+
 "capital-case@npm:^1.0.4":
   version: 1.0.4
   resolution: "capital-case@npm:1.0.4"
@@ -15210,6 +15255,13 @@ __metadata:
   version: 3.36.1
   resolution: "core-js@npm:3.36.1"
   checksum: 10/ce1e1bfc1034b6f2ff7c91077319e8abdd650ee606ffe6e80073e64ab9d8aad2d6a6d953461b01f331a6f796ad2fd766a3386b88aa371b45d44fa7c0b9913ce6
+  languageName: node
+  linkType: hard
+
+"core-js@npm:^3.6.0, core-js@npm:^3.8.3":
+  version: 3.49.0
+  resolution: "core-js@npm:3.49.0"
+  checksum: 10/31d018f9830b0240ae40869e380595f2d06a8800709ad63299a42a438ba0c8d5805045fa02a20a78f42761d83103b0b71eca982955f5e890fb7cf6b2fe6a9ab1
   languageName: node
   linkType: hard
 
@@ -16374,6 +16426,18 @@ __metadata:
   version: 2.1.7
   resolution: "domino@npm:2.1.7"
   checksum: 10/15b7aed1073abc6148a8aafe5b29143f93a2c5f7161b3cdabc9226905fd3e19f736d26bee0fb929a0a016966680d5ca93760ddf573d46ebc0e687a98a4e85ca9
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.1":
+  version: 3.4.8
+  resolution: "dompurify@npm:3.4.8"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/d661322889a8938bfb99ee27853e9e78661949398e803f344865fd94f8378a494efadd329faea0b16e8085efae1bfeed5f5df372909c3a2be3e583686a0a48fa
   languageName: node
   linkType: hard
 
@@ -18372,6 +18436,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-png@npm:^6.2.0":
+  version: 6.4.0
+  resolution: "fast-png@npm:6.4.0"
+  dependencies:
+    "@types/pako": "npm:^2.0.3"
+    iobuffer: "npm:^5.3.2"
+    pako: "npm:^2.1.0"
+  checksum: 10/b6eaf71f5f5e6e9e6b56ea9f60f214cbe1879e309d47eb7fc5fcf1ed85fb284cd4483ab128e2259389d4db8ef22e266b54853386b8362bae3babb0e4dc626347
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:^3.0.1":
   version: 3.1.0
   resolution: "fast-uri@npm:3.1.0"
@@ -18479,6 +18554,13 @@ __metadata:
   version: 4.1.1
   resolution: "fetch-retry@npm:4.1.1"
   checksum: 10/c97006c2b604a817cbd4e35085965d07a8f1c51b475bf037f305b98d5748ee742ec98aba119b4df6bf727e61f2f0ee05c5fa714701c4234b91c4b43e0f119bd9
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.8.1":
+  version: 0.8.3
+  resolution: "fflate@npm:0.8.3"
+  checksum: 10/6ebf528dc9c56e78e715eac615b009b25dc33e15c1920b11ebba44e6d76181c647756a81a23e19247907496b93aa99928514c53090579a65109e026ac2824aa7
   languageName: node
   linkType: hard
 
@@ -19795,7 +19877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html2canvas@npm:^1.4.1":
+"html2canvas@npm:^1.0.0-rc.5, html2canvas@npm:^1.4.1":
   version: 1.4.1
   resolution: "html2canvas@npm:1.4.1"
   dependencies:
@@ -20200,6 +20282,13 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.0.0"
   checksum: 10/cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
+  languageName: node
+  linkType: hard
+
+"iobuffer@npm:^5.3.2":
+  version: 5.4.0
+  resolution: "iobuffer@npm:5.4.0"
+  checksum: 10/7f7afe12ee94e34dcf129a5fbb38838f63d6502970f5aa4722c728d65b90ac828c660cd5ec5423bd2b4f348483ba8d6f3e3ad9a5908810bc0f4fae774b3f0e39
   languageName: node
   linkType: hard
 
@@ -22264,6 +22353,30 @@ __metadata:
   dependencies:
     debug: "npm:^2.1.3"
   checksum: 10/90aabd9deb3a9ba83aedf8d40e1aaff1fc29f3f3fe42985a661782498dde526a7cd9b7bec4b8721f7d0beafab9e5ccfdafd46640f7dd6c58d529a6bb5238e2b8
+  languageName: node
+  linkType: hard
+
+"jspdf@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "jspdf@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.6"
+    canvg: "npm:^3.0.11"
+    core-js: "npm:^3.6.0"
+    dompurify: "npm:^3.3.1"
+    fast-png: "npm:^6.2.0"
+    fflate: "npm:^0.8.1"
+    html2canvas: "npm:^1.0.0-rc.5"
+  dependenciesMeta:
+    canvg:
+      optional: true
+    core-js:
+      optional: true
+    dompurify:
+      optional: true
+    html2canvas:
+      optional: true
+  checksum: 10/594dd7c1f34a3d9c48e555be2a8e664b5875c2709e1e83490a0fe20d953b35d96193ecbeaba4aa751020d2b63c8c8a82bb91c73660a775d6f8b2bef4f9ca11b0
   languageName: node
   linkType: hard
 
@@ -25132,6 +25245,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "pako@npm:2.1.0"
+  checksum: 10/38a04991d0ec4f4b92794a68b8c92bf7340692c5d980255c92148da96eb3e550df7a86a7128b5ac0c65ecddfe5ef3bbe9c6dab13e1bc315086e759b18f7c1401
+  languageName: node
+  linkType: hard
+
 "param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
@@ -25363,6 +25483,13 @@ __metadata:
   version: 1.2.0
   resolution: "pend@npm:1.2.0"
   checksum: 10/6c72f5243303d9c60bd98e6446ba7d30ae29e3d56fdb6fae8767e8ba6386f33ee284c97efe3230a0d0217e2b1723b8ab490b1bbf34fcbb2180dbc8a9de47850d
+  languageName: node
+  linkType: hard
+
+"performance-now@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "performance-now@npm:2.1.0"
+  checksum: 10/534e641aa8f7cba160f0afec0599b6cecefbb516a2e837b512be0adbe6c1da5550e89c78059c7fabc5c9ffdf6627edabe23eb7c518c4500067a898fa65c2b550
   languageName: node
   linkType: hard
 
@@ -25922,6 +26049,15 @@ __metadata:
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: 10/a516faa25574be7947969883e6068dbe4aa19e8ef8e8e0fd96cddd6d36485e9106d85c0041a27153286b0770b381328f4072aa40d3b18a19f5f7d2b78b94b5ed
+  languageName: node
+  linkType: hard
+
+"raf@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "raf@npm:3.4.1"
+  dependencies:
+    performance-now: "npm:^2.1.0"
+  checksum: 10/4c4b4c826b09d2aec6ca809f1a3c3c12136e7ec8d13fbb91f495dd2c99cd43345240e003da3bfd16036a432e635049fc6d9f69f9187f5f22ea88bb146ec75881
   languageName: node
   linkType: hard
 
@@ -26585,6 +26721,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-to-pdf@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "react-to-pdf@npm:3.2.2"
+  dependencies:
+    html2canvas: "npm:^1.4.1"
+    jspdf: "npm:^4.2.1"
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: 10/333ce95e37478d334404d44251caa11af88faaec6a95b3ac2a4507f75bad77e2bd5692eac78f25c8fad6a7c5a20699b04aafb2cb9ff7e604a3cf080c58200f55
+  languageName: node
+  linkType: hard
+
 "react@npm:19.2.0":
   version: 19.2.0
   resolution: "react@npm:19.2.0"
@@ -26711,7 +26860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.2":
+"regenerator-runtime@npm:^0.13.2, regenerator-runtime@npm:^0.13.7":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 10/d493e9e118abef5b099c78170834f18540c4933cedf9bfabc32d3af94abfb59a7907bd7950259cbab0a929ebca7db77301e8024e5121e6482a82f78283dfd20c
@@ -27067,6 +27216,13 @@ __metadata:
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10/2f3d11d3d8929b4bfeefc9acb03aae90f971401de0add5ae6c5e38fec14f0405e6a4aad8fdb76344bfdd20c5193110e3750cbbd28ba86d73729d222b6cf4a729
+  languageName: node
+  linkType: hard
+
+"rgbcolor@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "rgbcolor@npm:1.0.1"
+  checksum: 10/afa76637181017e13dfc39debcc41f2f994a1b7c807cc863ba53bc03268ed7a28411094c1008185446b60a9d87131abae392acbe851c96f6dcf9994497019938
   languageName: node
   linkType: hard
 
@@ -28108,6 +28264,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackblur-canvas@npm:^2.0.0":
+  version: 2.7.0
+  resolution: "stackblur-canvas@npm:2.7.0"
+  checksum: 10/ad20aa886f5141c69b682cb8dd88ee04822f7dfa9f566d0657cf8fa43f5dd69122fe42dbc7071d44f655da89784756d34705b12d03f1c1f928325a55c698ab51
+  languageName: node
+  linkType: hard
+
 "stackframe@npm:^1.3.4":
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
@@ -28691,6 +28854,13 @@ __metadata:
   version: 1.1.0
   resolution: "svg-path-parser@npm:1.1.0"
   checksum: 10/b8989e8184aec300ead32fa507ac2b35f562d7b9e6a90ffebd8cec1cd8e9a713ace1d35b81803a72d235f46709cfc356a8774540f651554770e0245d3d87dc54
+  languageName: node
+  linkType: hard
+
+"svg-pathdata@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "svg-pathdata@npm:6.0.3"
+  checksum: 10/ed20b3fd20fd2f9dfa519fee2a690ec6bff84be00882c04b1461d6e5a250da3e37236c1f3abe2dae9c8dae841cc33f2700396186f894e1953dc6c0149201ac21
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Feasibility (Edited):
 
Not Possible: react-to-pdf is not compatible with Better Angel's Tailwind v4.

## What this is

A **draft spike** proving the client-side "Export PDF" feature is feasible before building the full thing. Thin slice, mock data, strict `react-to-pdf`. See `docs/handoff-client-pdf-export.md` for the full feature.

## What's here

- **Add `react-to-pdf@^3.2.2`** (html2canvas under the hood). Installs cleanly under yarn 4.2.2 / Node 22.21.1.
- **New `libs/react/shelter-operator/src/lib/pages/report/`** skeleton:
  - `ShelterReportPrint.tsx` — chrome-less presentational report body (the DOM captured into the PDF); reuses `OverviewView` card styling + base-ui `Text`.
  - `ShelterReportPage.tsx` — route wrapper. `usePDF({ filename, page: { format: 'letter', orientation: 'portrait', margin: 10 } })`; `Export PDF` `Button` (Download icon) sits **outside** the `targetRef` so it isn't captured; `isExporting` disables it while running.
  - `mockReport.ts`, `types.ts` (`ShelterReportData` mirrors the `adminShelter` overview fields), `report.css` (fixed 800px width for predictable capture).
- **Route**: `/operator/shelter/:shelterId/report` added to `routePaths.ts` + `OperatorApp.tsx`.

## Verified

- ✅ `react-to-pdf` installs; `package.json` / `yarn.lock` diff isolated to it + its deps.
- ✅ `nx typecheck react-shelter-operator` passes — the `usePDF`/`targetRef` integration compiles against base-ui components and routing.

## Not yet verified (needs a manual browser check)

- ⏳ The actual click → download. Run `npx nx serve shelter-web` (Node 22.21.1), go to `/operator/shelter/<id>/report`, click **Export PDF**, confirm `shelter-report-<id>.pdf` downloads with content/styling intact. Per plan, if html2canvas renders poorly we **note & stop** rather than swapping libraries.

## Out of scope

Real GraphQL wiring, multi-page/scaling polish, cross-browser matrix, occupancy-tab integration, server-side print work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a client-side PDF export spike for the shelter operator report using a new printable report page and route.

New Features:
- Add a shelter report route and page that renders a printable shelter summary view for operators.
- Enable client-side PDF generation of the shelter report using react-to-pdf with mock shelter data.

Enhancements:
- Define a dedicated ShelterReportData shape and mock data to mirror existing admin shelter overview fields for future GraphQL wiring.
- Apply fixed-width layout styling for the printable shelter report to produce predictable single-page PDF output.

Build:
- Add react-to-pdf as a new dependency for client-side PDF generation.