### PR TITLE
feat(backend): idempotent test data setup + org group reconciliation

### DIFF
--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -118,31 +118,23 @@ def create_organization_with_presets(
         if REGISTRY.org_type(preset_name) is None:
             raise ValidationError(f"Unknown org-type preset: {preset_name}")
 
-    org = Organization.objects.create(name=name)
+    org, _ = Organization.objects.get_or_create(name=name)
 
     # Collect unique templates from all requested presets (deduplicate by name).
-    templates_by_name: dict[str, PermissionGroupTemplate] = {}
     org_types: list[str] = []
 
     for preset_name in preset_names:
         org_config = REGISTRY.org_type(preset_name)
         assert org_config is not None
         org_types.append(org_config.name)
-        for template_config in org_config.templates:
-            if template_config.name not in templates_by_name:
-                permission_group_template, _created = PermissionGroupTemplate.objects.get_or_create(
-                    name=template_config.name
-                )
-                templates_by_name[template_config.name] = permission_group_template
 
     # Create PermissionGroup per template for this org.
-    for permission_group_template in templates_by_name.values():
-        PermissionGroup.objects.get_or_create(organization=org, template=permission_group_template)
+    reconcile_org_groups(org)
 
-    # Profile with org types.
-    OrganizationProfile.objects.create(
+    # Profile with org types — update_or_create to fill in on existing orgs too.
+    OrganizationProfile.objects.update_or_create(
         organization=org,
-        org_types=[OrgTypeChoices(org_type) for org_type in org_types],
+        defaults={"org_types": [OrgTypeChoices(org_type) for org_type in org_types]},
     )
 
     # Link the owner (django-organizations auto-creates OrganizationOwner).
@@ -152,6 +144,49 @@ def create_organization_with_presets(
         OrgRoleManager(org).add_roles(owner, *owner_roles)
 
     return org
+
+
+# ── Group reconciliation ──────────────────────────────────────────────
+
+
+def reconcile_org_groups(org: Organization) -> None:
+    """Create missing and delete stale ``PermissionGroup`` records for *org*.
+
+    Expected templates are derived from the org's ``profile.org_types``
+    via :data:`common.org_types.REGISTRY`.  Groups whose template is no
+    longer in the org's presets are deleted.
+
+    Safe to call repeatedly — all operations are idempotent.
+    """
+    from .models import PermissionGroup
+
+    # Expected template names from current org-type presets.
+    expected: set[str] = set()
+    org_type_values = org.profile.org_types if hasattr(org, "profile") else []
+    for org_type_value in org_type_values:
+        org_config = REGISTRY.org_type(org_type_value.value)
+        if org_config is None:
+            continue
+        for template_config in org_config.templates:
+            expected.add(template_config.name)
+
+    if not expected:
+        return
+
+    # Create missing.
+    for template_name in expected:
+        permission_group_template, _ = PermissionGroupTemplate.objects.get_or_create(
+            name=template_name,
+        )
+        PermissionGroup.objects.get_or_create(
+            organization=org,
+            template=permission_group_template,
+        )
+
+    # Delete stale.
+    PermissionGroup.objects.filter(organization=org).exclude(
+        template__name__in=expected,
+    ).delete()
 
 
 # ── Member removal ───────────────────────────────────────────────────

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -11,51 +11,130 @@ from .models import PermissionGroupTemplate, User
 
 logger = logging.getLogger(__name__)
 
-
-@receiver(post_migrate)
-def create_superuser(sender: Any, **kwargs: Any) -> None:
-    if settings.IS_LOCAL_DEV and not User.objects.filter(username="admin").exists():
-        User.objects.create_superuser(username="admin", email="admin@example.com", password="password")
+# ── Local dev data setup ──────────────────────────────────────────────
 
 
 @receiver(post_migrate)
-def create_test_agent(sender: Any, **kwargs: Any) -> None:
-    if settings.IS_LOCAL_DEV and not User.objects.filter(username="agent").exists():
-        User.objects.create_user(
-            username="agent",
-            email="agent@example.com",
-            password="password",
-            first_name="Carolyn",
+def setup_local_dev_data(sender: Any, **kwargs: Any) -> None:
+    """Create test users and org — local dev only.
+
+    Role assignment is deferred to ``sync_all_org_permission_groups``
+    which runs after all migration app tables exist.  This avoids
+    ``PermissionGroup.DoesNotExist`` when the signal fires before
+    the accounts app is fully migrated.
+    """
+    if not settings.IS_LOCAL_DEV:
+        return
+
+    _ensure_test_users()
+    _ensure_test_org()
+
+
+def _ensure_test_users() -> None:
+    """Idempotent: create admin + agent with known passwords."""
+    admin, _ = User.objects.get_or_create(
+        username="admin",
+        defaults={"email": "admin@example.com", "password": "password"},
+    )
+    User.objects.filter(username="admin").update(is_superuser=True, is_staff=True)
+    if not admin.check_password("password"):
+        admin.set_password("password")
+        admin.save(update_fields=["password"])
+
+    agent, _ = User.objects.get_or_create(
+        username="agent",
+        defaults={
+            "email": "agent@example.com",
+            "password": "password",
+            "first_name": "Carolyn",
+        },
+    )
+    if not agent.check_password("password"):
+        agent.set_password("password")
+        agent.save(update_fields=["password"])
+
+
+def _ensure_test_org() -> None:
+    """Idempotent: create test_org with presets and owner (no role assignment yet)."""
+    from accounts.groups import ORG_ADMIN
+    from accounts.services import create_organization_with_presets
+    from notes.groups import CASEWORKER
+    from shelters.groups import SHELTER_OPERATOR
+
+    admin = User.objects.get(username="admin")
+
+    test_org, created = Organization.objects.get_or_create(name="test_org")
+    if created:
+        create_organization_with_presets(
+            name="test_org",
+            preset_names=["shelter", "outreach"],
+            owner=admin,
+            owner_roles=(),  # roles assigned by sync_all_org_permission_groups
         )
 
 
-@receiver(post_migrate)
-def create_test_organization(sender: Any, **kwargs: Any) -> None:
-    if settings.IS_LOCAL_DEV and not Organization.objects.filter(name="test_org").exists():
-        test_usernames = ["admin", "agent"]
-        test_users = User.objects.filter(username__in=test_usernames)
-        test_org = Organization.objects.create(name="test_org")
-        for test_user in test_users:
-            test_org.add_user(test_user)
+# ── Permission sync (all environments) ────────────────────────────────
 
 
 @receiver(post_migrate)
-def update_group_permissions(sender: Any, **kwargs: Any) -> None:
-    """Sync Django Group permissions for all registered templates.
+def sync_all_org_permission_groups(sender: Any, **kwargs: Any) -> None:
+    """Reconcile every org's PermissionGroups against current presets.
 
-    Uses :meth:`Registry.template_names` so that new org types and roles
-    are automatically included -- no need to manually update a hardcoded
-    list.
+    Also assigns test-agent roles on local dev (safe to call repeatedly
+    — ``member_add`` is idempotent).
     """
+    from accounts.services import member_add, reconcile_org_groups as reconcile
+    from notes.groups import CASEWORKER
+    from shelters.groups import SHELTER_OPERATOR
+
+    # The accounts app tables may not be ready when this fires for other
+    # apps; skip gracefully until the final post_migrate run.
+    try:
+        for org in Organization.objects.all():
+            reconcile(org)
+    except Exception:
+        return
+
+    _sync_template_permissions()
+
+    if not settings.IS_LOCAL_DEV:
+        return
+
+    try:
+        from accounts.groups import ORG_ADMIN
+
+        test_org = Organization.objects.get(name="test_org")
+        admin = User.objects.get(username="admin")
+        agent = User.objects.get(username="agent")
+
+        member_add(
+            email=admin.email or "admin@example.com",
+            first_name="Admin",
+            last_name="User",
+            middle_name=None,
+            organization=test_org,
+            permission_templates=(ORG_ADMIN, SHELTER_OPERATOR, CASEWORKER),
+        )
+        member_add(
+            email=agent.email or "agent@example.com",
+            first_name=agent.first_name or "",
+            last_name=agent.last_name or "",
+            middle_name=None,
+            organization=test_org,
+            permission_templates=(SHELTER_OPERATOR, CASEWORKER),
+        )
+    except Exception:
+        pass
+
+def _sync_template_permissions() -> None:
+    """Sync Django Group.permissions for all registered templates."""
     from common.org_types import REGISTRY
 
     template_names = REGISTRY.template_names()
-
     with transaction.atomic():
         templates = PermissionGroupTemplate.objects.filter(name__in=template_names).prefetch_related(
             "permissions", "permissiongroup_set__group"
         )
-
         for template in templates:
             perms = list(template.permissions.all())
             for pgt in template.permissiongroup_set.all():


### PR DESCRIPTION
- Single post_migrate receiver for local dev test data (admin, agent, test_org)
- create_organization_with_presets now uses get_or_create (idempotent)
- reconcile_org_groups service: creates missing + deletes stale PermissionGroups
- sync_all_org_permission_groups signal: full reconciliation for all orgs in all environments, iterating presets from REGISTRY
- Agent role assignment deferred until tables are guaranteed ready