### PR TITLE
[BP] fix(docker): add Dockerfile syntax directive for COPY --parents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM python:3.14.2-trixie AS base
 
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Problem

The dev-container build fails on some machines with:

```
failed to solve: dockerfile parse error on line 140: unknown flag: --parents
```

The `Dockerfile` uses `COPY --chown=... --parents ...` (introduced in the Poetry→uv migration, #2160) but has **no `# syntax=` directive**. Without one, BuildKit uses the Dockerfile frontend **bundled with the local engine**. `COPY --parents` only became part of the **stable** Dockerfile frontend in **v1.20**, so any engine whose bundled frontend is older doesn't recognize the flag and the build fails. It builds fine on newer engines / CI, which is why it slipped through.

## Fix

Add a syntax directive as the first line of the `Dockerfile`:

```dockerfile
# syntax=docker/dockerfile:1
```

This makes BuildKit fetch the latest stable 1.x frontend (≥1.20), which supports `--parents`, regardless of the engine's bundled default.

## Why `:1` (and not `:1-labs`)

`--parents` was originally a **labs** feature (Dockerfile v1.7, 2024) but was promoted to the **stable** channel in **v1.20**, so the plain stable `:1` channel is sufficient — no need to opt into the experimental labs channel.

**Source:** [moby/buildkit Dockerfile reference](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md) — `COPY --parents`, _Minimum Dockerfile version: 1.20_.

## Verification

- `Dev Containers: Rebuild and Reopen in Container` builds past the previously failing `COPY --parents` step.