### PR TITLE
fix: replace crypto.randomUUID() with expo-crypto in upload hooks

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/ClientDocumentUploads/useClientDocumentUpload.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/ClientDocumentUploads/useClientDocumentUpload.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client/react';
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { uploadFileToS3WithPresignedPost } from '@monorepo/expo/shared/services';
+import { randomUUID } from 'expo-crypto';
 import { ClientDocumentNamespaceEnum } from '../../../../../apollo';
 import { ClientProfileDocument } from '../../../__generated__/Client.generated';
 import {
@@ -30,7 +31,7 @@ export function useClientDocumentUpload() {
     const documentUploadMap = new Map<string, ReactNativeFile>();
 
     const uploadInputs = documents.map((doc) => {
-      const refId = crypto.randomUUID();
+      const refId = randomUUID();
 
       documentUploadMap.set(refId, doc);
 

--- a/libs/expo/betterangels/src/lib/ui-components/ClientProfilePhotoUploader/useClientProfilePhotoUpload.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientProfilePhotoUploader/useClientProfilePhotoUpload.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client/react';
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { uploadFileToS3WithPresignedPost } from '@monorepo/expo/shared/services';
+import { randomUUID } from 'expo-crypto';
 import { useCallback, useState } from 'react';
 import {
   GenerateClientProfilePhotoUploadDocument,
@@ -26,7 +27,7 @@ export function useClientProfilePhotoUpload() {
       setProcessing(true);
 
       try {
-        const refId = crypto.randomUUID();
+        const refId = randomUUID();
 
         // 1: Request presigned POST data from backend
         const result = await generateUpload({


### PR DESCRIPTION
## Problem

Users reported uploads not working in the outreach app. The error was:

```
ReferenceError: property crypto does not exist
```

## Root Cause

Commit `810ebbe11` (June 24, 2026) replaced `${Date.now()}`-based refIds with `crypto.randomUUID()` during a PR review for SDB-244. However, `crypto.randomUUID()` is a Web Crypto API that **does not exist** in the React Native/Expo runtime.

## Fix

Replace `crypto.randomUUID()` with `randomUUID()` from `expo-crypto`, which:
- Is already a project dependency
- Is already used correctly in `PdfViewer.tsx` for the same hashing purpose
- Works cross-platform (iOS, Android, Expo Web)

## Files Changed

| File | Change |
|---|---|
| `useClientProfilePhotoUpload.ts` | `crypto.randomUUID()` → `randomUUID()` from `expo-crypto` |
| `useClientDocumentUpload.ts` | `crypto.randomUUID()` → `randomUUID()` from `expo-crypto` |

The 4 web-only usages in `libs/react/shelter-operator/` were left as-is since `crypto.randomUUID()` is a standard browser API and works correctly in that context.