### PR TITLE
open now schedule types (SDB-89)

### DIFF
--- a/libs/react/shelter/src/lib/atoms/shelterPropertyFiltersAtom.ts
+++ b/libs/react/shelter/src/lib/atoms/shelterPropertyFiltersAtom.ts
@@ -3,6 +3,7 @@ import { TShelterPropertyFilters } from '../components/ShelterSearch';
 
 export const nullShelterPropertyFilters: TShelterPropertyFilters = {
   openNow: undefined,
+  openNowScheduleTypes: undefined,
   isAccessCenter: undefined,
   pets: [],
   demographics: [],

--- a/libs/react/shelter/src/lib/components/ShelterFilters/FilterPills.tsx
+++ b/libs/react/shelter/src/lib/components/ShelterFilters/FilterPills.tsx
@@ -45,9 +45,16 @@ export function FilterPills(props: IProps) {
         pills.push({
           id: 'openNow',
           label: 'Open now',
-          clear: (prev) => ({ ...prev, openNow: undefined }),
+          clear: (prev) => ({
+            ...prev,
+            openNow: undefined,
+            openNowScheduleTypes: undefined,
+          }),
         });
       }
+      continue;
+    }
+    if (key === 'openNowScheduleTypes') {
       continue;
     }
     if (key === 'isAccessCenter') {

--- a/libs/react/shelter/src/lib/components/ShelterFilters/FilterPills.tsx
+++ b/libs/react/shelter/src/lib/components/ShelterFilters/FilterPills.tsx
@@ -1,9 +1,20 @@
 import { CloseIcon } from '@monorepo/react/icons';
 import { mergeCss } from '@monorepo/react/shared';
 import { useSetAtom } from 'jotai';
-import { shelterPropertyFiltersAtom, shelterSearchTriggerAtom } from '../../atoms';
+import { ScheduleTypeChoices } from '../../apollo';
+import {
+  shelterPropertyFiltersAtom,
+  shelterSearchTriggerAtom,
+} from '../../atoms';
 import { TShelterPropertyFilters } from '../ShelterSearch';
 import { getFilterLabel } from './config';
+
+const OPEN_NOW_SCHEDULE_TYPE_LABELS: Record<ScheduleTypeChoices, string> = {
+  [ScheduleTypeChoices.Operating]: 'Operating Hours',
+  [ScheduleTypeChoices.Intake]: 'Intake',
+  [ScheduleTypeChoices.MealService]: 'Meal Services',
+  [ScheduleTypeChoices.StaffAvailability]: 'Staff Availability',
+};
 
 type TArrayFilterKey = keyof Pick<
   TShelterPropertyFilters,
@@ -41,20 +52,30 @@ export function FilterPills(props: IProps) {
 
   for (const [key, value] of Object.entries(filters)) {
     if (key === 'openNow') {
-      if (value) {
-        pills.push({
-          id: 'openNow',
-          label: 'Open now',
-          clear: (prev) => ({
-            ...prev,
-            openNow: undefined,
-            openNowScheduleTypes: undefined,
-          }),
-        });
-      }
       continue;
     }
     if (key === 'openNowScheduleTypes') {
+      const scheduleTypes = value as ScheduleTypeChoices[] | undefined;
+      scheduleTypes?.forEach((scheduleType) => {
+        const label = OPEN_NOW_SCHEDULE_TYPE_LABELS[scheduleType];
+        if (label) {
+          pills.push({
+            id: `openNowScheduleTypes-${scheduleType}`,
+            label,
+            clear: (prev) => {
+              const nextTypes = (prev.openNowScheduleTypes ?? []).filter(
+                (t) => t !== scheduleType
+              );
+              return {
+                ...prev,
+                openNowScheduleTypes:
+                  nextTypes.length > 0 ? nextTypes : undefined,
+                openNow: nextTypes.length > 0 ? true : undefined,
+              };
+            },
+          });
+        }
+      });
       continue;
     }
     if (key === 'isAccessCenter') {

--- a/libs/react/shelter/src/lib/components/ShelterFilters/ShelterFilters.tsx
+++ b/libs/react/shelter/src/lib/components/ShelterFilters/ShelterFilters.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@apollo/client/react';
 import { Checkbox, ExpandableContainer } from '@monorepo/react/components';
 import { mergeCss } from '@monorepo/react/shared';
+import { useState } from 'react';
+import { ScheduleTypeChoices } from '../../apollo';
 import { TShelterPropertyFilters } from '../ShelterSearch';
 import { FilterSelector } from './FilterSelector';
 import { ShelterMaxStayDocument } from './__generated__/shelterMaxStay.generated';
@@ -22,11 +24,26 @@ type IProps = {
   onFiltersChange: (filters: TShelterPropertyFilters) => void;
 };
 
+const OPEN_NOW_OPTIONS: {
+  key: ScheduleTypeChoices;
+  label: string;
+}[] = [
+  { key: ScheduleTypeChoices.Operating, label: 'Operating Hours' },
+  { key: ScheduleTypeChoices.Intake, label: 'Intake' },
+  { key: ScheduleTypeChoices.MealService, label: 'Meal Services' },
+  { key: ScheduleTypeChoices.StaffAvailability, label: 'Staff Availability' },
+];
+
 export function ShelterFilters(props: IProps) {
   const { className, filters, onFiltersChange } = props;
 
   const { data: maxStayData } = useQuery(ShelterMaxStayDocument);
   const maxStayMax = maxStayData?.shelterMaxStay ?? undefined;
+
+  const initialOpenNowTypes = filters.openNowScheduleTypes ?? [];
+  const [openNowTypes, setOpenNowTypes] = useState<ScheduleTypeChoices[]>(
+    initialOpenNowTypes
+  );
 
   const parentCss = ['pb-24', className];
 
@@ -40,10 +57,20 @@ export function ShelterFilters(props: IProps) {
     });
   }
 
-  function onOpenNowChange(checked: boolean) {
+  function onOpenNowScheduleTypeChange(
+    scheduleType: ScheduleTypeChoices,
+    checked: boolean
+  ) {
+    const newTypes = checked
+      ? [...openNowTypes, scheduleType]
+      : openNowTypes.filter((t) => t !== scheduleType);
+
+    setOpenNowTypes(newTypes);
+
     onFiltersChange({
       ...filters,
-      openNow: checked,
+      openNow: newTypes.length > 0 ? true : undefined,
+      openNowScheduleTypes: newTypes.length > 0 ? newTypes : undefined,
     });
   }
 
@@ -94,12 +121,17 @@ export function ShelterFilters(props: IProps) {
           </ExpandableContainer>
         </div>
         <div className="mt-8">
-          <ExpandableContainer header="Availability">
-            <Checkbox
-              label="Open now"
-              checked={!!filters.openNow}
-              onChange={onOpenNowChange}
-            />
+          <ExpandableContainer header="Open Now">
+            {OPEN_NOW_OPTIONS.map((option) => (
+              <Checkbox
+                key={option.key}
+                label={option.label}
+                checked={openNowTypes.includes(option.key)}
+                onChange={(checked) =>
+                  onOpenNowScheduleTypeChange(option.key, checked)
+                }
+              />
+            ))}
           </ExpandableContainer>
         </div>
 

--- a/libs/react/shelter/src/lib/components/ShelterFilters/ShelterFilters.tsx
+++ b/libs/react/shelter/src/lib/components/ShelterFilters/ShelterFilters.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@apollo/client/react';
 import { Checkbox, ExpandableContainer } from '@monorepo/react/components';
 import { mergeCss } from '@monorepo/react/shared';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ScheduleTypeChoices } from '../../apollo';
 import { TShelterPropertyFilters } from '../ShelterSearch';
 import { FilterSelector } from './FilterSelector';
@@ -41,9 +41,12 @@ export function ShelterFilters(props: IProps) {
   const maxStayMax = maxStayData?.shelterMaxStay ?? undefined;
 
   const initialOpenNowTypes = filters.openNowScheduleTypes ?? [];
-  const [openNowTypes, setOpenNowTypes] = useState<ScheduleTypeChoices[]>(
-    initialOpenNowTypes
-  );
+  const [openNowTypes, setOpenNowTypes] =
+    useState<ScheduleTypeChoices[]>(initialOpenNowTypes);
+
+  useEffect(() => {
+    setOpenNowTypes(filters.openNowScheduleTypes ?? []);
+  }, [filters.openNowScheduleTypes]);
 
   const parentCss = ['pb-24', className];
 
@@ -122,16 +125,18 @@ export function ShelterFilters(props: IProps) {
         </div>
         <div className="mt-8">
           <ExpandableContainer header="Open Now">
-            {OPEN_NOW_OPTIONS.map((option) => (
-              <Checkbox
-                key={option.key}
-                label={option.label}
-                checked={openNowTypes.includes(option.key)}
-                onChange={(checked) =>
-                  onOpenNowScheduleTypeChange(option.key, checked)
-                }
-              />
-            ))}
+            <div className="flex flex-col gap-2">
+              {OPEN_NOW_OPTIONS.map((option) => (
+                <Checkbox
+                  key={option.key}
+                  label={option.label}
+                  checked={openNowTypes.includes(option.key)}
+                  onChange={(checked) =>
+                    onOpenNowScheduleTypeChange(option.key, checked)
+                  }
+                />
+              ))}
+            </div>
           </ExpandableContainer>
         </div>
 

--- a/libs/react/shelter/src/lib/components/ShelterFilters/config.ts
+++ b/libs/react/shelter/src/lib/components/ShelterFilters/config.ts
@@ -37,7 +37,7 @@ export type TShelterFilterOption = {
 
 type TSelectableFilterName = Exclude<
   keyof TShelterPropertyFilters,
-  'openNow' | 'isAccessCenter' | 'maxStay'
+  'openNow' | 'openNowScheduleTypes' | 'isAccessCenter' | 'maxStay'
 >;
 
 export type TFilterConfig = {

--- a/libs/react/shelter/src/lib/components/ShelterSearch/ResultsSource.tsx
+++ b/libs/react/shelter/src/lib/components/ShelterSearch/ResultsSource.tsx
@@ -16,7 +16,7 @@ function propertyFiltersAffectQuery(
     return false;
   }
 
-  const { openNow, ...propertyOnly } = propertyFilters;
+  const { openNow, openNowScheduleTypes, ...propertyOnly } = propertyFilters;
 
   return Object.keys(propertyOnly).length > 0;
 }

--- a/libs/react/shelter/src/lib/components/ShelterSearch/SheltersDisplay.tsx
+++ b/libs/react/shelter/src/lib/components/ShelterSearch/SheltersDisplay.tsx
@@ -63,7 +63,7 @@ export function SheltersDisplay(props: TProps) {
     }
 
     if (propertyFilters) {
-      const { openNow, isAccessCenter, maxStay, ...propertyOnlyFilters } =
+      const { openNow, openNowScheduleTypes, isAccessCenter, maxStay, ...propertyOnlyFilters } =
         propertyFilters;
 
       if (openNow) {

--- a/libs/react/shelter/src/lib/components/ShelterSearch/types.ts
+++ b/libs/react/shelter/src/lib/components/ShelterSearch/types.ts
@@ -5,12 +5,14 @@ import {
   PetChoices,
   ReferralRequirementChoices,
   RoomStyleChoices,
+  ScheduleTypeChoices,
   ShelterChoices,
   SpecialSituationRestrictionChoices,
 } from '../../apollo';
 
 export type TShelterPropertyFilters = {
   openNow?: boolean | null;
+  openNowScheduleTypes?: ScheduleTypeChoices[] | null;
   isAccessCenter?: boolean | null;
   maxStay?: { days: number; includeNull: boolean };
   demographics?: DemographicChoices[] | null;

--- a/libs/react/shelter/src/lib/pages/filters/FiltersPage.tsx
+++ b/libs/react/shelter/src/lib/pages/filters/FiltersPage.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   nullShelterPropertyFilters,
-  shelterSearchTriggerAtom,
   shelterPropertyFiltersAtom,
+  shelterSearchTriggerAtom,
 } from '../../atoms';
 import {
   FiltersActions,
@@ -34,7 +34,7 @@ export function FiltersPage() {
   }
 
   return (
-    <div className="absolute top-0 left-0 right-0 bottom-0 z-modal bg-white flex flex-col animate-slideInUp overflow-x-hidden overflow-y-auto">
+    <div className="fixed inset-0 z-modal bg-white flex flex-col animate-slideInUp overflow-x-hidden overflow-y-auto">
       <div className="md:pt-8 p-6 md:p-10 max-h-[calc(100vh-88px)] overflow-hidden overflow-y-auto">
         <div className="flex justify-between align-center mt-0 mb-4">
           <button


### PR DESCRIPTION
SDB-89

## Summary by Sourcery

Add support for filtering shelters by specific schedule types when using the "Open now" filter and wire these new filter values through the search and filter-pill logic.

New Features:
- Allow users to select specific schedule types (operating hours, intake, meal services, staff availability) for the "Open now" shelter filter.

Enhancements:
- Update filter pills and filter configuration to handle the new open-now schedule-type filters without exposing them as independent selectable filters.