### PR TITLE
chore: configure ruff + pylance for VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,8 +33,6 @@
   "mypy.targets": [],
   "mypy.runUsingActiveInterpreter": false,
   "mypy.dmypyExecutable": "${workspaceFolder}/tools/scripts/dmypy-wrapper.sh",
-  "python.analysis.typeCheckingMode": "off",
-  "python.analysis.include": ["apps/betterangels-backend"],
   "python.testing.pytestArgs": ["apps", "libs"],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ line-length = 120
 exclude = ["node_modules", ".venv/lib", "*/migrations/*"]
 
 [tool.ruff.lint]
-select = ["E", "F", "B"]
+select = ["E", "F", "B", "I"]
 ignore = ["E501", "B904", "B905"]
 
 [tool.ruff.lint.isort]
-known-first-party = []
+known-first-party = ["accounts", "betterangels_backend", "clients", "common", "hmis", "legal", "notes", "proxy", "referrals", "reports", "shelters", "tasks", "teams"]
 
 [tool.ruff.lint.per-file-ignores]
 "*/migrations/*" = ["I"]
@@ -31,6 +31,13 @@ known-first-party = []
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.pyright]
+typeCheckingMode = "off"
+pythonVersion = "3.14"
+pythonPlatform = "Linux"
+reportLineTooLong = "none"
+include = ["apps/betterangels-backend"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

Fixes Ruff and Pylance VS Code configuration for the backend.

### Changes

**pyproject.toml**
- Add `[tool.pyright]` section to suppress Pylance's default 79-char line-length warnings (Ruff uses 120)
- Move `include` from VS Code settings to pyproject.toml to avoid Pylance `settingsNotOverridable` warnings
- Add `I` (isort) to Ruff lint select so CLI/CI enforces import ordering (matching VS Code's `source.organizeImports` behavior)
- Populate `known-first-party` with all backend packages so cross-package imports are grouped correctly

**.vscode/settings.json**
- Remove `python.analysis.typeCheckingMode` and `python.analysis.include` (now in pyproject.toml)
- Remove `python.analysis.diagnosticSeverityOverrides` (now handled by `reportLineTooLong` in pyproject.toml)

### Why
- Pylance was showing 79-char line-too-long squiggles despite Ruff's 120-char limit
- Pylance was warning that certain settings couldn't be overridden when a pyproject.toml exists
- Ruff CLI wasn't checking import ordering, creating a mismatch with VS Code on-save behavior

## Summary by Sourcery

Configure Ruff, isort, and Pyright/Pylance settings for consistent linting and analysis in the backend project.

Enhancements:
- Enable Ruff import-ordering checks and configure known first-party packages for correct grouping across backend apps.
- Add centralized Pyright configuration in pyproject.toml, including line-length, environment, and include paths, and remove overlapping VS Code workspace settings.