### PR TITLE
fix: remove broken python-envs settings and fix defaultInterpreterPath

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,10 @@
         "GraphQL.vscode-graphql",
         "TypeScriptTeam.native-preview",
         "saoudrizwan.claude-dev"
-      ]
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+      }
     }
   },
   // Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,10 +48,7 @@
         "GraphQL.vscode-graphql",
         "TypeScriptTeam.native-preview",
         "saoudrizwan.claude-dev"
-      ],
-      "settings": {
-        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
-      }
+      ]
     }
   },
   // Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
   "eslint.format.enable": true,
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "djlint.useVenv": true,
   "[html][django-html][handlebars][hbs][mustache][jinja][jinja-html][nj][njk][nunjucks][twig]": {
     "editor.defaultFormatter": "monosans.djlint"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,6 @@
   "eslint.format.enable": true,
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
-  "python.defaultInterpreterPath": ".venv/bin/python",
   "djlint.useVenv": true,
   "[html][django-html][handlebars][hbs][mustache][jinja][jinja-html][nj][njk][nunjucks][twig]": {
     "editor.defaultFormatter": "monosans.djlint"
@@ -38,7 +37,5 @@
   "python.testing.pytestArgs": ["apps", "libs"],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
-  "python.analysis.autoImportCompletions": true,
-  "python-envs.defaultEnvManager": "ms-python.python:uv",
-  "python-envs.defaultPackageManager": "ms-python.python:uv"
+  "python.analysis.autoImportCompletions": true
 }


### PR DESCRIPTION
## What

Fixes two VS Code configuration issues in the dev container:

1. **Remove `python-envs.defaultEnvManager` and `python-envs.defaultPackageManager`** — Both referenced `ms-python.python:uv`, which is not a registered environment manager in the current Python extension (v2026.4.0). This was causing:
   > Default environment manager 'ms-python.python:uv' could not be applied: Environment manager 'ms-python.python:uv' is not registered.
   
   The `python-envs.alwaysUseUv` setting already defaults to `true`, so `uv` is still used automatically for venv creation and package installation.

2. **Fix `python.defaultInterpreterPath`** — Changed from bare relative path `.venv/bin/python` to `${workspaceFolder}/.venv/bin/python`. This resolves two problems:
   - The bare relative path could fail to resolve in some extension versions
   - Workspace settings override host machine user settings (e.g. `/opt/homebrew/bin/python3` on macOS), which would otherwise leak into the Linux dev container and cause: *"Could not resolve interpreter path '/opt/homebrew/bin/python3'"*

## Files changed

| File | Change |
|---|---|
| `.vscode/settings.json` | Removed `python-envs.defaultEnvManager` & `defaultPackageManager`; fixed `python.defaultInterpreterPath` to use `${workspaceFolder}` |
| `.devcontainer/devcontainer.json` | No changes |