### PR TITLE
chore: bump outreach app version to 1.2.1 (build 75)

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.2.0',
+    version: '1.2.1',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.2.0',
+      buildNumber: '1.2.1',
       associatedDomains: [`applinks:${HOSTNAME}`],
       config: {
         usesNonExemptEncryption: false,
@@ -70,7 +70,7 @@ export default {
         },
       ],
       config: {},
-      versionCode: 74,
+      versionCode: 75,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/ClientDocumentUploads/useClientDocumentUpload.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/Docs/UploadModal/ClientDocumentUploads/useClientDocumentUpload.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client/react';
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { uploadFileToS3WithPresignedPost } from '@monorepo/expo/shared/services';
+import { randomUUID } from 'expo-crypto';
 import { ClientDocumentNamespaceEnum } from '../../../../../apollo';
 import { ClientProfileDocument } from '../../../__generated__/Client.generated';
 import {
@@ -30,7 +31,7 @@ export function useClientDocumentUpload() {
     const documentUploadMap = new Map<string, ReactNativeFile>();
 
     const uploadInputs = documents.map((doc) => {
-      const refId = crypto.randomUUID();
+      const refId = randomUUID();
 
       documentUploadMap.set(refId, doc);
 

--- a/libs/expo/betterangels/src/lib/ui-components/ClientProfilePhotoUploader/useClientProfilePhotoUpload.ts
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientProfilePhotoUploader/useClientProfilePhotoUpload.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@apollo/client/react';
 import { ReactNativeFile } from '@monorepo/expo/shared/clients';
 import { uploadFileToS3WithPresignedPost } from '@monorepo/expo/shared/services';
+import { randomUUID } from 'expo-crypto';
 import { useCallback, useState } from 'react';
 import {
   GenerateClientProfilePhotoUploadDocument,
@@ -26,7 +27,7 @@ export function useClientProfilePhotoUpload() {
       setProcessing(true);
 
       try {
-        const refId = crypto.randomUUID();
+        const refId = randomUUID();
 
         // 1: Request presigned POST data from backend
         const result = await generateUpload({


### PR DESCRIPTION
## Why

Bump the app version to ensure all users receive the crypto fix from #2184. Without a version bump, users with a cached/broken build could continue running the old `crypto.randomUUID()` code that causes uploads to fail.

## Changes

| Field | Before | After |
|---|---|---|
| `version` | 1.2.0 | **1.2.1** |
| `buildNumber` (iOS) | 1.2.0 | **1.2.1** |
| `versionCode` (Android) | 74 | **75** |

## Depends on

- [ ] #2184 (fix: replace crypto.randomUUID() with expo-crypto)