### PR TITLE
[BP] Add reporting GraphQL types

### DIFF
--- a/apps/betterangels-backend/clients/enums.py
+++ b/apps/betterangels-backend/clients/enums.py
@@ -55,6 +55,7 @@ class EyeColorEnum(models.TextChoices):
     OTHER = "other", _("Other")
 
 
+@strawberry.enum
 class GenderEnum(models.TextChoices):
     MALE = "male", _("Male")
     FEMALE = "female", _("Female")
@@ -140,6 +141,7 @@ class PronounEnum(models.TextChoices):
     OTHER = "other", _("Other")
 
 
+@strawberry.enum
 class RaceEnum(models.TextChoices):
     AMERICAN_INDIAN_ALASKA_NATIVE = "american_indian_alaska_native", _("American Indian/Alaska Native")
     ASIAN = "asian", _("Asian")
@@ -177,6 +179,7 @@ class SocialMediaEnum(models.TextChoices):
     WHATSAPP = "whatsapp", _("WhatsApp")
 
 
+@strawberry.enum
 class VeteranStatusEnum(models.TextChoices):
     YES = "yes", _("Yes")
     NO = "no", _("No")

--- a/apps/betterangels-backend/shelters/types/__init__.py
+++ b/apps/betterangels-backend/shelters/types/__init__.py
@@ -46,6 +46,12 @@ from shelters.types.outputs import (
     ShelterType,
     ShelterTypeMixin,
 )
+from shelters.types.reporting import (
+    DailyBedStatusMetricsType,
+    DailyOccupancyMetricsType,
+    ReservationMetricsType,
+    ShelterOccupancyMetricsType,
+)
 
 __all__ = [
     # lookups
@@ -90,4 +96,9 @@ __all__ = [
     "ShelterPhotoType",
     "ShelterType",
     "ShelterTypeMixin",
+    # reporting
+    "DailyBedStatusMetricsType",
+    "DailyOccupancyMetricsType",
+    "ReservationMetricsType",
+    "ShelterOccupancyMetricsType",
 ]

--- a/apps/betterangels-backend/shelters/types/reporting.py
+++ b/apps/betterangels-backend/shelters/types/reporting.py
@@ -1,0 +1,43 @@
+"""GraphQL types for shelter reporting/occupancy metrics."""
+
+from datetime import date
+from typing import List, Optional
+
+import strawberry
+from strawberry import ID
+
+
+@strawberry.type
+class DailyOccupancyMetricsType:
+    date: date
+    occupied_count: int
+    total_beds: int
+    occupancy_pct: float
+
+
+@strawberry.type
+class DailyBedStatusMetricsType:
+    date: date
+    available: int
+    occupied: int
+    reserved: int
+    out_of_service: int
+
+
+@strawberry.type
+class ReservationMetricsType:
+    check_in_overdue: int
+    cancelled: int
+    checked_in: int
+    check_in_overdue_to_checked_in: int
+
+
+@strawberry.type
+class ShelterOccupancyMetricsType:
+    shelter_id: ID
+    start_date: date
+    end_date: date
+    daily_occupancy: List[DailyOccupancyMetricsType]
+    daily_bed_status: List[DailyBedStatusMetricsType]
+    reservation_metrics: ReservationMetricsType
+    avg_days_to_occupancy: Optional[float] = None


### PR DESCRIPTION
Adds Strawberry GraphQL types for DailyOccupancyMetricsType, DailyBedStatusMetricsType, ReservationMetricsType, ShelterOccupancyMetricsType, and DemographicFiltersInput (for report date range and demographic/bed filters). 

ShelterOccupancyMetricsType aggregates all occupancy, bed status, reservation, and days-to-occupancy metrics into a single response for frontend reporting.

Also exposes GenderEnum, RaceEnum, and VeteranStatusEnum to support client demographic filtering in GraphQL.

This PR is types only. The resolver and the 'Query' field that returns 'ShelterOccupancyMetricsType' will land in a follow-up ticket once all the reporting selectors have merged.

## Summary by Sourcery

Introduce GraphQL reporting types and demographic filter input for shelter occupancy metrics.

New Features:
- Add Strawberry GraphQL types for daily occupancy, daily bed status, reservation metrics, and aggregate shelter occupancy metrics.
- Add a DemographicFiltersInput GraphQL input for date range, bed attributes, and client demographic filters in reporting queries.
- Expose GenderEnum, RaceEnum, and VeteranStatusEnum as Strawberry enums for use in GraphQL filters.

Enhancements:
- Export new reporting GraphQL types from the shelters.types package for external use.