### PR TITLE
SDB-178 PR #2: Org services + multi-org permission resolution

### DIFF
--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -1,0 +1,158 @@
+"""
+Organization services.
+
+Higher-level operations that span models, the org-type registry, and
+permission groups.  Defined here (not in :mod:`accounts.utils`) so the
+registry can be used at runtime without creating circular imports.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from accounts.org_type_registry import OrgTypeRegistry
+from common.permissions.config import TemplateConfig
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+from django.db import transaction
+from django.db.models import QuerySet
+
+if TYPE_CHECKING:
+    from accounts.models import PermissionGroup, PermissionGroupTemplate
+    from organizations.models import Organization
+
+
+# ---------------------------------------------------------------------------
+# Organization creation
+# ---------------------------------------------------------------------------
+
+
+@transaction.atomic
+def create_organization_with_presets(
+    *,
+    name: str,
+    preset_names: list[str],
+) -> "Organization":
+    """Create an :class:`~organizations.models.Organization`, its profile, and
+    all permission groups defined by the given *preset_names*.
+
+    Raises :class:`~accounts.org_type_registry.OrgTypeNotFoundError` if any
+    *preset_name* is not registered.
+    """
+    from accounts.models import (
+        OrganizationProfile,
+        OrgTypeChoices,
+        PermissionGroup,
+        PermissionGroupTemplate,
+    )
+    from organizations.models import Organization
+
+    registry = OrgTypeRegistry.get()
+
+    org = Organization.objects.create(name=name)
+
+    org_types: list[OrgTypeChoices] = []
+    for preset_name in preset_names:
+        preset = registry.lookup(preset_name)
+        org_types.append(OrgTypeChoices(preset_name))
+        _create_permission_groups_from_templates(
+            org=org,
+            templates=preset.permission_templates,
+            PermissionGroupTemplate=PermissionGroupTemplate,
+            PermissionGroup=PermissionGroup,
+        )
+
+    OrganizationProfile.objects.create(organization=org, org_types=org_types)
+
+    return org
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_permission_groups_from_templates(
+    *,
+    org: "Organization",
+    templates: tuple[TemplateConfig, ...],
+    PermissionGroupTemplate: type["PermissionGroupTemplate"],
+    PermissionGroup: type["PermissionGroup"],
+) -> None:
+    """Given a sequence of :class:`TemplateConfig` objects, ensure each has a
+    corresponding :class:`PermissionGroupTemplate` row and a
+    :class:`PermissionGroup` row for *org*.
+
+    ``PermissionGroup.save()`` creates the underlying Django ``Group`` and
+    assigns permissions automatically, so callers only need to iterate
+    templates.
+    """
+    for template_config in templates:
+        pgt, _ = PermissionGroupTemplate.objects.get_or_create(
+            name=template_config.name,
+        )
+        PermissionGroup.objects.create(organization=org, template=pgt)
+
+
+# ---------------------------------------------------------------------------
+# Permission group resolution
+# ---------------------------------------------------------------------------
+
+
+def get_permission_groups_for_org(org: "Organization") -> QuerySet["PermissionGroup"]:
+    """Return all :class:`~accounts.models.PermissionGroup` rows belonging to
+    *org*."""
+    from accounts.models import PermissionGroup
+
+    return PermissionGroup.objects.filter(organization=org)
+
+
+def get_member_permission_group(org: "Organization") -> "PermissionGroup":
+    """Return the default member-level ``PermissionGroup`` for *org*.
+
+    The member group is defined by the *first* template in the *first*
+    registered preset for the org's primary type.  This is the group that
+    non-admin/non-superuser members are placed in by default.
+    """
+    from accounts.models import PermissionGroup
+
+    profile = org.profile
+    org_types = profile.org_types
+
+    if not org_types:
+        raise ValueError(f"Organization '{org.name}' has no org_types set on its profile.")
+
+    registry = OrgTypeRegistry.get()
+    primary_preset = registry.lookup(org_types[0].value)
+    first_template = primary_preset.permission_templates[0]
+
+    return PermissionGroup.objects.get(
+        organization=org,
+        template__name=first_template.name,
+    )
+
+
+def get_user_permission_group_for_org(
+    user: "AbstractBaseUser | AnonymousUser",
+    org_id: str,
+) -> "PermissionGroup":
+    """Return the highest-priority ``PermissionGroup`` the *user* belongs to in
+    *org_id*.  Raises :exc:`PermissionError` when the user has no group in
+    that organization.
+    """
+    from accounts.models import PermissionGroup
+
+    # Prefer non-member groups first; if none, fall back to member group.
+    permission_group = (
+        PermissionGroup.objects.select_related("organization", "group", "template")
+        .filter(
+            organization_id=org_id,
+            group__user=user,
+        )
+        .order_by("-group__permissions")  # crude priority by permission count
+        .first()
+    )
+
+    if not (permission_group and permission_group.group):
+        raise PermissionError("User lacks proper organization or permissions")
+
+    return permission_group

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -1,0 +1,115 @@
+"""Tests for accounts.services."""
+
+import pytest
+from accounts.models import OrganizationProfile, PermissionGroup
+from accounts.services import (
+    create_organization_with_presets,
+    get_member_permission_group,
+)
+from django.test import TestCase
+
+
+class TestCreateOrganizationWithPresets(TestCase):
+    """Integration tests for create_organization_with_presets."""
+
+    def setUp(self) -> None:
+        from accounts.org_type_registry import OrgTypeRegistry
+
+        OrgTypeRegistry.reset()
+        self._register_presets()
+
+    @staticmethod
+    def _register_presets() -> None:
+        from accounts.org_type_registry import OrgTypePreset, OrgTypeRegistry
+        from common.permissions.config import TemplateConfig
+
+        r = OrgTypeRegistry.get()
+        r.register(
+            OrgTypePreset(
+                name="outreach",
+                label="Outreach",
+                permission_templates=(
+                    TemplateConfig(name="Caseworker", permissions=["notes.add_note"]),
+                    TemplateConfig(name="Organization Admin", permissions=["org.access"]),
+                    TemplateConfig(name="Organization Superuser", permissions=["org.super"]),
+                ),
+            )
+        )
+        r.register(
+            OrgTypePreset(
+                name="shelter",
+                label="Shelter",
+                permission_templates=(
+                    TemplateConfig(name="Shelter Operator", permissions=["shelters.view_shelter"]),
+                    TemplateConfig(name="Organization Admin", permissions=["org.access"]),
+                    TemplateConfig(name="Organization Superuser", permissions=["org.super"]),
+                ),
+            )
+        )
+
+    def test_create_outreach_org(self) -> None:
+        org = create_organization_with_presets(
+            name="Test Outreach",
+            preset_names=["outreach"],
+        )
+        assert org.name == "Test Outreach"
+
+        # Profile
+        profile = OrganizationProfile.objects.get(organization=org)
+        assert [t.value for t in profile.org_types] == ["outreach"]
+
+        # Permission groups
+        pg_names = set(PermissionGroup.objects.filter(organization=org).values_list("template__name", flat=True))
+        assert pg_names == {"Caseworker", "Organization Admin", "Organization Superuser"}
+
+    def test_create_shelter_org(self) -> None:
+        org = create_organization_with_presets(
+            name="Test Shelter",
+            preset_names=["shelter"],
+        )
+        profile = OrganizationProfile.objects.get(organization=org)
+        assert [t.value for t in profile.org_types] == ["shelter"]
+
+        pg_names = set(PermissionGroup.objects.filter(organization=org).values_list("template__name", flat=True))
+        assert pg_names == {"Shelter Operator", "Organization Admin", "Organization Superuser"}
+
+    def test_create_dual_type_org(self) -> None:
+        """Multi-type org: outreach + shelter."""
+        org = create_organization_with_presets(
+            name="Dual Org",
+            preset_names=["outreach", "shelter"],
+        )
+        profile = OrganizationProfile.objects.get(organization=org)
+        assert sorted(t.value for t in profile.org_types) == ["outreach", "shelter"]
+
+        pg_names = set(PermissionGroup.objects.filter(organization=org).values_list("template__name", flat=True))
+        # Shared templates (Org Admin, Org Superuser) are de-duplicated by get_or_create
+        assert "Caseworker" in pg_names
+        assert "Shelter Operator" in pg_names
+        assert "Organization Admin" in pg_names
+        assert "Organization Superuser" in pg_names
+        assert PermissionGroup.objects.filter(organization=org).count() == 4
+
+
+class TestGetMemberPermissionGroup(TestCase):
+    """Tests for get_member_permission_group."""
+
+    def setUp(self) -> None:
+        from accounts.org_type_registry import OrgTypeRegistry
+
+        OrgTypeRegistry.reset()
+        TestCreateOrganizationWithPresets._register_presets()
+
+    def test_returns_first_template_group(self) -> None:
+        org = create_organization_with_presets(name="M", preset_names=["shelter"])
+        member_pg = get_member_permission_group(org)
+        assert member_pg.template.name == "Shelter Operator"
+
+    def test_missing_org_types_raises(self) -> None:
+        from organizations.models import Organization
+
+        org = Organization.objects.create(name="No Types")
+        OrganizationProfile.objects.create(organization=org, org_types=[])
+
+        with pytest.raises(ValueError, match="no org_types"):
+            get_member_permission_group(org)

--- a/apps/betterangels-backend/accounts/utils.py
+++ b/apps/betterangels-backend/accounts/utils.py
@@ -47,9 +47,11 @@ def remove_org_group_permissions_from_user(user: User, organization: Organizatio
 
 
 def get_user_permission_group(user: Union[AbstractBaseUser, AnonymousUser]) -> PermissionGroup:
-    # WARNING: Temporary workaround for organization selection
-    # TODO: Update once organization selection is implemented. Currently selects
-    # the first organization with a default Caseworker role for the user.
+    """DEPRECATED: Use :func:`resolve_permission_group` instead.
+
+    Returns the first Caseworker permission group found for *user*.
+    Only works correctly for single-org users and outreach orgs.
+    """
     permission_group = (
         PermissionGroup.objects.select_related("organization", "group")
         .filter(
@@ -63,6 +65,22 @@ def get_user_permission_group(user: Union[AbstractBaseUser, AnonymousUser]) -> P
         raise PermissionError("User lacks proper organization or permissions")
 
     return permission_group
+
+
+def resolve_permission_group(
+    user: Union[AbstractBaseUser, AnonymousUser],
+    org_id: str,
+) -> PermissionGroup:
+    """Return the permission group for *user* in the organization identified
+    by *org_id*.
+
+    Resolves the user's highest-priority group by looking at all groups
+    they belong to in that organization.  This is the multi-org-aware
+    replacement for :func:`get_user_permission_group`.
+    """
+    from accounts.services import get_user_permission_group_for_org
+
+    return get_user_permission_group_for_org(user, org_id)
 
 
 def get_outreach_authorized_users() -> QuerySet[User]:


### PR DESCRIPTION
## Overview

PR #2 of 3 for SDB-178 (shelter operator self-onboarding). Adds organization services powered by the registry and introduces multi-org-aware permission group resolution.

**Base:** `sdb-178-pr1-org-type-registry` (PR #1)

## Changes

### New files
- `accounts/services.py` — Organization services module
  - `create_organization_with_presets(name=\...\, preset_names=["shelter"])` — atomic org creation with profile + permission groups via registry
  - `get_member_permission_group(org)` — returns the default member-level group (first template of primary org type)
  - `get_user_permission_group_for_org(user, org_id)` — multi-org-aware group lookup
  - `get_permission_groups_for_org(org)` — convenience queryset
  - `_create_permission_groups_from_templates()` — internal: creates PermissionGroupTemplate + PermissionGroup rows
- `accounts/tests/test_services.py` — integration tests
  - Outreach org creation (3 permission groups)
  - Shelter org creation (3 permission groups)
  - Dual-type org (outreach + shelter, 4 unique groups due to shared templates)
  - Member permission group resolution
  - Error case: missing org_types

### Modified files
- `accounts/utils.py`
  - Added `resolve_permission_group(user, org_id)` — multi-org replacement for `get_user_permission_group`
  - Deprecated `get_user_permission_group` with docstring (still works for backward compat)

## Architecture

```
create_organization_with_presets(name, ["shelter"])
  ├── Organization.objects.create(name=name)
  ├── For each preset in registry:
  │     └── PermissionGroupTemplate.get_or_create(name=tmpl.name)
  │         └── PermissionGroup.objects.create(org, template)
  └── OrganizationProfile.objects.create(org, org_types=["shelter"])

get_member_permission_group(org)
  └── Reads org.profile.org_types[0] → registry → first template → PermissionGroup
```

Key design decisions:
- `create_organization_with_presets` is `@transaction.atomic` — either all groups are created or none
- Shared templates (Org Admin, Org Superuser) are naturally de-duplicated by `get_or_create`
- `get_member_permission_group` uses the **first template** of the primary org type — shelters get "Shelter Operator", outreach gets "Caseworker"
- Permission models are lazily imported inside the atomic block to avoid import-time side-effects

## Dependencies
- PR #1: `accounts/org_type_registry.py` (OrgTypeRegistry, OrgTypePreset)

## What's NOT in this PR
- Backend/wiring changes (mutations, invite backend, settings cleanup) → PR #3
- Deprecated permission removal → PR #3

## Summary by Sourcery

Introduce organization service layer for org creation and multi-organization permission resolution, and wire a new resolver into the existing permission utilities.

New Features:
- Add organization service for atomic creation of organizations, profiles, and preset-based permission groups backed by the org-type registry.
- Add service helpers to resolve member-level and per-organization permission groups, including a multi-org-aware resolver used by callers.

Enhancements:
- Deprecate the legacy single-org-only get_user_permission_group helper in favor of a new resolve_permission_group wrapper.
- Centralize permission-group and org-type logic in a dedicated accounts.services module to avoid circular imports and clarify responsibilities.

Tests:
- Add integration tests covering org creation for outreach, shelter, and dual-type organizations, including permission group creation and de-duplication.
- Add tests for member permission group resolution and error handling when organization types are missing.