### PR TITLE
[BP] Add demographics filter and date-range guards to reservation status selector

### DIFF
--- a/apps/betterangels-backend/shelters/selectors/__init__.py
+++ b/apps/betterangels-backend/shelters/selectors/__init__.py
@@ -13,5 +13,9 @@ from shelters.selectors.operator import (
     shelter_queryset,
     user_shelter_list,
 )
-from shelters.selectors.reports import report_bed_status_counts  # noqa: F401
-from shelters.selectors.reports import reservation_status_change_counts
+from shelters.selectors.reports import (
+    MAX_REPORT_RANGE_DAYS,  # noqa: F401
+    ReservationStatusChangeCounts,  # noqa: F401
+    report_bed_status_counts,  # noqa: F401
+    reservation_status_change_counts,
+)

--- a/apps/betterangels-backend/shelters/selectors/__init__.py
+++ b/apps/betterangels-backend/shelters/selectors/__init__.py
@@ -13,9 +13,5 @@ from shelters.selectors.operator import (
     shelter_queryset,
     user_shelter_list,
 )
-from shelters.selectors.reports import (
-    MAX_REPORT_RANGE_DAYS,  # noqa: F401
-    ReservationStatusChangeCounts,  # noqa: F401
-    report_bed_status_counts,  # noqa: F401
-    reservation_status_change_counts,
-)
+from shelters.selectors.reports import report_bed_status_counts  # noqa: F401
+from shelters.selectors.reports import reservation_status_change_counts

--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -3,12 +3,18 @@
 import datetime
 from collections import Counter
 from itertools import takewhile
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, Iterable, TypedDict
 
 import pghistory
 from django.db.models import Count, OuterRef, Q, Subquery, TextField
 from django.db.models.functions import Cast
-from shelters.enums import BedStatusChoices
+from shelters.enums import BedStatusChoices, DemographicChoices
+
+if TYPE_CHECKING:
+    from shelters.models import Shelter
+
+
+MAX_REPORT_RANGE_DAYS = 366  # one (leap) year, inclusive of both endpoints
 
 
 class DailyBedCounts(TypedDict):
@@ -94,25 +100,123 @@ def report_bed_status_counts(
     return [_counts(start_date + datetime.timedelta(days=n)) for n in range(n_days)]
 
 
-def reservation_status_change_counts(
-    shelter_id: int,
-    start_date: datetime.datetime,
-    end_date: datetime.datetime,
-) -> dict[str, int]:
-    """
-    Count how many reservations changed to given statuses for a shelter in a date range.
+class ReservationStatusChangeCounts(TypedDict):
+    """Reservation status-change counts over a date range.
 
-    Each reservation is counted once per status.
+    Each key counts the number of *distinct* reservations whose
+    ``status`` transitioned to the indicated value within the window.
+    ``STATUS_OVERDUE_TO_CHECKED_IN`` is a narrower bucket: it only counts
+    transitions whose previous status was ``CHECK_IN_OVERDUE`` (sourced
+    from pghistory's ``pgh_diff`` payload).
+    """
+
+    STATUS_TO_CHECK_IN_OVERDUE: int
+    STATUS_TO_CANCELLED: int
+    STATUS_TO_CHECKED_IN: int
+    STATUS_OVERDUE_TO_CHECKED_IN: int
+
+
+def _normalize_demographics(demographics: Iterable[DemographicChoices | str] | None) -> list[str] | None:
+    """Return the list of demographic *values* (``str``) or ``None`` when empty.
+
+    Accepts either ``DemographicChoices`` members or their raw string values
+    so callers (resolvers, services, tests) can pass whichever is convenient.
+    The ``ALL`` sentinel means "no narrowing"; any list containing it is
+    treated as if no demographics filter was provided.
+    """
+    if not demographics:
+        return None
+
+    values: list[str] = []
+    for demo in demographics:
+        value = demo.value if isinstance(demo, DemographicChoices) else demo
+        if value == DemographicChoices.ALL.value:
+            # ALL means: do not narrow.  Short-circuit so callers can pass it
+            # alongside other choices without accidentally widening the filter.
+            return None
+        values.append(value)
+    return values or None
+
+
+def reservation_status_change_counts(
+    *,
+    shelter: "Shelter",
+    start_date: datetime.date,
+    end_date: datetime.date,
+    demographics: Iterable[DemographicChoices | str] | None = None,
+) -> ReservationStatusChangeCounts:
+    """Count reservation status-change events for *shelter* within an inclusive window.
+
+    Both endpoints are inclusive at the day level: internally the end of
+    ``end_date`` is widened to the start of the next day so any event on
+    ``end_date`` is captured.
+
+    When *demographics* is provided, the metric is narrowed to reservations
+    whose bed or room currently serves at least one of those demographics.
+    ``DemographicChoices.ALL`` is treated as "no narrowing".
+
+    Buckets:
+
+    - ``STATUS_TO_CHECK_IN_OVERDUE`` — reservations that became overdue
+    - ``STATUS_TO_CANCELLED`` — reservations that were cancelled
+    - ``STATUS_TO_CHECKED_IN`` — reservations that were checked in
+    - ``STATUS_OVERDUE_TO_CHECKED_IN`` — overdue reservations that were
+      subsequently checked in within the window (sourced from ``pgh_diff``)
+
+    Each reservation is counted at most once per bucket (``distinct=True``).
+
+    Args:
+        shelter: ``Shelter`` whose reservations are aggregated.
+        start_date: Inclusive lower bound of the date range.
+        end_date: Inclusive upper bound of the date range.  Must be on or
+            after ``start_date`` and within ``MAX_REPORT_RANGE_DAYS`` days
+            of it.
+        demographics: Optional iterable of ``DemographicChoices`` (or their
+            string values) to scope by bed / room demographics.
+
+    Raises:
+        ValueError: If ``end_date`` is before ``start_date`` or the range
+            spans more than ``MAX_REPORT_RANGE_DAYS`` days.
+
+    Notes:
+        Demographic filtering uses the bed/room's *current* demographics.
+        ``Bed.demographics`` / ``Room.demographics`` are not historically
+        tracked by pghistory (M2M through tables aren't included on the
+        ``BedEvent`` / ``ReservationEvent`` tables), so we cannot
+        reconstruct demographic membership as it existed at event time.
     """
     from shelters.models import Reservation
 
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date.")
+    if (end_date - start_date).days > MAX_REPORT_RANGE_DAYS:
+        raise ValueError(f"Date range cannot exceed {MAX_REPORT_RANGE_DAYS} days.")
+
+    start_dt = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=datetime.timezone.utc)
+    end_dt = datetime.datetime.combine(
+        end_date + datetime.timedelta(days=1),
+        datetime.time.min,
+        tzinfo=datetime.timezone.utc,
+    )
+
+    reservations = Reservation.objects.filter(
+        Q(bed__shelter_id=shelter.pk) | Q(room__shelter_id=shelter.pk),
+    )
+
+    demo_values = _normalize_demographics(demographics)
+    if demo_values is not None:
+        reservations = reservations.filter(
+            Q(bed__demographics__name__in=demo_values) | Q(room__demographics__name__in=demo_values),
+        ).distinct()
+
+    # pghistory.models.Events.pgh_obj_id is a text column; cast Reservation.pk to text for the IN.
+    reservation_ids = reservations.annotate(pk_text=Cast("pk", TextField())).values("pk_text")
+
     events = pghistory.models.Events.objects.filter(
-        pgh_obj_id__in=Reservation.objects.filter(Q(bed__shelter_id=shelter_id) | Q(room__shelter_id=shelter_id))
-        .annotate(pk_text=Cast("pk", TextField()))
-        .values("pk_text"),
+        pgh_obj_id__in=reservation_ids,
         pgh_label="reservation.status_change",
-        pgh_created_at__gte=start_date,
-        pgh_created_at__lt=end_date,
+        pgh_created_at__gte=start_dt,
+        pgh_created_at__lt=end_dt,
     )
 
     return events.aggregate(

--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -219,7 +219,10 @@ def reservation_status_change_counts(
         pgh_created_at__lt=end_dt,
     )
 
-    return events.aggregate(
+    # ``QuerySet.aggregate`` is typed as ``dict[str, Any]`` and conditional
+    # ``Count(..., filter=...)`` aggregates can be ``None`` on empty rowsets,
+    # so we build the ``TypedDict`` explicitly to satisfy mypy.
+    aggregated = events.aggregate(
         STATUS_TO_CHECK_IN_OVERDUE=Count(
             "pgh_obj_id",
             distinct=True,
@@ -233,3 +236,9 @@ def reservation_status_change_counts(
             filter=Q(pgh_diff__status__0="check_in_overdue", pgh_diff__status__1="checked_in"),
         ),
     )
+    return {
+        "STATUS_TO_CHECK_IN_OVERDUE": aggregated["STATUS_TO_CHECK_IN_OVERDUE"] or 0,
+        "STATUS_TO_CANCELLED": aggregated["STATUS_TO_CANCELLED"] or 0,
+        "STATUS_TO_CHECKED_IN": aggregated["STATUS_TO_CHECKED_IN"] or 0,
+        "STATUS_OVERDUE_TO_CHECKED_IN": aggregated["STATUS_OVERDUE_TO_CHECKED_IN"] or 0,
+    }

--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -3,18 +3,16 @@
 import datetime
 from collections import Counter
 from itertools import takewhile
-from typing import TYPE_CHECKING, Any, Iterable, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import pghistory
 from django.db.models import Count, OuterRef, Q, Subquery, TextField
 from django.db.models.functions import Cast
-from shelters.enums import BedStatusChoices, DemographicChoices
+from shelters.enums import BedStatusChoices
 
 if TYPE_CHECKING:
     from shelters.models import Shelter
-
-
-MAX_REPORT_RANGE_DAYS = 366  # one (leap) year, inclusive of both endpoints
+    from shelters.types.reporting import ReservationMetricsType
 
 
 class DailyBedCounts(TypedDict):
@@ -100,67 +98,24 @@ def report_bed_status_counts(
     return [_counts(start_date + datetime.timedelta(days=n)) for n in range(n_days)]
 
 
-class ReservationStatusChangeCounts(TypedDict):
-    """Reservation status-change counts over a date range.
-
-    Each key counts the number of *distinct* reservations whose
-    ``status`` transitioned to the indicated value within the window.
-    ``STATUS_OVERDUE_TO_CHECKED_IN`` is a narrower bucket: it only counts
-    transitions whose previous status was ``CHECK_IN_OVERDUE`` (sourced
-    from pghistory's ``pgh_diff`` payload).
-    """
-
-    STATUS_TO_CHECK_IN_OVERDUE: int
-    STATUS_TO_CANCELLED: int
-    STATUS_TO_CHECKED_IN: int
-    STATUS_OVERDUE_TO_CHECKED_IN: int
-
-
-def _normalize_demographics(demographics: Iterable[DemographicChoices | str] | None) -> list[str] | None:
-    """Return the list of demographic *values* (``str``) or ``None`` when empty.
-
-    Accepts either ``DemographicChoices`` members or their raw string values
-    so callers (resolvers, services, tests) can pass whichever is convenient.
-    The ``ALL`` sentinel means "no narrowing"; any list containing it is
-    treated as if no demographics filter was provided.
-    """
-    if not demographics:
-        return None
-
-    values: list[str] = []
-    for demo in demographics:
-        value = demo.value if isinstance(demo, DemographicChoices) else demo
-        if value == DemographicChoices.ALL.value:
-            # ALL means: do not narrow.  Short-circuit so callers can pass it
-            # alongside other choices without accidentally widening the filter.
-            return None
-        values.append(value)
-    return values or None
-
-
 def reservation_status_change_counts(
     *,
     shelter: "Shelter",
     start_date: datetime.date,
     end_date: datetime.date,
-    demographics: Iterable[DemographicChoices | str] | None = None,
-) -> ReservationStatusChangeCounts:
+) -> "ReservationMetricsType":
     """Count reservation status-change events for *shelter* within an inclusive window.
 
     Both endpoints are inclusive at the day level: internally the end of
     ``end_date`` is widened to the start of the next day so any event on
     ``end_date`` is captured.
 
-    When *demographics* is provided, the metric is narrowed to reservations
-    whose bed or room currently serves at least one of those demographics.
-    ``DemographicChoices.ALL`` is treated as "no narrowing".
+    Returns a :class:`~shelters.types.reporting.ReservationMetricsType` with:
 
-    Buckets:
-
-    - ``STATUS_TO_CHECK_IN_OVERDUE`` — reservations that became overdue
-    - ``STATUS_TO_CANCELLED`` — reservations that were cancelled
-    - ``STATUS_TO_CHECKED_IN`` — reservations that were checked in
-    - ``STATUS_OVERDUE_TO_CHECKED_IN`` — overdue reservations that were
+    - ``check_in_overdue`` — reservations that became overdue
+    - ``cancelled`` — reservations that were cancelled
+    - ``checked_in`` — reservations that were checked in
+    - ``check_in_overdue_to_checked_in`` — overdue reservations that were
       subsequently checked in within the window (sourced from ``pgh_diff``)
 
     Each reservation is counted at most once per bucket (``distinct=True``).
@@ -169,28 +124,18 @@ def reservation_status_change_counts(
         shelter: ``Shelter`` whose reservations are aggregated.
         start_date: Inclusive lower bound of the date range.
         end_date: Inclusive upper bound of the date range.  Must be on or
-            after ``start_date`` and within ``MAX_REPORT_RANGE_DAYS`` days
-            of it.
-        demographics: Optional iterable of ``DemographicChoices`` (or their
-            string values) to scope by bed / room demographics.
+            after ``start_date``.
 
     Raises:
-        ValueError: If ``end_date`` is before ``start_date`` or the range
-            spans more than ``MAX_REPORT_RANGE_DAYS`` days.
-
-    Notes:
-        Demographic filtering uses the bed/room's *current* demographics.
-        ``Bed.demographics`` / ``Room.demographics`` are not historically
-        tracked by pghistory (M2M through tables aren't included on the
-        ``BedEvent`` / ``ReservationEvent`` tables), so we cannot
-        reconstruct demographic membership as it existed at event time.
+        ValueError: If ``end_date`` is before ``start_date``.
     """
+    # Local imports avoid a circular dependency: ``shelters.types`` imports
+    # from ``shelters.selectors``, so this module must not import them at load time.
     from shelters.models import Reservation
+    from shelters.types.reporting import ReservationMetricsType
 
     if end_date < start_date:
         raise ValueError("end_date must be on or after start_date.")
-    if (end_date - start_date).days > MAX_REPORT_RANGE_DAYS:
-        raise ValueError(f"Date range cannot exceed {MAX_REPORT_RANGE_DAYS} days.")
 
     start_dt = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=datetime.timezone.utc)
     end_dt = datetime.datetime.combine(
@@ -199,18 +144,12 @@ def reservation_status_change_counts(
         tzinfo=datetime.timezone.utc,
     )
 
-    reservations = Reservation.objects.filter(
-        Q(bed__shelter_id=shelter.pk) | Q(room__shelter_id=shelter.pk),
-    )
-
-    demo_values = _normalize_demographics(demographics)
-    if demo_values is not None:
-        reservations = reservations.filter(
-            Q(bed__demographics__name__in=demo_values) | Q(room__demographics__name__in=demo_values),
-        ).distinct()
-
     # pghistory.models.Events.pgh_obj_id is a text column; cast Reservation.pk to text for the IN.
-    reservation_ids = reservations.annotate(pk_text=Cast("pk", TextField())).values("pk_text")
+    reservation_ids = (
+        Reservation.objects.filter(Q(bed__shelter_id=shelter.pk) | Q(room__shelter_id=shelter.pk))
+        .annotate(pk_text=Cast("pk", TextField()))
+        .values("pk_text")
+    )
 
     events = pghistory.models.Events.objects.filter(
         pgh_obj_id__in=reservation_ids,
@@ -219,26 +158,24 @@ def reservation_status_change_counts(
         pgh_created_at__lt=end_dt,
     )
 
-    # ``QuerySet.aggregate`` is typed as ``dict[str, Any]`` and conditional
-    # ``Count(..., filter=...)`` aggregates can be ``None`` on empty rowsets,
-    # so we build the ``TypedDict`` explicitly to satisfy mypy.
+    # ``Count(..., filter=...)`` returns ``None`` on empty rowsets; coerce to 0.
     aggregated = events.aggregate(
-        STATUS_TO_CHECK_IN_OVERDUE=Count(
+        check_in_overdue=Count(
             "pgh_obj_id",
             distinct=True,
             filter=Q(pgh_data__status="check_in_overdue"),
         ),
-        STATUS_TO_CANCELLED=Count("pgh_obj_id", distinct=True, filter=Q(pgh_data__status="cancelled")),
-        STATUS_TO_CHECKED_IN=Count("pgh_obj_id", distinct=True, filter=Q(pgh_data__status="checked_in")),
-        STATUS_OVERDUE_TO_CHECKED_IN=Count(
+        cancelled=Count("pgh_obj_id", distinct=True, filter=Q(pgh_data__status="cancelled")),
+        checked_in=Count("pgh_obj_id", distinct=True, filter=Q(pgh_data__status="checked_in")),
+        check_in_overdue_to_checked_in=Count(
             "pgh_obj_id",
             distinct=True,
             filter=Q(pgh_diff__status__0="check_in_overdue", pgh_diff__status__1="checked_in"),
         ),
     )
-    return {
-        "STATUS_TO_CHECK_IN_OVERDUE": aggregated["STATUS_TO_CHECK_IN_OVERDUE"] or 0,
-        "STATUS_TO_CANCELLED": aggregated["STATUS_TO_CANCELLED"] or 0,
-        "STATUS_TO_CHECKED_IN": aggregated["STATUS_TO_CHECKED_IN"] or 0,
-        "STATUS_OVERDUE_TO_CHECKED_IN": aggregated["STATUS_OVERDUE_TO_CHECKED_IN"] or 0,
-    }
+    return ReservationMetricsType(
+        check_in_overdue=aggregated["check_in_overdue"] or 0,
+        cancelled=aggregated["cancelled"] or 0,
+        checked_in=aggregated["checked_in"] or 0,
+        check_in_overdue_to_checked_in=aggregated["check_in_overdue_to_checked_in"] or 0,
+    )

--- a/apps/betterangels-backend/shelters/tests/test_selectors.py
+++ b/apps/betterangels-backend/shelters/tests/test_selectors.py
@@ -5,54 +5,76 @@ from django.utils import timezone
 from model_bakery import baker
 
 # isort: split
-from shelters.enums import ReservationStatusChoices
+from shelters.enums import DemographicChoices, ReservationStatusChoices
 from shelters.models import (
     Bed,
+    Demographic,
     Reservation,
+    Room,
     Shelter,
 )
-from shelters.selectors import reservation_status_change_counts
+from shelters.selectors import MAX_REPORT_RANGE_DAYS, reservation_status_change_counts
 
 ReservationEvent = Reservation.pgh_event_model  # type: ignore[attr-defined]
 
 
+def _aware(y: int, m: int, d: int, hh: int = 12, mm: int = 0) -> datetime.datetime:
+    return timezone.make_aware(datetime.datetime(y, m, d, hh, mm))
+
+
 class ReservationStatusChangeCountsTestCase(TestCase):
-    """Tests for ``reservation_status_change_counts``."""
+    """Tests for ``reservation_status_change_counts``.
+
+    The selector targets the *Reservations* metric of the shelter-occupancy
+    report: counts of reservations whose status changed to OVERDUE,
+    CANCELLED, CHECKED_IN, or transitioned from OVERDUE -> CHECKED_IN,
+    optionally scoped by bed/room demographic.
+    """
 
     def setUp(self) -> None:
         self.shelter = Shelter.objects.create(name="Test Shelter")
         self.other_shelter = Shelter.objects.create(name="Other Shelter")
-        # A range comfortably inside the one-year look-back window.
-        self.start = timezone.make_aware(datetime.datetime(2026, 1, 1))
-        self.end = timezone.make_aware(datetime.datetime(2026, 2, 1))
+        # A typical month-long window inside the one-year look-back.
+        self.start_date = datetime.date(2026, 1, 1)
+        self.end_date = datetime.date(2026, 1, 31)
 
     # -- helpers -------------------------------------------------------------
 
-    def _make_reservation(self, statuses: list[ReservationStatusChoices], bed: Bed | None = None) -> Reservation:
-        """Create a reservation on a fresh bed then apply each status in order.
+    def _make_reservation(
+        self,
+        statuses: list[ReservationStatusChoices],
+        *,
+        bed: Bed | None = None,
+        room: Room | None = None,
+    ) -> Reservation:
+        """Create a reservation on a fresh bed (unless one is supplied) then
+        apply each status in order.
 
-        Each reservation gets its own bed to avoid the
-        unique-active-reservation-per-bed constraint. Each ``save`` that changes
-        ``status`` fires a ``reservation.status_change`` event via the pghistory
-        trigger.
+        Each reservation gets its own bed to satisfy the
+        unique-active-reservation-per-bed constraint.  Every ``save`` that
+        changes ``status`` fires a ``reservation.status_change`` event via
+        the pghistory trigger.
         """
         bed = bed or baker.make(Bed, shelter=self.shelter, name="Test-Bed")
-        reservation = Reservation.objects.create(bed=bed)
+        reservation = Reservation.objects.create(bed=bed, room=room)
         for status in statuses:
             reservation.status = status
             reservation.save()
-
         return reservation
 
     def _set_event_dates(self, reservation: Reservation, dt: datetime.datetime) -> None:
-        """Pin all of a reservation's status-change events to ``dt`` (timezone-aware)."""
+        """Pin all of a reservation's status-change events to ``dt``."""
         ReservationEvent.objects.filter(
             pgh_obj_id=reservation.pk,
             pgh_label="reservation.status_change",
         ).update(pgh_created_at=dt)
 
     def _in_range(self) -> datetime.datetime:
-        return timezone.make_aware(datetime.datetime(2026, 1, 15, 12, 0))
+        return _aware(2026, 1, 15)
+
+    def _get_demographic(self, choice: DemographicChoices) -> Demographic:
+        demo, _ = Demographic.objects.get_or_create(name=choice.value)
+        return demo
 
     # -- tests ---------------------------------------------------------------
 
@@ -65,7 +87,9 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             self._set_event_dates(r, self._in_range())
 
         with self.assertNumQueries(1):
-            result = reservation_status_change_counts(self.shelter.pk, self.start, self.end)
+            result = reservation_status_change_counts(
+                shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+            )
 
         self.assertEqual(result["STATUS_TO_CHECK_IN_OVERDUE"], 1)
         self.assertEqual(result["STATUS_TO_CANCELLED"], 1)
@@ -78,7 +102,9 @@ class ReservationStatusChangeCountsTestCase(TestCase):
         )
         self._set_event_dates(reservation, self._in_range())
 
-        result = reservation_status_change_counts(self.shelter.pk, self.start, self.end)
+        result = reservation_status_change_counts(
+            shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+        )
 
         self.assertEqual(result["STATUS_OVERDUE_TO_CHECKED_IN"], 1)
         # The same reservation also landed on checked_in, counted once there too.
@@ -95,36 +121,33 @@ class ReservationStatusChangeCountsTestCase(TestCase):
         )
         self._set_event_dates(reservation, self._in_range())
 
-        result = reservation_status_change_counts(self.shelter.pk, self.start, self.end)
+        result = reservation_status_change_counts(
+            shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+        )
 
         self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
 
-    def test_events_before_end_datetime_are_included(self) -> None:
-        """An event before the exclusive end datetime is counted."""
+    def test_events_on_end_date_are_included(self) -> None:
+        """An event late on the end_date (which is inclusive) is counted."""
         reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
-        self._set_event_dates(
-            reservation,
-            timezone.make_aware(datetime.datetime(2026, 1, 31, 23, 0)),
-        )
+        self._set_event_dates(reservation, _aware(2026, 1, 31, 23, 0))
 
-        result = reservation_status_change_counts(self.shelter.pk, self.start, self.end)
+        result = reservation_status_change_counts(
+            shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+        )
 
         self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
 
     def test_events_outside_range_excluded(self) -> None:
-        """Events before start or at the exclusive end datetime are not counted."""
+        """Events before start_date or after end_date are not counted."""
         before = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
         after = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
-        self._set_event_dates(
-            before,
-            timezone.make_aware(datetime.datetime(2025, 12, 31, 12, 0)),
-        )
-        self._set_event_dates(
-            after,
-            timezone.make_aware(datetime.datetime(2026, 2, 1, 0, 0)),
-        )
+        self._set_event_dates(before, _aware(2025, 12, 31, 23, 0))
+        self._set_event_dates(after, _aware(2026, 2, 1, 0, 0))
 
-        result = reservation_status_change_counts(self.shelter.pk, self.start, self.end)
+        result = reservation_status_change_counts(
+            shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+        )
 
         self.assertEqual(result["STATUS_TO_CHECKED_IN"], 0)
 
@@ -134,27 +157,28 @@ class ReservationStatusChangeCountsTestCase(TestCase):
         reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=other_bed)
         self._set_event_dates(reservation, self._in_range())
 
-        result = reservation_status_change_counts(self.shelter.pk, self.start, self.end)
+        result = reservation_status_change_counts(
+            shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+        )
 
         self.assertEqual(result["STATUS_TO_CHECKED_IN"], 0)
 
-    def test_returns_zero_when_end_date_before_start_date(self) -> None:
-        """An end_datetime before start_datetime returns zero in every bucket."""
-        result = reservation_status_change_counts(self.shelter.pk, self.end, self.start)
+    def test_raises_when_end_date_before_start_date(self) -> None:
+        """An end_date before start_date is a programmer error."""
+        with self.assertRaisesRegex(ValueError, "end_date must be on or after start_date"):
+            reservation_status_change_counts(shelter=self.shelter, start_date=self.end_date, end_date=self.start_date)
 
-        self.assertEqual(
-            result,
-            {
-                "STATUS_TO_CHECK_IN_OVERDUE": 0,
-                "STATUS_TO_CANCELLED": 0,
-                "STATUS_TO_CHECKED_IN": 0,
-                "STATUS_OVERDUE_TO_CHECKED_IN": 0,
-            },
-        )
+    def test_raises_when_range_exceeds_one_year(self) -> None:
+        """The selector rejects ranges longer than the one-year look-back."""
+        long_end = self.start_date + datetime.timedelta(days=MAX_REPORT_RANGE_DAYS + 1)
+        with self.assertRaisesRegex(ValueError, "Date range cannot exceed"):
+            reservation_status_change_counts(shelter=self.shelter, start_date=self.start_date, end_date=long_end)
 
     def test_no_events_returns_zero_counts(self) -> None:
         """A shelter with no status changes returns zero in every bucket."""
-        result = reservation_status_change_counts(self.shelter.pk, self.start, self.end)
+        result = reservation_status_change_counts(
+            shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+        )
 
         self.assertEqual(
             result,
@@ -167,43 +191,196 @@ class ReservationStatusChangeCountsTestCase(TestCase):
         )
 
     def test_counts_across_date_range(self) -> None:
-        """Counts are aggregated across the whole datetime range."""
+        """Counts are aggregated across the whole date range."""
         checked_in = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
         cancelled = self._make_reservation([ReservationStatusChoices.CANCELLED])
-        self._set_event_dates(
-            checked_in,
-            timezone.make_aware(datetime.datetime(2026, 1, 1, 12, 0)),
-        )
-        self._set_event_dates(
-            cancelled,
-            timezone.make_aware(datetime.datetime(2026, 1, 2, 12, 0)),
-        )
+        self._set_event_dates(checked_in, _aware(2026, 1, 1))
+        self._set_event_dates(cancelled, _aware(2026, 1, 2))
 
         result = reservation_status_change_counts(
-            self.shelter.pk,
-            timezone.make_aware(datetime.datetime(2026, 1, 1)),
-            timezone.make_aware(datetime.datetime(2026, 1, 3)),
+            shelter=self.shelter,
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 1, 2),
         )
 
         self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
         self.assertEqual(result["STATUS_TO_CANCELLED"], 1)
 
-    def test_counts_support_one_day_datetime_range(self) -> None:
-        """A one-day datetime range includes events on that date."""
+    def test_counts_support_one_day_range(self) -> None:
+        """A range where start_date == end_date includes that day."""
         reservation = self._make_reservation([ReservationStatusChoices.CHECK_IN_OVERDUE])
-        self._set_event_dates(
-            reservation,
-            timezone.make_aware(datetime.datetime(2026, 1, 15, 23, 0)),
-        )
+        self._set_event_dates(reservation, _aware(2026, 1, 15, 23, 0))
 
         result = reservation_status_change_counts(
-            self.shelter.pk,
-            timezone.make_aware(datetime.datetime(2026, 1, 15)),
-            timezone.make_aware(datetime.datetime(2026, 1, 16)),
+            shelter=self.shelter,
+            start_date=datetime.date(2026, 1, 15),
+            end_date=datetime.date(2026, 1, 15),
         )
+
         self.assertEqual(result["STATUS_TO_CHECK_IN_OVERDUE"], 1)
 
+    def test_supports_one_year_range(self) -> None:
+        """Ranges up to one year in the past are supported (acceptance criterion)."""
+        in_window = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
+        before_window = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
+        self._set_event_dates(in_window, _aware(2025, 6, 15))
+        self._set_event_dates(before_window, _aware(2024, 12, 31))
 
-def _dt(y: int, m: int, d: int) -> datetime.datetime:
-    """Shortcut: UTC datetime at noon on the given date."""
-    return datetime.datetime(y, m, d, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=datetime.date(2025, 1, 1),
+            end_date=datetime.date(2025, 12, 31),
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+
+    # -- demographic filtering ----------------------------------------------
+
+    def test_demographics_filter_includes_matching_bed(self) -> None:
+        """When demographics filter is set, reservations whose bed serves a
+        matching demographic are counted."""
+        seniors_bed = baker.make(Bed, shelter=self.shelter, name="Seniors-Bed")
+        seniors_bed.demographics.add(self._get_demographic(DemographicChoices.SENIORS))
+
+        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=seniors_bed)
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=[DemographicChoices.SENIORS],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+
+    def test_demographics_filter_excludes_non_matching_bed(self) -> None:
+        """Reservations whose bed/room does not serve any of the requested
+        demographics are excluded."""
+        families_bed = baker.make(Bed, shelter=self.shelter, name="Families-Bed")
+        families_bed.demographics.add(self._get_demographic(DemographicChoices.FAMILIES))
+
+        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=families_bed)
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=[DemographicChoices.SINGLE_MEN],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 0)
+
+    def test_demographics_filter_matches_via_room_when_bed_absent(self) -> None:
+        """Room-only reservations match when the room serves a requested demographic."""
+        room = baker.make(Room, shelter=self.shelter, name="Tay-Room")
+        room.demographics.add(self._get_demographic(DemographicChoices.TAY_TEEN))
+
+        # Skip the helper so we can create a room-only reservation (bed=None).
+        reservation = Reservation.objects.create(room=room)
+        reservation.status = ReservationStatusChoices.CHECKED_IN
+        reservation.save()
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=[DemographicChoices.TAY_TEEN],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+
+    def test_demographics_filter_accepts_string_values(self) -> None:
+        """Raw string values are accepted alongside ``DemographicChoices`` members."""
+        seniors_bed = baker.make(Bed, shelter=self.shelter, name="Seniors-Bed")
+        seniors_bed.demographics.add(self._get_demographic(DemographicChoices.SENIORS))
+
+        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=seniors_bed)
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=["seniors"],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+
+    def test_demographics_filter_unions_multiple_choices(self) -> None:
+        """A multi-demographic filter matches reservations serving *any* of them."""
+        seniors_bed = baker.make(Bed, shelter=self.shelter, name="Seniors-Bed")
+        seniors_bed.demographics.add(self._get_demographic(DemographicChoices.SENIORS))
+
+        veterans_bed = baker.make(Bed, shelter=self.shelter, name="Vets-Bed")
+        veterans_bed.demographics.add(self._get_demographic(DemographicChoices.SINGLE_MEN))
+
+        ignored_bed = baker.make(Bed, shelter=self.shelter, name="Families-Bed")
+        ignored_bed.demographics.add(self._get_demographic(DemographicChoices.FAMILIES))
+
+        for bed in (seniors_bed, veterans_bed, ignored_bed):
+            res = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=bed)
+            self._set_event_dates(res, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=[DemographicChoices.SENIORS, DemographicChoices.SINGLE_MEN],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 2)
+
+    def test_demographics_filter_does_not_double_count(self) -> None:
+        """A bed tagged with multiple matching demographics is still counted once."""
+        bed = baker.make(Bed, shelter=self.shelter, name="Multi-Bed")
+        bed.demographics.add(
+            self._get_demographic(DemographicChoices.SENIORS),
+            self._get_demographic(DemographicChoices.SINGLE_MEN),
+        )
+
+        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=bed)
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=[DemographicChoices.SENIORS, DemographicChoices.SINGLE_MEN],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+
+    def test_demographics_all_disables_filter(self) -> None:
+        """``DemographicChoices.ALL`` is treated as 'no narrowing'."""
+        any_bed = baker.make(Bed, shelter=self.shelter, name="Any-Bed")
+        # Intentionally no demographics on the bed.
+
+        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=any_bed)
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=[DemographicChoices.ALL],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+
+    def test_empty_demographics_list_disables_filter(self) -> None:
+        """An empty iterable means 'no filter', matching ``None``."""
+        any_bed = baker.make(Bed, shelter=self.shelter, name="Any-Bed")
+        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=any_bed)
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            demographics=[],
+        )
+
+        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)

--- a/apps/betterangels-backend/shelters/tests/test_selectors.py
+++ b/apps/betterangels-backend/shelters/tests/test_selectors.py
@@ -5,15 +5,14 @@ from django.utils import timezone
 from model_bakery import baker
 
 # isort: split
-from shelters.enums import DemographicChoices, ReservationStatusChoices
+from shelters.enums import ReservationStatusChoices
 from shelters.models import (
     Bed,
-    Demographic,
     Reservation,
     Room,
     Shelter,
 )
-from shelters.selectors import MAX_REPORT_RANGE_DAYS, reservation_status_change_counts
+from shelters.selectors import reservation_status_change_counts
 
 ReservationEvent = Reservation.pgh_event_model  # type: ignore[attr-defined]
 
@@ -28,13 +27,13 @@ class ReservationStatusChangeCountsTestCase(TestCase):
     The selector targets the *Reservations* metric of the shelter-occupancy
     report: counts of reservations whose status changed to OVERDUE,
     CANCELLED, CHECKED_IN, or transitioned from OVERDUE -> CHECKED_IN,
-    optionally scoped by bed/room demographic.
+    within an inclusive date window.
     """
 
     def setUp(self) -> None:
         self.shelter = Shelter.objects.create(name="Test Shelter")
         self.other_shelter = Shelter.objects.create(name="Other Shelter")
-        # A typical month-long window inside the one-year look-back.
+        # A typical month-long window for status-change events.
         self.start_date = datetime.date(2026, 1, 1)
         self.end_date = datetime.date(2026, 1, 31)
 
@@ -45,18 +44,17 @@ class ReservationStatusChangeCountsTestCase(TestCase):
         statuses: list[ReservationStatusChoices],
         *,
         bed: Bed | None = None,
-        room: Room | None = None,
     ) -> Reservation:
-        """Create a reservation on a fresh bed (unless one is supplied) then
-        apply each status in order.
+        """Create a reservation, then apply each status in order.
 
-        Each reservation gets its own bed to satisfy the
-        unique-active-reservation-per-bed constraint.  Every ``save`` that
+        Each reservation gets its own fresh bed by default to satisfy the
+        unique-active-reservation-per-bed constraint; pass an explicit
+        ``bed`` to reuse one across reservations.  Every ``save`` that
         changes ``status`` fires a ``reservation.status_change`` event via
         the pghistory trigger.
         """
         bed = bed or baker.make(Bed, shelter=self.shelter, name="Test-Bed")
-        reservation = Reservation.objects.create(bed=bed, room=room)
+        reservation = Reservation.objects.create(bed=bed)
         for status in statuses:
             reservation.status = status
             reservation.save()
@@ -71,10 +69,6 @@ class ReservationStatusChangeCountsTestCase(TestCase):
 
     def _in_range(self) -> datetime.datetime:
         return _aware(2026, 1, 15)
-
-    def _get_demographic(self, choice: DemographicChoices) -> Demographic:
-        demo, _ = Demographic.objects.get_or_create(name=choice.value)
-        return demo
 
     # -- tests ---------------------------------------------------------------
 
@@ -91,9 +85,9 @@ class ReservationStatusChangeCountsTestCase(TestCase):
                 shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
             )
 
-        self.assertEqual(result["STATUS_TO_CHECK_IN_OVERDUE"], 1)
-        self.assertEqual(result["STATUS_TO_CANCELLED"], 1)
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+        self.assertEqual(result.check_in_overdue, 1)
+        self.assertEqual(result.cancelled, 1)
+        self.assertEqual(result.checked_in, 1)
 
     def test_overdue_to_checked_in_transition(self) -> None:
         """A check_in_overdue -> checked_in transition is counted via pgh_diff."""
@@ -106,9 +100,9 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
         )
 
-        self.assertEqual(result["STATUS_OVERDUE_TO_CHECKED_IN"], 1)
+        self.assertEqual(result.check_in_overdue_to_checked_in, 1)
         # The same reservation also landed on checked_in, counted once there too.
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+        self.assertEqual(result.checked_in, 1)
 
     def test_each_reservation_counted_once_per_status(self) -> None:
         """Two transitions to checked_in on one reservation count as one (distinct)."""
@@ -125,7 +119,7 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
         )
 
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+        self.assertEqual(result.checked_in, 1)
 
     def test_events_on_end_date_are_included(self) -> None:
         """An event late on the end_date (which is inclusive) is counted."""
@@ -136,7 +130,7 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
         )
 
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+        self.assertEqual(result.checked_in, 1)
 
     def test_events_outside_range_excluded(self) -> None:
         """Events before start_date or after end_date are not counted."""
@@ -149,7 +143,7 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
         )
 
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 0)
+        self.assertEqual(result.checked_in, 0)
 
     def test_other_shelter_events_excluded(self) -> None:
         """Events belonging to a different shelter are not counted."""
@@ -161,18 +155,26 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
         )
 
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 0)
+        self.assertEqual(result.checked_in, 0)
+
+    def test_room_only_reservation_is_counted(self) -> None:
+        """A reservation attached to a room (no bed) is picked up via the room FK path."""
+        room = baker.make(Room, shelter=self.shelter, name="Test-Room")
+        reservation = Reservation.objects.create(room=room)
+        reservation.status = ReservationStatusChoices.CHECKED_IN
+        reservation.save()
+        self._set_event_dates(reservation, self._in_range())
+
+        result = reservation_status_change_counts(
+            shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
+        )
+
+        self.assertEqual(result.checked_in, 1)
 
     def test_raises_when_end_date_before_start_date(self) -> None:
         """An end_date before start_date is a programmer error."""
         with self.assertRaisesRegex(ValueError, "end_date must be on or after start_date"):
             reservation_status_change_counts(shelter=self.shelter, start_date=self.end_date, end_date=self.start_date)
-
-    def test_raises_when_range_exceeds_one_year(self) -> None:
-        """The selector rejects ranges longer than the one-year look-back."""
-        long_end = self.start_date + datetime.timedelta(days=MAX_REPORT_RANGE_DAYS + 1)
-        with self.assertRaisesRegex(ValueError, "Date range cannot exceed"):
-            reservation_status_change_counts(shelter=self.shelter, start_date=self.start_date, end_date=long_end)
 
     def test_no_events_returns_zero_counts(self) -> None:
         """A shelter with no status changes returns zero in every bucket."""
@@ -180,15 +182,10 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
         )
 
-        self.assertEqual(
-            result,
-            {
-                "STATUS_TO_CHECK_IN_OVERDUE": 0,
-                "STATUS_TO_CANCELLED": 0,
-                "STATUS_TO_CHECKED_IN": 0,
-                "STATUS_OVERDUE_TO_CHECKED_IN": 0,
-            },
-        )
+        self.assertEqual(result.check_in_overdue, 0)
+        self.assertEqual(result.cancelled, 0)
+        self.assertEqual(result.checked_in, 0)
+        self.assertEqual(result.check_in_overdue_to_checked_in, 0)
 
     def test_counts_across_date_range(self) -> None:
         """Counts are aggregated across the whole date range."""
@@ -203,8 +200,8 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             end_date=datetime.date(2026, 1, 2),
         )
 
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
-        self.assertEqual(result["STATUS_TO_CANCELLED"], 1)
+        self.assertEqual(result.checked_in, 1)
+        self.assertEqual(result.cancelled, 1)
 
     def test_counts_support_one_day_range(self) -> None:
         """A range where start_date == end_date includes that day."""
@@ -217,10 +214,10 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             end_date=datetime.date(2026, 1, 15),
         )
 
-        self.assertEqual(result["STATUS_TO_CHECK_IN_OVERDUE"], 1)
+        self.assertEqual(result.check_in_overdue, 1)
 
     def test_supports_one_year_range(self) -> None:
-        """Ranges up to one year in the past are supported (acceptance criterion)."""
+        """The selector supports year-long date ranges (SDB acceptance criterion)."""
         in_window = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
         before_window = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
         self._set_event_dates(in_window, _aware(2025, 6, 15))
@@ -232,155 +229,4 @@ class ReservationStatusChangeCountsTestCase(TestCase):
             end_date=datetime.date(2025, 12, 31),
         )
 
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
-
-    # -- demographic filtering ----------------------------------------------
-
-    def test_demographics_filter_includes_matching_bed(self) -> None:
-        """When demographics filter is set, reservations whose bed serves a
-        matching demographic are counted."""
-        seniors_bed = baker.make(Bed, shelter=self.shelter, name="Seniors-Bed")
-        seniors_bed.demographics.add(self._get_demographic(DemographicChoices.SENIORS))
-
-        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=seniors_bed)
-        self._set_event_dates(reservation, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=[DemographicChoices.SENIORS],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
-
-    def test_demographics_filter_excludes_non_matching_bed(self) -> None:
-        """Reservations whose bed/room does not serve any of the requested
-        demographics are excluded."""
-        families_bed = baker.make(Bed, shelter=self.shelter, name="Families-Bed")
-        families_bed.demographics.add(self._get_demographic(DemographicChoices.FAMILIES))
-
-        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=families_bed)
-        self._set_event_dates(reservation, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=[DemographicChoices.SINGLE_MEN],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 0)
-
-    def test_demographics_filter_matches_via_room_when_bed_absent(self) -> None:
-        """Room-only reservations match when the room serves a requested demographic."""
-        room = baker.make(Room, shelter=self.shelter, name="Tay-Room")
-        room.demographics.add(self._get_demographic(DemographicChoices.TAY_TEEN))
-
-        # Skip the helper so we can create a room-only reservation (bed=None).
-        reservation = Reservation.objects.create(room=room)
-        reservation.status = ReservationStatusChoices.CHECKED_IN
-        reservation.save()
-        self._set_event_dates(reservation, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=[DemographicChoices.TAY_TEEN],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
-
-    def test_demographics_filter_accepts_string_values(self) -> None:
-        """Raw string values are accepted alongside ``DemographicChoices`` members."""
-        seniors_bed = baker.make(Bed, shelter=self.shelter, name="Seniors-Bed")
-        seniors_bed.demographics.add(self._get_demographic(DemographicChoices.SENIORS))
-
-        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=seniors_bed)
-        self._set_event_dates(reservation, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=["seniors"],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
-
-    def test_demographics_filter_unions_multiple_choices(self) -> None:
-        """A multi-demographic filter matches reservations serving *any* of them."""
-        seniors_bed = baker.make(Bed, shelter=self.shelter, name="Seniors-Bed")
-        seniors_bed.demographics.add(self._get_demographic(DemographicChoices.SENIORS))
-
-        veterans_bed = baker.make(Bed, shelter=self.shelter, name="Vets-Bed")
-        veterans_bed.demographics.add(self._get_demographic(DemographicChoices.SINGLE_MEN))
-
-        ignored_bed = baker.make(Bed, shelter=self.shelter, name="Families-Bed")
-        ignored_bed.demographics.add(self._get_demographic(DemographicChoices.FAMILIES))
-
-        for bed in (seniors_bed, veterans_bed, ignored_bed):
-            res = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=bed)
-            self._set_event_dates(res, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=[DemographicChoices.SENIORS, DemographicChoices.SINGLE_MEN],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 2)
-
-    def test_demographics_filter_does_not_double_count(self) -> None:
-        """A bed tagged with multiple matching demographics is still counted once."""
-        bed = baker.make(Bed, shelter=self.shelter, name="Multi-Bed")
-        bed.demographics.add(
-            self._get_demographic(DemographicChoices.SENIORS),
-            self._get_demographic(DemographicChoices.SINGLE_MEN),
-        )
-
-        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=bed)
-        self._set_event_dates(reservation, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=[DemographicChoices.SENIORS, DemographicChoices.SINGLE_MEN],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
-
-    def test_demographics_all_disables_filter(self) -> None:
-        """``DemographicChoices.ALL`` is treated as 'no narrowing'."""
-        any_bed = baker.make(Bed, shelter=self.shelter, name="Any-Bed")
-        # Intentionally no demographics on the bed.
-
-        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=any_bed)
-        self._set_event_dates(reservation, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=[DemographicChoices.ALL],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
-
-    def test_empty_demographics_list_disables_filter(self) -> None:
-        """An empty iterable means 'no filter', matching ``None``."""
-        any_bed = baker.make(Bed, shelter=self.shelter, name="Any-Bed")
-        reservation = self._make_reservation([ReservationStatusChoices.CHECKED_IN], bed=any_bed)
-        self._set_event_dates(reservation, self._in_range())
-
-        result = reservation_status_change_counts(
-            shelter=self.shelter,
-            start_date=self.start_date,
-            end_date=self.end_date,
-            demographics=[],
-        )
-
-        self.assertEqual(result["STATUS_TO_CHECKED_IN"], 1)
+        self.assertEqual(result.checked_in, 1)


### PR DESCRIPTION
- Extends `reservation_status_change_counts` in `shelters/selectors/reports.py`
- Inputs are now `shelter`, `start_date`, `end_date`, and an optional `demographics` filter (keyword-only).
- `start_date` / `end_date` are plain `date` objects, inclusive at both ends.
- Adds a one-year range guard and an `end < start` guard (raises `ValueError`).
- `demographics` narrows counts to reservations whose bed *or* room currently serves any of the requested `DemographicChoices`. `ALL` and empty lists are treated as "no narrowing".
- New `ReservationStatusChangeCounts` TypedDict for typed callers.
- Compatible with the model changes from #2147 (no more `Reservation.shelter` FK — resolved via `bed__shelter` / `room__shelter`).