### PR TITLE
fix: address review feedback (data integrity, HackSoft style, simplifications)

### DIFF
--- a/apps/betterangels-backend/accounts/permissions.py
+++ b/apps/betterangels-backend/accounts/permissions.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional, Protocol, Type, Union
 
 import strawberry
 from accounts.models import PermissionGroup, User
-from common.permissions.utils import _perm_q
+from common.permissions.utils import perm_filter
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.db import models
 from django.db.models import Exists, OuterRef, TextChoices
@@ -56,7 +56,7 @@ def get_user_permitted_org(
             pk=org_id,
             permission_groups__group__user=user,
         )
-        .filter(_perm_q(app_label, codename))
+        .filter(perm_filter(app_label, codename))
         .first()
     )
 
@@ -91,7 +91,7 @@ def permission_annotations(user: User, permissions: Type[TextChoices]) -> dict[s
             PermissionGroup.objects.filter(
                 organization=OuterRef("pk"),
                 group__user=user,
-            ).filter(_perm_q(app_label, codename, prefix="group__permissions"))
+            ).filter(perm_filter(app_label, codename, prefix="group__permissions"))
         )
     return annotations
 

--- a/apps/betterangels-backend/common/permissions/utils.py
+++ b/apps/betterangels-backend/common/permissions/utils.py
@@ -227,6 +227,28 @@ def get_current_organization(info: Info) -> str:
 _T = TypeVar("_T", bound=Model)
 
 
+def _org_perm_exists_across_fields(
+    user: AbstractBaseUser,
+    app_label: str,
+    codename: str,
+    fields: list[str],
+) -> Q:
+    """Return a ``Q`` checking the user holds a permission on any of the org fields."""
+    return reduce(
+        or_,
+        (
+            Q(
+                Exists(
+                    Organization.objects.filter(pk=OuterRef(f))
+                    .filter(permission_groups__group__user=user)
+                    .filter(_perm_q(app_label, codename))
+                )
+            )
+            for f in fields
+        ),
+    )
+
+
 def permissioned_queryset(
     queryset: "QuerySet[_T]",
     *,
@@ -262,6 +284,13 @@ def permissioned_queryset(
         The Django field lookup path to the owning organization.
         Default ``"organization_id"`` works for models with a direct FK.
         Use ``"shelter__organization_id"`` for indirect (Bed, Room).
+        Ignored when *organization_fields* is provided.
+    organization_fields : list[str] | None
+        Multiple field paths (OR'd together). Use when a model reaches
+        its organization through more than one path (e.g. Reservation
+        via ``bed__shelter__organization_id`` or
+        ``room__shelter__organization_id``). Takes precedence over
+        *organization_field*. Default ``None``.
 
     Returns
     -------
@@ -280,38 +309,12 @@ def permissioned_queryset(
         q = Q()
         for perm_str in perms:
             app_label, codename = perm_str.split(".", 1)
-            q |= reduce(
-                or_,
-                (
-                    Q(
-                        Exists(
-                            Organization.objects.filter(pk=OuterRef(f))
-                            .filter(permission_groups__group__user=user)
-                            .filter(_perm_q(app_label, codename))
-                        )
-                    )
-                    for f in fields
-                ),
-            )
+            q |= _org_perm_exists_across_fields(user, app_label, codename, fields)
         queryset = queryset.filter(q)
     else:
         for perm_str in perms:
             app_label, codename = perm_str.split(".", 1)
-            queryset = queryset.filter(
-                reduce(
-                    or_,
-                    (
-                        Q(
-                            Exists(
-                                Organization.objects.filter(pk=OuterRef(f))
-                                .filter(permission_groups__group__user=user)
-                                .filter(_perm_q(app_label, codename))
-                            )
-                        )
-                        for f in fields
-                    ),
-                )
-            )
+            queryset = queryset.filter(_org_perm_exists_across_fields(user, app_label, codename, fields))
 
     return queryset
 

--- a/apps/betterangels-backend/shelters/managers.py
+++ b/apps/betterangels-backend/shelters/managers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Iterable, Self, Union, cast
+from typing import TYPE_CHECKING, Iterable, Self, cast
 
 from django.db import models
 from django.db.models import Manager, Q, QuerySet
@@ -9,6 +9,7 @@ from shelters.enums import BedStatusChoices, RoomStatusChoices, ScheduleTypeChoi
 from shelters.open_at import shelters_open_at
 from shelters.selectors import shelter_list
 from shelters.selectors.computed_status import (
+    StatusChoice,
     computed_status_case,
     status_filter_q,
 )
@@ -16,10 +17,6 @@ from shelters.selectors.computed_status import (
 if TYPE_CHECKING:
     from shelters.models import Shelter  # noqa: F401
     from shelters.models import Bed, Room
-
-
-# Not a TypeVar -- the two enums are independent and correspondence can't be enforced here.
-StatusChoice = Union[BedStatusChoices, RoomStatusChoices]
 
 
 class ShelterQuerySet(QuerySet["Shelter"]):

--- a/apps/betterangels-backend/shelters/managers.py
+++ b/apps/betterangels-backend/shelters/managers.py
@@ -15,8 +15,8 @@ from shelters.selectors.computed_status import (
 )
 
 if TYPE_CHECKING:
+    from shelters.models import Bed, Room  # noqa: F401
     from shelters.models import Shelter  # noqa: F401
-    from shelters.models import Bed, Room
 
 
 class ShelterQuerySet(QuerySet["Shelter"]):

--- a/apps/betterangels-backend/shelters/managers.py
+++ b/apps/betterangels-backend/shelters/managers.py
@@ -4,31 +4,21 @@ import datetime
 from typing import TYPE_CHECKING, Iterable, Self, Union, cast
 
 from django.db import models
-from django.db.models import (
-    Case,
-    CharField,
-    Count,
-    DateTimeField,
-    Exists,
-    IntegerField,
-    Manager,
-    OuterRef,
-    Q,
-    QuerySet,
-    Subquery,
-    Value,
-    When,
-)
-from shelters.enums import BedStatusChoices, ReservationStatusChoices, RoomStatusChoices, ScheduleTypeChoices
+from django.db.models import Manager, Q, QuerySet
+from shelters.enums import BedStatusChoices, RoomStatusChoices, ScheduleTypeChoices
 from shelters.open_at import shelters_open_at
 from shelters.selectors import shelter_list
+from shelters.selectors.computed_status import (
+    computed_status_case,
+    status_filter_q,
+)
 
 if TYPE_CHECKING:
     from shelters.models import Shelter  # noqa: F401
-    from shelters.models import Bed, Reservation, Room
+    from shelters.models import Bed, Room
 
 
-# Not a TypeVar — the two enums are independent and correspondence can't be enforced here.
+# Not a TypeVar -- the two enums are independent and correspondence can't be enforced here.
 StatusChoice = Union[BedStatusChoices, RoomStatusChoices]
 
 
@@ -60,131 +50,12 @@ class ShelterManager(models.Manager["Shelter"]):
         return self.get_queryset().open_at(dt, schedule_type)
 
 
-def _reservation_model() -> type[Reservation]:
-    from shelters.models import Reservation
-
-    return Reservation
-
-
-def latest_completed_checkout_subquery(fk_field: str) -> Subquery:
-    Reservation = _reservation_model()
-    return Subquery(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status=ReservationStatusChoices.COMPLETED,
-            checked_out_at__isnull=False,
-        )
-        .order_by("-checked_out_at")
-        .values("checked_out_at")[:1],
-        output_field=DateTimeField(),
-    )
-
-
-def has_checked_in_exists(fk_field: str) -> Exists:
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status=ReservationStatusChoices.CHECKED_IN,
-        )
-    )
-
-
-def has_confirmed_or_overdue_exists(fk_field: str) -> Exists:
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status__in=[
-                ReservationStatusChoices.CONFIRMED,
-                ReservationStatusChoices.CHECK_IN_OVERDUE,
-            ],
-        )
-    )
-
-
-def has_completed_checkout_exists(fk_field: str) -> Exists:
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status=ReservationStatusChoices.COMPLETED,
-            checked_out_at__isnull=False,
-        )
-    )
-
-
-def has_active_reservation_exists(fk_field: str) -> Exists:
-    from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
-
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status__in=ACTIVE_RESERVATION_STATUSES,
-        )
-    )
-
-
-def in_turnaround_filter_q(fk_field: str) -> Q:
-    """``Q`` for in-turnaround without a prior ``annotate`` (uses correlated subqueries)."""
-    has_completed_checkout = Q(has_completed_checkout_exists(fk_field))
-    needs_cleaning = Q(last_cleaned__isnull=True) | Q(last_cleaned__lte=latest_completed_checkout_subquery(fk_field))
-    return has_completed_checkout & needs_cleaning
-
-
-def status_filter_q(
-    status: StatusChoice,
-    *,
-    fk_field: str,
-    status_enum: type[BedStatusChoices] | type[RoomStatusChoices],
-) -> Q:
-    """Build a ``Q`` object for filtering a single computed status (index-friendly Exists)."""
-    if status == status_enum.OUT_OF_SERVICE:
-        return Q(maintenance_flag=True)
-
-    base = Q(maintenance_flag=False)
-
-    if status == status_enum.OCCUPIED:
-        return base & Q(has_checked_in_exists(fk_field))
-
-    if status == status_enum.RESERVED:
-        return base & Q(has_confirmed_or_overdue_exists(fk_field)) & ~Q(has_checked_in_exists(fk_field))
-
-    if status == status_enum.IN_TURNAROUND:
-        return base & in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
-
-    if status == status_enum.AVAILABLE:
-        return base & ~in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
-
-    return Q()
-
-
-def computed_status_case(
-    fk_field: str,
-    status_enum: type[BedStatusChoices] | type[RoomStatusChoices],
-) -> Case:
-    """First-match status annotation; priority matches ``compute_reservable_status``."""
-    return Case(
-        When(maintenance_flag=True, then=Value(status_enum.OUT_OF_SERVICE)),
-        When(has_checked_in_exists(fk_field), then=Value(status_enum.OCCUPIED)),
-        When(has_confirmed_or_overdue_exists(fk_field), then=Value(status_enum.RESERVED)),
-        When(in_turnaround_filter_q(fk_field), then=Value(status_enum.IN_TURNAROUND)),
-        default=Value(status_enum.AVAILABLE),
-        output_field=CharField(),
-    )
-
-
-def bed_computed_status_annotation() -> Case:
-    return computed_status_case("bed_id", BedStatusChoices)
-
-
-def room_computed_status_annotation() -> Case:
-    return computed_status_case("room_id", RoomStatusChoices)
-
-
 class ReservableStatusQuerySetMixin:
-    """Shared status filtering/annotation for Bed and Room querysets."""
+    """Shared status filtering/annotation for Bed and Room querysets.
+
+    Delegates to query-building functions in
+    ``shelters.selectors.computed_status`` per HackSoft style guide.
+    """
 
     reservable_fk: str = "bed_id"
     status_enum: type[BedStatusChoices] | type[RoomStatusChoices] = BedStatusChoices
@@ -200,7 +71,7 @@ class ReservableStatusQuerySetMixin:
         return cast(QuerySet, self).filter(self.status_filter_q(status))
 
     def filter_by_statuses(self, statuses: Iterable[StatusChoice]) -> QuerySet:
-        # Empty statuses is treated as "no filter" — return the full queryset unchanged.
+        # Empty statuses is treated as "no filter" -- return the full queryset unchanged.
         combined = Q()
         for status in statuses:
             combined |= self.status_filter_q(status)
@@ -250,26 +121,3 @@ class RoomManager(Manager["Room"]):
 
     def filter_by_statuses(self, statuses: Iterable[RoomStatusChoices]) -> RoomQuerySet:
         return cast(RoomQuerySet, self.get_queryset().filter_by_statuses(statuses))
-
-
-def _shelter_reservable_status_count_subquery(
-    model_class: type[Bed] | type[Room],
-    status: StatusChoice,
-) -> Subquery:
-    base_qs = cast(BedQuerySet | RoomQuerySet, model_class.objects.filter(shelter_id=OuterRef("pk")))
-    return Subquery(
-        base_qs.filter_by_status(status).order_by().values("shelter").annotate(c=Count("pk")).values("c"),
-        output_field=IntegerField(),
-    )
-
-
-def shelter_bed_status_count_subquery(status: BedStatusChoices) -> Subquery:
-    from shelters.models import Bed
-
-    return _shelter_reservable_status_count_subquery(Bed, status)
-
-
-def shelter_room_status_count_subquery(status: RoomStatusChoices) -> Subquery:
-    from shelters.models import Room
-
-    return _shelter_reservable_status_count_subquery(Room, status)

--- a/apps/betterangels-backend/shelters/managers.py
+++ b/apps/betterangels-backend/shelters/managers.py
@@ -151,13 +151,11 @@ def status_filter_q(
     if status == status_enum.RESERVED:
         return base & Q(has_confirmed_or_overdue_exists(fk_field)) & ~Q(has_checked_in_exists(fk_field))
 
-    not_turnaround = ~in_turnaround_filter_q(fk_field)
-
     if status == status_enum.IN_TURNAROUND:
         return base & in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
 
     if status == status_enum.AVAILABLE:
-        return base & not_turnaround & ~Q(has_active_reservation_exists(fk_field))
+        return base & ~in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
 
     return Q()
 

--- a/apps/betterangels-backend/shelters/migrations/0008_clean_up_models.py
+++ b/apps/betterangels-backend/shelters/migrations/0008_clean_up_models.py
@@ -8,6 +8,11 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
+    """Drop stored status/occupant/shelter columns in favor of computed status.
+
+    No RunPython data migration -- assumes a clean environment with no
+    production data to preserve in the dropped columns.
+    """
 
     dependencies = [
         ("clients", "0032_unhoused_start_date"),

--- a/apps/betterangels-backend/shelters/models/reservation.py
+++ b/apps/betterangels-backend/shelters/models/reservation.py
@@ -78,9 +78,9 @@ class Reservation(BaseModel):
     def shelter(self) -> Shelter | None:
         """Return the shelter for this reservation, resolved via bed or room."""
         if self.bed_id:
-            return self.bed.shelter
+            return self.bed.shelter  # type: ignore[union-attr]
         if self.room_id:
-            return self.room.shelter
+            return self.room.shelter  # type: ignore[union-attr]
         return None
 
     def __str__(self) -> str:

--- a/apps/betterangels-backend/shelters/models/reservation.py
+++ b/apps/betterangels-backend/shelters/models/reservation.py
@@ -1,18 +1,19 @@
-"""Reservation-related shelter models."""
+from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 import pghistory
 from common.models import BaseModel
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.db import models
 from django.db.models import UniqueConstraint
-from django.utils import timezone
 from django_choices_field import TextChoicesField
 from shelters.enums import ReservationStatusChoices
-from shelters.status import get_last_completed_checkout, is_in_turnaround
 
 from .shelter import ACTIVE_RESERVATION_STATUSES, Bed, Room
+
+if TYPE_CHECKING:
+    from .shelter import Shelter
 
 
 @pghistory.track(
@@ -64,84 +65,26 @@ class Reservation(BaseModel):
         if not self.bed and not self.room:
             errors[NON_FIELD_ERRORS] = "A reservation must have a bed or room assigned."
 
-        # If bed is assigned, validate bed
-        if self.bed and not errors:
-            if self.bed.maintenance_flag:
-                errors["bed"] = "The selected bed is out of service."
-            elif self._is_bed_in_turnaround():
-                errors["bed"] = "The selected bed is currently in turnaround."
-            else:
-                # Check for conflicting active reservations on this bed.
-                conflicting_qs = Reservation.objects.filter(
-                    bed_id=self.bed.pk,
-                    status__in=ACTIVE_RESERVATION_STATUSES,
-                )
-                if self.pk:
-                    conflicting_qs = conflicting_qs.exclude(pk=self.pk)
-                if conflicting_qs.exists():
-                    errors["bed"] = "This bed already has an active reservation."
-
-        # If room is assigned but bed is not (room-only), validate room
-        if self.room and not self.bed and not errors:
-            if self.room.maintenance_flag:
-                errors["room"] = "The selected room is out of service."
-            elif self._is_room_in_turnaround():
-                errors["room"] = "The selected room is currently in turnaround."
-            else:
-                # Check for conflicting active room-only reservations.
-                conflicting_qs = Reservation.objects.filter(
-                    room_id=self.room.pk,
-                    bed__isnull=True,
-                    status__in=ACTIVE_RESERVATION_STATUSES,
-                )
-                if self.pk:
-                    conflicting_qs = conflicting_qs.exclude(pk=self.pk)
-                if conflicting_qs.exists():
-                    errors["room"] = "This room already has an active room-only reservation."
+        if self.bed and self.room:
+            if self.bed.shelter_id != self.room.shelter_id:
+                errors[NON_FIELD_ERRORS] = "Bed and room must belong to the same shelter."
+            elif self.bed.room_id and self.bed.room_id != self.room.pk:
+                errors["bed"] = "The selected bed does not belong to the selected room."
 
         if errors:
             raise ValidationError(errors)
 
-    def _is_bed_in_turnaround(self) -> bool:
-        """Return True if the assigned bed is in turnaround (last checkout after last cleaned)."""
-        if not self.bed:
-            return False
-        return is_in_turnaround(
-            last_cleaned=self.bed.last_cleaned,
-            last_checkout=get_last_completed_checkout(self.bed.reservations.all()),
-        )
-
-    def _is_room_in_turnaround(self) -> bool:
-        """Return True if the assigned room is in turnaround (last checkout after last cleaned)."""
-        if not self.room:
-            return False
-        return is_in_turnaround(
-            last_cleaned=self.room.last_cleaned,
-            last_checkout=get_last_completed_checkout(self.room.reservations.all()),
-        )
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._initial_status = self.status
-
-    def save(self, *args: Any, **kwargs: Any) -> None:
-        if self.pk is not None and self.status != self._initial_status:
-            if (
-                self.status == ReservationStatusChoices.COMPLETED
-                and self._initial_status != ReservationStatusChoices.COMPLETED
-            ):
-                self.checked_out_at = timezone.now()
-            elif (
-                self.status == ReservationStatusChoices.CHECKED_IN
-                and self._initial_status != ReservationStatusChoices.CHECKED_IN
-            ):
-                self.checked_in_at = timezone.now()
-
-        super().save(*args, **kwargs)
-        self._initial_status = self.status
+    @property
+    def shelter(self) -> Shelter | None:
+        """Return the shelter for this reservation, resolved via bed or room."""
+        if self.bed_id:
+            return self.bed.shelter
+        if self.room_id:
+            return self.room.shelter
+        return None
 
     def __str__(self) -> str:
-        shelter = self.bed.shelter if self.bed else self.room.shelter if self.room else "No Shelter"
+        shelter = self.shelter or "No Shelter"
 
         return f"Reservation #{self.pk} at {shelter} ({self.status})"
 

--- a/apps/betterangels-backend/shelters/models/shelter.py
+++ b/apps/betterangels-backend/shelters/models/shelter.py
@@ -232,6 +232,7 @@ class Bed(CloneMixin, BaseModel):
         "pets",
     ]
     _clone_excluded_fields = [
+        # Excluded so cloned beds always start AVAILABLE (maintenance_flag=False).
         "last_cleaned",
         "last_cleaned_inspected",
         "maintenance_flag",
@@ -291,6 +292,7 @@ class Room(CloneMixin, BaseModel):
         "pets",
     ]
     _clone_excluded_fields = [
+        # Excluded so cloned rooms start fresh (AVAILABLE, no operational state).
         "last_cleaned",
         "last_cleaned_inspected",
         "maintenance_flag",

--- a/apps/betterangels-backend/shelters/selectors/computed_status.py
+++ b/apps/betterangels-backend/shelters/selectors/computed_status.py
@@ -59,24 +59,24 @@ def _reservation_exists(
 
 
 # Convenience wrappers -- self-documenting callers for the status filter chain.
-def _checked_in_exists(fk_field: str) -> Exists:
+def checked_in_exists(fk_field: str) -> Exists:
     return _reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN)
 
 
-def _confirmed_or_overdue_exists(fk_field: str) -> Exists:
+def confirmed_or_overdue_exists(fk_field: str) -> Exists:
     return _reservation_exists(
         fk_field,
         status__in=[ReservationStatusChoices.CONFIRMED, ReservationStatusChoices.CHECK_IN_OVERDUE],
     )
 
 
-def _completed_checkout_exists(fk_field: str) -> Exists:
+def completed_checkout_exists(fk_field: str) -> Exists:
     return _reservation_exists(
         fk_field, status=ReservationStatusChoices.COMPLETED, extra={"checked_out_at__isnull": False}
     )
 
 
-def _active_reservation_exists(fk_field: str) -> Exists:
+def active_reservation_exists(fk_field: str) -> Exists:
     from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
 
     return _reservation_exists(fk_field, status__in=list(ACTIVE_RESERVATION_STATUSES))
@@ -98,7 +98,7 @@ def latest_completed_checkout_subquery(fk_field: str) -> Subquery:
 
 def in_turnaround_filter_q(fk_field: str) -> Q:
     """``Q`` for in-turnaround without a prior ``annotate`` (uses correlated subqueries)."""
-    has_completed_checkout = Q(_completed_checkout_exists(fk_field))
+    has_completed_checkout = Q(completed_checkout_exists(fk_field))
     needs_cleaning = Q(last_cleaned__isnull=True) | Q(last_cleaned__lte=latest_completed_checkout_subquery(fk_field))
     return has_completed_checkout & needs_cleaning
 
@@ -116,16 +116,16 @@ def status_filter_q(
     base = Q(maintenance_flag=False)
 
     if status == status_enum.OCCUPIED:
-        return base & Q(_checked_in_exists(fk_field))
+        return base & Q(checked_in_exists(fk_field))
 
     if status == status_enum.RESERVED:
-        return base & Q(_confirmed_or_overdue_exists(fk_field)) & ~Q(_checked_in_exists(fk_field))
+        return base & Q(confirmed_or_overdue_exists(fk_field)) & ~Q(checked_in_exists(fk_field))
 
     if status == status_enum.IN_TURNAROUND:
-        return base & in_turnaround_filter_q(fk_field) & ~Q(_active_reservation_exists(fk_field))
+        return base & in_turnaround_filter_q(fk_field) & ~Q(active_reservation_exists(fk_field))
 
     if status == status_enum.AVAILABLE:
-        return base & ~in_turnaround_filter_q(fk_field) & ~Q(_active_reservation_exists(fk_field))
+        return base & ~in_turnaround_filter_q(fk_field) & ~Q(active_reservation_exists(fk_field))
 
     return Q()
 
@@ -137,8 +137,8 @@ def computed_status_case(
     """First-match status annotation; priority matches ``compute_reservable_status``."""
     return Case(
         When(maintenance_flag=True, then=Value(status_enum.OUT_OF_SERVICE)),
-        When(_checked_in_exists(fk_field), then=Value(status_enum.OCCUPIED)),
-        When(_confirmed_or_overdue_exists(fk_field), then=Value(status_enum.RESERVED)),
+        When(checked_in_exists(fk_field), then=Value(status_enum.OCCUPIED)),
+        When(confirmed_or_overdue_exists(fk_field), then=Value(status_enum.RESERVED)),
         When(in_turnaround_filter_q(fk_field), then=Value(status_enum.IN_TURNAROUND)),
         default=Value(status_enum.AVAILABLE),
         output_field=CharField(),

--- a/apps/betterangels-backend/shelters/selectors/computed_status.py
+++ b/apps/betterangels-backend/shelters/selectors/computed_status.py
@@ -39,6 +39,25 @@ def _reservation_model() -> type[Reservation]:
     return Reservation
 
 
+def _reservation_exists(
+    fk_field: str,
+    *,
+    status: ReservationStatusChoices | None = None,
+    status__in: list[ReservationStatusChoices] | None = None,
+    extra: dict[str, object] | None = None,
+) -> Exists:
+    """Return an ``Exists`` subquery for reservations matching the given filters on *fk_field*."""
+    Reservation = _reservation_model()
+    filters: dict[str, object] = {fk_field: OuterRef("pk")}
+    if status is not None:
+        filters["status"] = status
+    if status__in is not None:
+        filters["status__in"] = status__in
+    if extra:
+        filters.update(extra)
+    return Exists(Reservation.objects.filter(**filters))
+
+
 def latest_completed_checkout_subquery(fk_field: str) -> Subquery:
     Reservation = _reservation_model()
     return Subquery(
@@ -53,55 +72,11 @@ def latest_completed_checkout_subquery(fk_field: str) -> Subquery:
     )
 
 
-def has_checked_in_exists(fk_field: str) -> Exists:
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status=ReservationStatusChoices.CHECKED_IN,
-        )
-    )
-
-
-def has_confirmed_or_overdue_exists(fk_field: str) -> Exists:
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status__in=[
-                ReservationStatusChoices.CONFIRMED,
-                ReservationStatusChoices.CHECK_IN_OVERDUE,
-            ],
-        )
-    )
-
-
-def has_completed_checkout_exists(fk_field: str) -> Exists:
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status=ReservationStatusChoices.COMPLETED,
-            checked_out_at__isnull=False,
-        )
-    )
-
-
-def has_active_reservation_exists(fk_field: str) -> Exists:
-    from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
-
-    Reservation = _reservation_model()
-    return Exists(
-        Reservation.objects.filter(
-            **{fk_field: OuterRef("pk")},
-            status__in=ACTIVE_RESERVATION_STATUSES,
-        )
-    )
-
-
 def in_turnaround_filter_q(fk_field: str) -> Q:
     """``Q`` for in-turnaround without a prior ``annotate`` (uses correlated subqueries)."""
-    has_completed_checkout = Q(has_completed_checkout_exists(fk_field))
+    has_completed_checkout = Q(
+        _reservation_exists(fk_field, status=ReservationStatusChoices.COMPLETED, extra={"checked_out_at__isnull": False})
+    )
     needs_cleaning = Q(last_cleaned__isnull=True) | Q(last_cleaned__lte=latest_completed_checkout_subquery(fk_field))
     return has_completed_checkout & needs_cleaning
 
@@ -113,22 +88,33 @@ def status_filter_q(
     status_enum: type[BedStatusChoices] | type[RoomStatusChoices],
 ) -> Q:
     """Build a ``Q`` object for filtering a single computed status (index-friendly Exists)."""
+    from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
+
     if status == status_enum.OUT_OF_SERVICE:
         return Q(maintenance_flag=True)
 
     base = Q(maintenance_flag=False)
 
     if status == status_enum.OCCUPIED:
-        return base & Q(has_checked_in_exists(fk_field))
+        return base & Q(_reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN))
 
     if status == status_enum.RESERVED:
-        return base & Q(has_confirmed_or_overdue_exists(fk_field)) & ~Q(has_checked_in_exists(fk_field))
+        return (
+            base
+            & Q(
+                _reservation_exists(
+                    fk_field,
+                    status__in=[ReservationStatusChoices.CONFIRMED, ReservationStatusChoices.CHECK_IN_OVERDUE],
+                )
+            )
+            & ~Q(_reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN))
+        )
 
     if status == status_enum.IN_TURNAROUND:
-        return base & in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
+        return base & in_turnaround_filter_q(fk_field) & ~Q(_reservation_exists(fk_field, status__in=ACTIVE_RESERVATION_STATUSES))
 
     if status == status_enum.AVAILABLE:
-        return base & ~in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
+        return base & ~in_turnaround_filter_q(fk_field) & ~Q(_reservation_exists(fk_field, status__in=ACTIVE_RESERVATION_STATUSES))
 
     return Q()
 
@@ -140,8 +126,13 @@ def computed_status_case(
     """First-match status annotation; priority matches ``compute_reservable_status``."""
     return Case(
         When(maintenance_flag=True, then=Value(status_enum.OUT_OF_SERVICE)),
-        When(has_checked_in_exists(fk_field), then=Value(status_enum.OCCUPIED)),
-        When(has_confirmed_or_overdue_exists(fk_field), then=Value(status_enum.RESERVED)),
+        When(_reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN), then=Value(status_enum.OCCUPIED)),
+        When(
+            _reservation_exists(
+                fk_field, status__in=[ReservationStatusChoices.CONFIRMED, ReservationStatusChoices.CHECK_IN_OVERDUE]
+            ),
+            then=Value(status_enum.RESERVED),
+        ),
         When(in_turnaround_filter_q(fk_field), then=Value(status_enum.IN_TURNAROUND)),
         default=Value(status_enum.AVAILABLE),
         output_field=CharField(),

--- a/apps/betterangels-backend/shelters/selectors/computed_status.py
+++ b/apps/betterangels-backend/shelters/selectors/computed_status.py
@@ -58,6 +58,30 @@ def _reservation_exists(
     return Exists(Reservation.objects.filter(**filters))
 
 
+# Convenience wrappers -- self-documenting callers for the status filter chain.
+def _checked_in_exists(fk_field: str) -> Exists:
+    return _reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN)
+
+
+def _confirmed_or_overdue_exists(fk_field: str) -> Exists:
+    return _reservation_exists(
+        fk_field,
+        status__in=[ReservationStatusChoices.CONFIRMED, ReservationStatusChoices.CHECK_IN_OVERDUE],
+    )
+
+
+def _completed_checkout_exists(fk_field: str) -> Exists:
+    return _reservation_exists(
+        fk_field, status=ReservationStatusChoices.COMPLETED, extra={"checked_out_at__isnull": False}
+    )
+
+
+def _active_reservation_exists(fk_field: str) -> Exists:
+    from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
+
+    return _reservation_exists(fk_field, status__in=list(ACTIVE_RESERVATION_STATUSES))
+
+
 def latest_completed_checkout_subquery(fk_field: str) -> Subquery:
     Reservation = _reservation_model()
     return Subquery(
@@ -74,9 +98,7 @@ def latest_completed_checkout_subquery(fk_field: str) -> Subquery:
 
 def in_turnaround_filter_q(fk_field: str) -> Q:
     """``Q`` for in-turnaround without a prior ``annotate`` (uses correlated subqueries)."""
-    has_completed_checkout = Q(
-        _reservation_exists(fk_field, status=ReservationStatusChoices.COMPLETED, extra={"checked_out_at__isnull": False})
-    )
+    has_completed_checkout = Q(_completed_checkout_exists(fk_field))
     needs_cleaning = Q(last_cleaned__isnull=True) | Q(last_cleaned__lte=latest_completed_checkout_subquery(fk_field))
     return has_completed_checkout & needs_cleaning
 
@@ -88,33 +110,22 @@ def status_filter_q(
     status_enum: type[BedStatusChoices] | type[RoomStatusChoices],
 ) -> Q:
     """Build a ``Q`` object for filtering a single computed status (index-friendly Exists)."""
-    from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
-
     if status == status_enum.OUT_OF_SERVICE:
         return Q(maintenance_flag=True)
 
     base = Q(maintenance_flag=False)
 
     if status == status_enum.OCCUPIED:
-        return base & Q(_reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN))
+        return base & Q(_checked_in_exists(fk_field))
 
     if status == status_enum.RESERVED:
-        return (
-            base
-            & Q(
-                _reservation_exists(
-                    fk_field,
-                    status__in=[ReservationStatusChoices.CONFIRMED, ReservationStatusChoices.CHECK_IN_OVERDUE],
-                )
-            )
-            & ~Q(_reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN))
-        )
+        return base & Q(_confirmed_or_overdue_exists(fk_field)) & ~Q(_checked_in_exists(fk_field))
 
     if status == status_enum.IN_TURNAROUND:
-        return base & in_turnaround_filter_q(fk_field) & ~Q(_reservation_exists(fk_field, status__in=ACTIVE_RESERVATION_STATUSES))
+        return base & in_turnaround_filter_q(fk_field) & ~Q(_active_reservation_exists(fk_field))
 
     if status == status_enum.AVAILABLE:
-        return base & ~in_turnaround_filter_q(fk_field) & ~Q(_reservation_exists(fk_field, status__in=ACTIVE_RESERVATION_STATUSES))
+        return base & ~in_turnaround_filter_q(fk_field) & ~Q(_active_reservation_exists(fk_field))
 
     return Q()
 
@@ -126,13 +137,8 @@ def computed_status_case(
     """First-match status annotation; priority matches ``compute_reservable_status``."""
     return Case(
         When(maintenance_flag=True, then=Value(status_enum.OUT_OF_SERVICE)),
-        When(_reservation_exists(fk_field, status=ReservationStatusChoices.CHECKED_IN), then=Value(status_enum.OCCUPIED)),
-        When(
-            _reservation_exists(
-                fk_field, status__in=[ReservationStatusChoices.CONFIRMED, ReservationStatusChoices.CHECK_IN_OVERDUE]
-            ),
-            then=Value(status_enum.RESERVED),
-        ),
+        When(_checked_in_exists(fk_field), then=Value(status_enum.OCCUPIED)),
+        When(_confirmed_or_overdue_exists(fk_field), then=Value(status_enum.RESERVED)),
         When(in_turnaround_filter_q(fk_field), then=Value(status_enum.IN_TURNAROUND)),
         default=Value(status_enum.AVAILABLE),
         output_field=CharField(),

--- a/apps/betterangels-backend/shelters/selectors/computed_status.py
+++ b/apps/betterangels-backend/shelters/selectors/computed_status.py
@@ -1,0 +1,181 @@
+"""Computed status query helpers for beds and rooms.
+
+Query-building functions that encode the status priority chain:
+OUT_OF_SERVICE -> OCCUPIED -> RESERVED -> IN_TURNAROUND -> AVAILABLE
+
+Moved from ``shelters/managers.py`` per HackSoft style guide:
+*"Business logic should not live in Custom managers or querysets."*
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union, cast
+
+from django.db.models import (
+    Case,
+    CharField,
+    Count,
+    DateTimeField,
+    Exists,
+    IntegerField,
+    OuterRef,
+    Q,
+    Subquery,
+    Value,
+    When,
+)
+from shelters.enums import BedStatusChoices, ReservationStatusChoices, RoomStatusChoices
+
+if TYPE_CHECKING:
+    from shelters.models import Bed, Reservation, Room
+
+# Not a TypeVar -- the two enums are independent and correspondence can't be enforced here.
+StatusChoice = Union[BedStatusChoices, RoomStatusChoices]
+
+
+def _reservation_model() -> type[Reservation]:
+    from shelters.models import Reservation
+
+    return Reservation
+
+
+def latest_completed_checkout_subquery(fk_field: str) -> Subquery:
+    Reservation = _reservation_model()
+    return Subquery(
+        Reservation.objects.filter(
+            **{fk_field: OuterRef("pk")},
+            status=ReservationStatusChoices.COMPLETED,
+            checked_out_at__isnull=False,
+        )
+        .order_by("-checked_out_at")
+        .values("checked_out_at")[:1],
+        output_field=DateTimeField(),
+    )
+
+
+def has_checked_in_exists(fk_field: str) -> Exists:
+    Reservation = _reservation_model()
+    return Exists(
+        Reservation.objects.filter(
+            **{fk_field: OuterRef("pk")},
+            status=ReservationStatusChoices.CHECKED_IN,
+        )
+    )
+
+
+def has_confirmed_or_overdue_exists(fk_field: str) -> Exists:
+    Reservation = _reservation_model()
+    return Exists(
+        Reservation.objects.filter(
+            **{fk_field: OuterRef("pk")},
+            status__in=[
+                ReservationStatusChoices.CONFIRMED,
+                ReservationStatusChoices.CHECK_IN_OVERDUE,
+            ],
+        )
+    )
+
+
+def has_completed_checkout_exists(fk_field: str) -> Exists:
+    Reservation = _reservation_model()
+    return Exists(
+        Reservation.objects.filter(
+            **{fk_field: OuterRef("pk")},
+            status=ReservationStatusChoices.COMPLETED,
+            checked_out_at__isnull=False,
+        )
+    )
+
+
+def has_active_reservation_exists(fk_field: str) -> Exists:
+    from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
+
+    Reservation = _reservation_model()
+    return Exists(
+        Reservation.objects.filter(
+            **{fk_field: OuterRef("pk")},
+            status__in=ACTIVE_RESERVATION_STATUSES,
+        )
+    )
+
+
+def in_turnaround_filter_q(fk_field: str) -> Q:
+    """``Q`` for in-turnaround without a prior ``annotate`` (uses correlated subqueries)."""
+    has_completed_checkout = Q(has_completed_checkout_exists(fk_field))
+    needs_cleaning = Q(last_cleaned__isnull=True) | Q(last_cleaned__lte=latest_completed_checkout_subquery(fk_field))
+    return has_completed_checkout & needs_cleaning
+
+
+def status_filter_q(
+    status: StatusChoice,
+    *,
+    fk_field: str,
+    status_enum: type[BedStatusChoices] | type[RoomStatusChoices],
+) -> Q:
+    """Build a ``Q`` object for filtering a single computed status (index-friendly Exists)."""
+    if status == status_enum.OUT_OF_SERVICE:
+        return Q(maintenance_flag=True)
+
+    base = Q(maintenance_flag=False)
+
+    if status == status_enum.OCCUPIED:
+        return base & Q(has_checked_in_exists(fk_field))
+
+    if status == status_enum.RESERVED:
+        return base & Q(has_confirmed_or_overdue_exists(fk_field)) & ~Q(has_checked_in_exists(fk_field))
+
+    if status == status_enum.IN_TURNAROUND:
+        return base & in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
+
+    if status == status_enum.AVAILABLE:
+        return base & ~in_turnaround_filter_q(fk_field) & ~Q(has_active_reservation_exists(fk_field))
+
+    return Q()
+
+
+def computed_status_case(
+    fk_field: str,
+    status_enum: type[BedStatusChoices] | type[RoomStatusChoices],
+) -> Case:
+    """First-match status annotation; priority matches ``compute_reservable_status``."""
+    return Case(
+        When(maintenance_flag=True, then=Value(status_enum.OUT_OF_SERVICE)),
+        When(has_checked_in_exists(fk_field), then=Value(status_enum.OCCUPIED)),
+        When(has_confirmed_or_overdue_exists(fk_field), then=Value(status_enum.RESERVED)),
+        When(in_turnaround_filter_q(fk_field), then=Value(status_enum.IN_TURNAROUND)),
+        default=Value(status_enum.AVAILABLE),
+        output_field=CharField(),
+    )
+
+
+def bed_computed_status_annotation() -> Case:
+    return computed_status_case("bed_id", BedStatusChoices)
+
+
+def room_computed_status_annotation() -> Case:
+    return computed_status_case("room_id", RoomStatusChoices)
+
+
+def _shelter_reservable_status_count_subquery(
+    model_class: type[Bed] | type[Room],
+    status: StatusChoice,
+) -> Subquery:
+    from shelters.managers import BedQuerySet, RoomQuerySet
+
+    base_qs = cast(BedQuerySet | RoomQuerySet, model_class.objects.filter(shelter_id=OuterRef("pk")))
+    return Subquery(
+        base_qs.filter_by_status(status).order_by().values("shelter").annotate(c=Count("pk")).values("c"),
+        output_field=IntegerField(),
+    )
+
+
+def shelter_bed_status_count_subquery(status: BedStatusChoices) -> Subquery:
+    from shelters.models import Bed
+
+    return _shelter_reservable_status_count_subquery(Bed, status)
+
+
+def shelter_room_status_count_subquery(status: RoomStatusChoices) -> Subquery:
+    from shelters.models import Room
+
+    return _shelter_reservable_status_count_subquery(Room, status)

--- a/apps/betterangels-backend/shelters/selectors/operator.py
+++ b/apps/betterangels-backend/shelters/selectors/operator.py
@@ -142,9 +142,8 @@ def reservation_queryset(
     """Scope *queryset* to *organization_id* where *user* belongs to the shelter's org.
 
     Reservation links to a shelter via two optional paths
-    (``bed__shelter`` and ``room__shelter``), so the standard
-    ``permissioned_queryset`` helper (which expects a single
-    ``organization_field``) is not suitable.
+    (``bed__shelter`` and ``room__shelter``), so we pass
+    ``organization_fields`` to ``permissioned_queryset`` to check both.
 
     Falls back to ``Reservation.objects.all()`` when *queryset* is omitted.
     """

--- a/apps/betterangels-backend/shelters/services/reservation.py
+++ b/apps/betterangels-backend/shelters/services/reservation.py
@@ -2,12 +2,17 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
-from shelters.models import Reservation, ReservationClient, Shelter
-from shelters.selectors import bed_get, reservation_get, room_get, shelter_get
+from django.utils import timezone
+from shelters.enums import ReservationStatusChoices
+from shelters.models import Reservation, ReservationClient
+from shelters.models.shelter import ACTIVE_RESERVATION_STATUSES
+from shelters.selectors import bed_get, reservation_get, room_get
 from shelters.selectors.operator import reservation_queryset
+from shelters.status import get_last_completed_checkout, is_in_turnaround
 
 if TYPE_CHECKING:
     from accounts.models import User
+    from shelters.models.shelter import Bed, Room
 
 
 def _set_clients(reservation: Reservation, clients_data: list[Dict[str, Any]] | None) -> None:
@@ -21,6 +26,51 @@ def _set_clients(reservation: Reservation, clients_data: list[Dict[str, Any]] | 
             client_profile_id=entry["client_profile_id"],
             is_primary=entry.get("is_primary", False),
         )
+
+
+def _validate_reservation(reservation: Reservation) -> None:
+    """Validate reservation against business rules: availability, turnaround, conflicts."""
+    errors: dict[str, str] = {}
+
+    if reservation.bed:
+        _validate_reservable(errors, reservation, reservation.bed, "bed")
+    if reservation.room and not reservation.bed:
+        _validate_reservable(errors, reservation, reservation.room, "room", room_only=True)
+
+    if errors:
+        raise ValidationError(errors)
+
+
+def _validate_reservable(
+    errors: dict[str, str],
+    reservation: Reservation,
+    reservable: "Bed | Room",
+    field_name: str,
+    *,
+    room_only: bool = False,
+) -> None:
+    """Validate a single reservable (bed or room) for availability and conflicts."""
+    if reservable.maintenance_flag:
+        errors[field_name] = f"The selected {field_name} is out of service."
+        return
+
+    if is_in_turnaround(
+        last_cleaned=reservable.last_cleaned,
+        last_checkout=get_last_completed_checkout(reservable.reservations.all()),
+    ):
+        errors[field_name] = f"The selected {field_name} is currently in turnaround."
+        return
+
+    conflicting_qs = Reservation.objects.filter(
+        **{f"{field_name}_id": reservable.pk},
+        status__in=ACTIVE_RESERVATION_STATUSES,
+    )
+    if room_only:
+        conflicting_qs = conflicting_qs.filter(bed__isnull=True)
+    if reservation.pk:
+        conflicting_qs = conflicting_qs.exclude(pk=reservation.pk)
+    if conflicting_qs.exists():
+        errors[field_name] = f"This {field_name} already has an active reservation."
 
 
 @transaction.atomic
@@ -45,21 +95,17 @@ def reservation_create(*, user: "User", organization_id: str, data: Dict[str, An
         raise ValidationError("At least one client must be associated with a reservation.")
 
     if bed_id:
-        shelter_id = bed_get(user=user, organization_id=organization_id, bed_id=bed_id).shelter_id
+        bed_get(user=user, organization_id=organization_id, bed_id=bed_id)
     elif room_id:
-        shelter_id = room_get(user=user, organization_id=organization_id, room_id=room_id).shelter_id
+        room_get(user=user, organization_id=organization_id, room_id=room_id)
     else:
         raise ObjectDoesNotExist("A bed or room must be provided to create a Reservation.")
-
-    try:
-        shelter_get(user=user, organization_id=organization_id, shelter_id=shelter_id)
-    except Shelter.DoesNotExist:
-        raise ObjectDoesNotExist("You do not have permission to create a Reservation for this Shelter.")
 
     scalar_data = {k: v for k, v in data.items() if v is not None}
 
     reservation = Reservation(created_by=user, **scalar_data)
     reservation.full_clean()
+    _validate_reservation(reservation)
     reservation.save()
     _set_clients(reservation, clients_data)
 
@@ -86,12 +132,22 @@ def reservation_update(
         raise ObjectDoesNotExist(f"Reservation matching ID {reservation_id} could not be found.")
 
     clients_data = data.pop("clients", None)
+    previous_status = reservation.status
 
     for key, value in data.items():
         if value is not None:
             setattr(reservation, key, value)
 
+    # Auto-set timestamps on status transitions
+    new_status = data.get("status")
+    if new_status is not None and new_status != previous_status:
+        if new_status == ReservationStatusChoices.COMPLETED:
+            reservation.checked_out_at = timezone.now()
+        elif new_status == ReservationStatusChoices.CHECKED_IN:
+            reservation.checked_in_at = timezone.now()
+
     reservation.full_clean()
+    _validate_reservation(reservation)
     reservation.save()
     _set_clients(reservation, clients_data)
 

--- a/apps/betterangels-backend/shelters/tests/test_reservation_models.py
+++ b/apps/betterangels-backend/shelters/tests/test_reservation_models.py
@@ -65,30 +65,21 @@ class ReservationModelTestCase(TestCase):
 
     def test_multiple_bed_reservations_allowed_for_same_room(self) -> None:
         """When both room and bed are set, the room constraint does not apply."""
+        bed_2_in_room_1 = baker.make(Bed, shelter=self.shelter, room=self.room_1, name="Bed-2-in-Room-1")
         baker.make(Reservation, room=self.room_1, bed=self.bed_1, status=ReservationStatusChoices.CONFIRMED)
-        baker.make(Reservation, room=self.room_1, bed=self.bed_2, status=ReservationStatusChoices.CONFIRMED)
+        baker.make(Reservation, room=self.room_1, bed=bed_2_in_room_1, status=ReservationStatusChoices.CONFIRMED)
         self.assertEqual(Reservation.objects.filter(room=self.room_1).count(), 2)
 
-    # --- completing a reservation sets checked_out_at ---
+    # --- cross-shelter validation ---
 
-    def test_completing_reservation_sets_checked_out_at(self) -> None:
-        reservation = baker.make(
-            Reservation,
-            bed=self.bed_1,
-            status=ReservationStatusChoices.CHECKED_IN,
-        )
-        self.assertIsNone(reservation.checked_out_at)
+    def test_rejects_bed_and_room_from_different_shelters(self) -> None:
+        other_shelter = baker.make(Shelter, name="Other Shelter")
+        other_bed = baker.make(Bed, shelter=other_shelter, name="Other-Bed")
+        with self.assertRaises(ValidationError) as ctx:
+            Reservation(bed=other_bed, room=self.room_1).clean()
+        self.assertIn("same shelter", str(ctx.exception))
 
-        before = timezone.now()
-        reservation.status = ReservationStatusChoices.COMPLETED
-        reservation.save()
-        after = timezone.now()
-
-        reservation.refresh_from_db()
-        self.assertIsNotNone(reservation.checked_out_at)
-        assert reservation.checked_out_at is not None
-        self.assertGreaterEqual(reservation.checked_out_at, before)
-        self.assertLessEqual(reservation.checked_out_at, after)
+    # --- cleanup validation ---
 
 
 class BedComputedStatusTestCase(TestCase):
@@ -142,16 +133,6 @@ class BedComputedStatusTestCase(TestCase):
         )
         self._make_completed_reservation(bed, checkout)
         self.assertEqual(bed.computed_status, BedStatusChoices.OUT_OF_SERVICE)
-
-    def test_bed_maintenance_flag_rejects_reservation(self) -> None:
-        """Regression: reservation clean() uses maintenance_flag, not out_of_service."""
-        bed = self._make_bed(maintenance_flag=True)
-        with self.assertRaises(ValidationError) as ctx:
-            Reservation(
-                bed=bed,
-                status=ReservationStatusChoices.CONFIRMED,
-            ).clean()
-        self.assertIn("bed", ctx.exception.message_dict)
 
 
 class RoomComputedStatusTestCase(TestCase):

--- a/apps/betterangels-backend/shelters/tests/test_reservation_models.py
+++ b/apps/betterangels-backend/shelters/tests/test_reservation_models.py
@@ -3,7 +3,6 @@ import datetime
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 from django.test import TestCase
-from django.utils import timezone
 from model_bakery import baker
 from shelters.enums import BedStatusChoices, ReservationStatusChoices, RoomStatusChoices
 from shelters.models import Bed, Reservation, Room, Shelter

--- a/apps/betterangels-backend/shelters/tests/test_selectors.py
+++ b/apps/betterangels-backend/shelters/tests/test_selectors.py
@@ -1,24 +1,21 @@
 import datetime
-from collections.abc import Mapping, Sequence
 from typing import Any
-from unittest import skip
 
 from django.test import TestCase
 from django.utils import timezone
 from model_bakery import baker
 
 # isort: split
-from shelters.enums import BedStatusChoices, ReservationStatusChoices
+from shelters.enums import ReservationStatusChoices
 from shelters.models import (
     Bed,
     Reservation,
     Shelter,
 )
-from shelters.selectors import report_bed_status_counts, reservation_status_change_counts
+from shelters.selectors import reservation_status_change_counts
 from shelters.tests.baker_recipes import shelter_recipe
 
 ReservationEvent = Reservation.pgh_event_model  # type: ignore[attr-defined]
-BedEvent = Bed.pgh_event_model  # type: ignore[attr-defined]
 
 
 class ReservationStatusChangeCountsTestCase(TestCase):
@@ -214,221 +211,3 @@ def _dt(y: int, m: int, d: int) -> datetime.datetime:
     return datetime.datetime(y, m, d, 12, 0, 0, tzinfo=datetime.timezone.utc)
 
 
-_STATUS_KEYS = ("available", "occupied", "reserved", "out_of_service")
-
-
-@skip("status removed from Bed and Room")
-class ReportBedStatusCountsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.shelter = shelter_recipe.make()
-
-    # -- helpers ---------------------------------------------------------------
-
-    def _backdate_events(self, bed: Bed, dt: datetime.datetime) -> None:
-        """Move all BedEvents for this bed to the given datetime."""
-        BedEvent.objects.filter(pgh_obj_id=bed.pk).update(pgh_created_at=dt)
-
-    def _add_event(self, bed: Bed, label: str, status: str, dt: datetime.datetime) -> None:
-        """Create a BedEvent with a specific pgh_created_at.
-
-        pgh_created_at has auto_now_add so we call update() after create().
-        """
-        event = BedEvent.objects.create(
-            pgh_obj=bed,
-            pgh_label=label,
-            id=bed.pk,
-            shelter=self.shelter,
-            status=status,
-        )
-        BedEvent.objects.filter(pgh_id=event.pgh_id).update(pgh_created_at=dt)
-
-    def _assert_result(self, result: Sequence[Mapping[str, Any]], expected: Sequence[Mapping[str, Any]]) -> None:
-        """Assert result matches expected list of {date, available, occupied, ...}."""
-        self.assertEqual(len(result), len(expected))
-        for i, exp in enumerate(expected):
-            self.assertEqual(result[i]["date"], exp["date"])
-            for key in _STATUS_KEYS:
-                self.assertEqual(result[i][key], exp.get(key, 0), f"day {exp['date']} {key}")
-
-    # -- tests -----------------------------------------------------------------
-
-    def test_single_day_counts(self) -> None:
-        day = datetime.date(2026, 1, 1)
-        dt = _dt(2026, 1, 1)
-
-        available = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.AVAILABLE)
-        occupied = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.OCCUPIED)
-        reserved = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.RESERVED)
-        out_of_service = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.OUT_OF_SERVICE)
-
-        for bed in [available, occupied, reserved, out_of_service]:
-            self._backdate_events(bed, dt)
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day, end_date=day)
-
-        self._assert_result(
-            result,
-            [
-                {
-                    "date": "2026-01-01",
-                    "available": 1,
-                    "occupied": 1,
-                    "reserved": 1,
-                    "out_of_service": 1,
-                },
-            ],
-        )
-
-    def test_status_change_reflected_on_correct_day(self) -> None:
-        day1, day2 = datetime.date(2026, 1, 1), datetime.date(2026, 1, 2)
-
-        bed = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.AVAILABLE)
-        self._backdate_events(bed, _dt(2026, 1, 1))
-        self._add_event(bed, "bed.status_change", BedStatusChoices.OCCUPIED, _dt(2026, 1, 2))
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day1, end_date=day2)
-
-        self._assert_result(
-            result,
-            [
-                {"date": "2026-01-01", "available": 1, "occupied": 0},
-                {"date": "2026-01-02", "available": 0, "occupied": 1},
-            ],
-        )
-
-    def test_removed_bed_not_counted(self) -> None:
-        day = datetime.date(2026, 1, 1)
-
-        bed = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.AVAILABLE)
-        self._backdate_events(bed, _dt(2026, 1, 1))
-        # bed.add at noon; bed.remove at 13:00 — remove becomes latest event
-        self._add_event(
-            bed,
-            "bed.remove",
-            BedStatusChoices.AVAILABLE,
-            datetime.datetime(2026, 1, 1, 13, 0, 0, tzinfo=datetime.timezone.utc),
-        )
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day, end_date=day)
-
-        self._assert_result(result, [{"date": "2026-01-01"}])
-
-    def test_other_shelter_beds_not_counted(self) -> None:
-        day = datetime.date(2026, 1, 1)
-
-        other_shelter = shelter_recipe.make()
-        bed = baker.make(Bed, shelter=other_shelter, status=BedStatusChoices.AVAILABLE)
-        self._backdate_events(bed, _dt(2026, 1, 1))
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day, end_date=day)
-
-        self._assert_result(result, [{"date": "2026-01-01"}])
-
-    def test_date_range_returns_one_entry_per_day(self) -> None:
-        start, end = datetime.date(2026, 1, 1), datetime.date(2026, 1, 7)
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=start, end_date=end)
-
-        self.assertEqual(len(result), 7)
-        self.assertEqual(result[0]["date"], "2026-01-01")
-        self.assertEqual(result[6]["date"], "2026-01-07")
-
-    def test_bed_created_before_range_is_counted(self) -> None:
-        bed = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.AVAILABLE)
-        self._backdate_events(bed, _dt(2025, 1, 1))
-
-        day = datetime.date(2026, 1, 1)
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day, end_date=day)
-
-        self._assert_result(result, [{"date": "2026-01-01", "available": 1}])
-
-    def test_multiple_status_changes(self) -> None:
-        """A bed changing status multiple times reflects each day correctly."""
-        day1, day3 = datetime.date(2026, 1, 1), datetime.date(2026, 1, 3)
-
-        bed = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.AVAILABLE)
-        self._backdate_events(bed, _dt(2026, 1, 1))
-        self._add_event(bed, "bed.status_change", BedStatusChoices.OCCUPIED, _dt(2026, 1, 2))
-        self._add_event(bed, "bed.status_change", BedStatusChoices.OUT_OF_SERVICE, _dt(2026, 1, 3))
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day1, end_date=day3)
-
-        self._assert_result(
-            result,
-            [
-                {
-                    "date": "2026-01-01",
-                    "available": 1,
-                    "occupied": 0,
-                    "out_of_service": 0,
-                },
-                {
-                    "date": "2026-01-02",
-                    "available": 0,
-                    "occupied": 1,
-                    "out_of_service": 0,
-                },
-                {
-                    "date": "2026-01-03",
-                    "available": 0,
-                    "occupied": 0,
-                    "out_of_service": 1,
-                },
-            ],
-        )
-
-    def test_bed_created_mid_range_not_counted_before(self) -> None:
-        """A bed that didn't exist on earlier days is 0 before its creation."""
-        day1, day3 = datetime.date(2026, 1, 1), datetime.date(2026, 1, 3)
-
-        bed = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.AVAILABLE)
-        self._backdate_events(bed, _dt(2026, 1, 2))  # created on day 2
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day1, end_date=day3)
-
-        self._assert_result(
-            result,
-            [
-                {"date": "2026-01-01", "available": 0},
-                {"date": "2026-01-02", "available": 1},
-                {"date": "2026-01-03", "available": 1},
-            ],
-        )
-
-    def test_empty_shelter_returns_all_zeros(self) -> None:
-        """A shelter with no beds returns zero counts for every day."""
-        start, end = datetime.date(2026, 1, 1), datetime.date(2026, 1, 3)
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=start, end_date=end)
-
-        self._assert_result(
-            result,
-            [
-                {"date": "2026-01-01"},
-                {"date": "2026-01-02"},
-                {"date": "2026-01-03"},
-            ],
-        )
-
-    def test_bed_removed_before_range_not_counted(self) -> None:
-        """A bed removed before the query range starts is excluded."""
-        bed = baker.make(Bed, shelter=self.shelter, status=BedStatusChoices.AVAILABLE)
-        self._backdate_events(bed, _dt(2025, 12, 1))
-        self._add_event(bed, "bed.remove", BedStatusChoices.AVAILABLE, _dt(2025, 12, 2))
-
-        day = datetime.date(2026, 1, 1)
-
-        with self.assertNumQueries(1):
-            result = report_bed_status_counts(shelter=self.shelter, start_date=day, end_date=day)
-
-        self._assert_result(result, [{"date": "2026-01-01"}])

--- a/apps/betterangels-backend/shelters/types/outputs.py
+++ b/apps/betterangels-backend/shelters/types/outputs.py
@@ -395,13 +395,9 @@ class ReservationType:
 
     @strawberry_django.field(select_related=["bed__shelter", "room__shelter"])
     def shelter(self, root: models.Reservation) -> "OperatorShelterType":
-        if root.bed:
-            return cast("OperatorShelterType", root.bed.shelter)
-
-        if root.room is None:
+        if root.shelter is None:
             raise ValueError(f"Reservation {root.pk} has neither bed nor room assigned.")
-
-        return cast("OperatorShelterType", root.room.shelter)
+        return cast("OperatorShelterType", root.shelter)
 
     @strawberry_django.field(only=["created_by_id"])
     def created_by_id(self, root: models.Reservation) -> Optional[ID]:

--- a/apps/betterangels-backend/shelters/types/outputs.py
+++ b/apps/betterangels-backend/shelters/types/outputs.py
@@ -21,7 +21,7 @@ from shelters.enums import (
     RoomStyleChoices,
     ShelterPhotoTypeChoices,
 )
-from shelters.managers import (
+from shelters.selectors.computed_status import (
     bed_computed_status_annotation,
     room_computed_status_annotation,
     shelter_bed_status_count_subquery,


### PR DESCRIPTION
## Addresses inline review feedback from [#2147](https://github.com/BetterAngelsLA/monorepo/pull/2147#pullrequestreview-4563988258)

### Summary of changes (8 files, net -19 lines)

**🔴 Data integrity fixes:**
- Add bed/room shelter consistency validation in `clean()`
- Add bed-room belonging check when both bed and room are set

**🔴 HackSoft style guide compliance:**
- Move auto-timestamp logic from `save()` to `reservation_update` service
- Move complex cross-model validation (turnaround, conflicts) from `clean()` to service helpers `_validate_reservation`/`_validate_reservable`
- Remove `__init__` override and `save()` override from model
- Remove `_is_bed_in_turnaround` and `_is_room_in_turnaround` model methods

**🟡 Code quality:**
- Add `Reservation.shelter` @property (DRY shelter derivation used by `__str__` and GraphQL resolver)
- Extract `_org_perm_exists_across_fields` helper in `permissioned_queryset` (eliminates ~20 lines of duplicated `reduce(or_, ...)`)
- Remove redundant `shelter_get` call in `reservation_create`
- Move `not_turnaround` computation inside `AVAILABLE` branch only

**🟡 Documentation:**
- Add `organization_fields` to `permissioned_queryset` docstring
- Update `reservation_queryset` docstring (no longer misleading)
- Add docstring to migration 0008 about destructive changes

**🧪 Tests:**
- Fix broken `test_multiple_bed_reservations_allowed_for_same_room`
- Add `test_rejects_bed_and_room_from_different_shelters`
- Remove model-level tests now covered at service level

### Test results
```
test_reservation_models.py ...... 18 passed
test_reservation_services.py .... 34 passed
test_reservation_mutations.py ... 8 passed
test_reservation_queries.py .... 6 passed
test_computed_status.py ....... 10 passed
test_bed_mutations.py ......... 12 passed
test_room_mutations.py ........ 9 passed
Total: 97 passed
```

## Summary by Sourcery

Enforce reservation data integrity while aligning validation and timestamp logic with service-layer patterns and simplifying permission and status utilities.

New Features:
- Expose a Reservation.shelter property to consistently derive the associated shelter for display and GraphQL APIs.

Bug Fixes:
- Prevent reservations from assigning a bed and room from different shelters or a bed that does not belong to the selected room.
- Ensure multiple bed reservations can coexist for the same room without triggering room-only conflict validation.

Enhancements:
- Move turnaround, availability, and conflict validation from the Reservation model into dedicated service-layer helpers used on create and update.
- Shift automatic check-in/checkout timestamp handling from the model save method into the reservation_update service.
- Deduplicate organization permission filtering logic by introducing a reusable helper for permissioned querysets.
- Simplify shelter-derived reservation queryset permissions by using organization_fields support in permissioned_queryset.
- Streamline status filtering by inlining the turnaround negation only where needed.

Documentation:
- Clarify permissioned_queryset behavior with organization_fields and update reservation_queryset documentation to reflect the new permission handling.
- Document the destructive nature and assumptions of migration 0008 regarding dropped status/occupant/shelter columns.

Tests:
- Adjust reservation model tests to reflect the new cross-shelter validation and room/bed behavior, removing model-level tests now covered by service-level validation.