### PR TITLE
feat(shelter-operator): date-range filter foundation — logic + state (PR1)

### DIFF
--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeFilterAtom.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeFilterAtom.ts
@@ -1,0 +1,20 @@
+import { atomWithReset } from 'jotai/utils';
+import { DEFAULT_PRESET, resolvePreset } from './presets';
+import type { DateRangeFilterState } from './types';
+
+/**
+ * Default filter state, captured at module load: the dashboard opens on
+ * "Last 30 Days". Resetting the atom returns to this value.
+ */
+export const initialDateRangeFilter: DateRangeFilterState = {
+  preset: DEFAULT_PRESET,
+  range: resolvePreset(DEFAULT_PRESET),
+};
+
+/**
+ * Shared date-range filter state. One source of truth for the presets dropdown
+ * and the custom calendar — mirrors the `atomWithReset` pattern in
+ * `atoms/shelterFiltersAtom.ts`.
+ */
+export const dateRangeFilterAtom =
+  atomWithReset<DateRangeFilterState>(initialDateRangeFilter);

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeFilterAtom.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeFilterAtom.ts
@@ -2,19 +2,10 @@ import { atomWithReset } from 'jotai/utils';
 import { DEFAULT_PRESET, resolvePreset } from './presets';
 import type { DateRangeFilterState } from './types';
 
-/**
- * Default filter state, captured at module load: the dashboard opens on
- * "Last 30 Days". Resetting the atom returns to this value.
- */
 export const initialDateRangeFilter: DateRangeFilterState = {
   preset: DEFAULT_PRESET,
   range: resolvePreset(DEFAULT_PRESET),
 };
 
-/**
- * Shared date-range filter state. One source of truth for the presets dropdown
- * and the custom calendar — mirrors the `atomWithReset` pattern in
- * `atoms/shelterFiltersAtom.ts`.
- */
 export const dateRangeFilterAtom =
   atomWithReset<DateRangeFilterState>(initialDateRangeFilter);

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -1,0 +1,11 @@
+export type { DateRange, DateRangePreset, DateRangeFilterState } from './types';
+export {
+  PRESET_LABELS,
+  PRESET_ORDER,
+  DEFAULT_PRESET,
+  resolvePreset,
+} from './presets';
+export {
+  dateRangeFilterAtom,
+  initialDateRangeFilter,
+} from './dateRangeFilterAtom';

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -1,7 +1,6 @@
 export type { DateRange, DateRangePreset, DateRangeFilterState } from './types';
 export {
   PRESET_LABELS,
-  PRESET_ORDER,
   DEFAULT_PRESET,
   resolvePreset,
 } from './presets';

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.test.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.test.ts
@@ -1,0 +1,47 @@
+import { resolvePreset } from './presets';
+import type { DateRange, DateRangePreset } from './types';
+
+// Fixed reference point so the resolver is deterministic: Sat 27 Jun 2026.
+const TODAY = new Date(2026, 5, 27);
+const d = (year: number, monthIndex: number, day: number) =>
+  new Date(year, monthIndex, day);
+
+describe('resolvePreset', () => {
+  const cases: Array<{
+    preset: DateRangePreset;
+    expected: DateRange;
+  }> = [
+    {
+      preset: 'LAST_7_DAYS',
+      // inclusive 7-day window ending today
+      expected: { from: d(2026, 5, 21), to: TODAY },
+    },
+    {
+      preset: 'LAST_30_DAYS',
+      // inclusive 30-day window ending today
+      expected: { from: d(2026, 4, 29), to: TODAY },
+    },
+    {
+      preset: 'MONTH_TO_DATE',
+      expected: { from: d(2026, 5, 1), to: TODAY },
+    },
+    {
+      preset: 'YEAR_TO_DATE',
+      expected: { from: d(2026, 0, 1), to: TODAY },
+    },
+    {
+      preset: 'CUSTOM',
+      expected: { from: null, to: null },
+    },
+  ];
+
+  it.each(cases)('resolves $preset', ({ preset, expected }) => {
+    expect(resolvePreset(preset, TODAY)).toEqual(expected);
+  });
+
+  it('defaults `today` to the current date for a relative preset', () => {
+    const { from, to } = resolvePreset('LAST_7_DAYS');
+    expect(from).toBeInstanceOf(Date);
+    expect(to).toBeInstanceOf(Date);
+  });
+});

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.test.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.test.ts
@@ -1,7 +1,6 @@
 import { resolvePreset } from './presets';
 import type { DateRange, DateRangePreset } from './types';
 
-// Fixed reference point so the resolver is deterministic: Sat 27 Jun 2026.
 const TODAY = new Date(2026, 5, 27);
 const d = (year: number, monthIndex: number, day: number) =>
   new Date(year, monthIndex, day);
@@ -13,12 +12,10 @@ describe('resolvePreset', () => {
   }> = [
     {
       preset: 'LAST_7_DAYS',
-      // inclusive 7-day window ending today
       expected: { from: d(2026, 5, 21), to: TODAY },
     },
     {
       preset: 'LAST_30_DAYS',
-      // inclusive 30-day window ending today
       expected: { from: d(2026, 4, 29), to: TODAY },
     },
     {

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.ts
@@ -1,42 +1,16 @@
 import { startOfMonth, startOfYear, subDays } from 'date-fns';
 import type { DateRange, DateRangePreset } from './types';
 
-/** Human-readable labels for each preset (drives the dropdown options). */
 export const PRESET_LABELS: Record<DateRangePreset, string> = {
   LAST_7_DAYS: 'Last 7 Days',
   LAST_30_DAYS: 'Last 30 Days',
-  // Figma's label read "Month-To-Year"; treated as a typo. "Month-To-Date"
-  // pairs naturally with "Year-To-Date". See the plan's Phase 0 decisions.
   MONTH_TO_DATE: 'Month-To-Date',
   YEAR_TO_DATE: 'Year-To-Date',
   CUSTOM: 'Custom',
 };
 
-/**
- * Presets in dropdown display order. `CUSTOM` is last because it opens the
- * calendar rather than resolving to a fixed range.
- */
-export const PRESET_ORDER: readonly DateRangePreset[] = [
-  'LAST_7_DAYS',
-  'LAST_30_DAYS',
-  'MONTH_TO_DATE',
-  'YEAR_TO_DATE',
-  'CUSTOM',
-] as const;
-
-/** The preset selected by default on load. */
 export const DEFAULT_PRESET: DateRangePreset = 'LAST_30_DAYS';
 
-/**
- * Resolve a preset to a concrete date range. The single source of truth for
- * preset → range; both the dropdown and the calendar derive ranges from here.
- *
- * "Last N Days" is an inclusive window ending today, so it spans exactly N
- * calendar days (today plus the N-1 days before it).
- *
- * `CUSTOM` has no fixed range — it resolves to an empty range and the caller
- * supplies the hand-picked dates.
- */
 export function resolvePreset(
   preset: DateRangePreset,
   today: Date = new Date()

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/presets.ts
@@ -1,0 +1,56 @@
+import { startOfMonth, startOfYear, subDays } from 'date-fns';
+import type { DateRange, DateRangePreset } from './types';
+
+/** Human-readable labels for each preset (drives the dropdown options). */
+export const PRESET_LABELS: Record<DateRangePreset, string> = {
+  LAST_7_DAYS: 'Last 7 Days',
+  LAST_30_DAYS: 'Last 30 Days',
+  // Figma's label read "Month-To-Year"; treated as a typo. "Month-To-Date"
+  // pairs naturally with "Year-To-Date". See the plan's Phase 0 decisions.
+  MONTH_TO_DATE: 'Month-To-Date',
+  YEAR_TO_DATE: 'Year-To-Date',
+  CUSTOM: 'Custom',
+};
+
+/**
+ * Presets in dropdown display order. `CUSTOM` is last because it opens the
+ * calendar rather than resolving to a fixed range.
+ */
+export const PRESET_ORDER: readonly DateRangePreset[] = [
+  'LAST_7_DAYS',
+  'LAST_30_DAYS',
+  'MONTH_TO_DATE',
+  'YEAR_TO_DATE',
+  'CUSTOM',
+] as const;
+
+/** The preset selected by default on load. */
+export const DEFAULT_PRESET: DateRangePreset = 'LAST_30_DAYS';
+
+/**
+ * Resolve a preset to a concrete date range. The single source of truth for
+ * preset → range; both the dropdown and the calendar derive ranges from here.
+ *
+ * "Last N Days" is an inclusive window ending today, so it spans exactly N
+ * calendar days (today plus the N-1 days before it).
+ *
+ * `CUSTOM` has no fixed range — it resolves to an empty range and the caller
+ * supplies the hand-picked dates.
+ */
+export function resolvePreset(
+  preset: DateRangePreset,
+  today: Date = new Date()
+): DateRange {
+  switch (preset) {
+    case 'LAST_7_DAYS':
+      return { from: subDays(today, 6), to: today };
+    case 'LAST_30_DAYS':
+      return { from: subDays(today, 29), to: today };
+    case 'MONTH_TO_DATE':
+      return { from: startOfMonth(today), to: today };
+    case 'YEAR_TO_DATE':
+      return { from: startOfYear(today), to: today };
+    case 'CUSTOM':
+      return { from: null, to: null };
+  }
+}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/types.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/types.ts
@@ -1,0 +1,27 @@
+/**
+ * A committed date range. `from`/`to` are `null` until a range has been chosen
+ * (e.g. while the user is mid-selection in the calendar, or for the `CUSTOM`
+ * preset before Save).
+ */
+export type DateRange = {
+  from: Date | null;
+  to: Date | null;
+};
+
+/**
+ * The named presets offered in the filter dropdown, plus `CUSTOM` for a range
+ * picked by hand in the calendar. Manually committing dates always resolves to
+ * `CUSTOM` — a hand-picked span is never snapped back to a named preset.
+ */
+export type DateRangePreset =
+  | 'LAST_7_DAYS'
+  | 'LAST_30_DAYS'
+  | 'MONTH_TO_DATE'
+  | 'YEAR_TO_DATE'
+  | 'CUSTOM';
+
+/** The shared filter state: the active preset and its resolved range. */
+export type DateRangeFilterState = {
+  preset: DateRangePreset;
+  range: DateRange;
+};

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/types.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/types.ts
@@ -1,18 +1,8 @@
-/**
- * A committed date range. `from`/`to` are `null` until a range has been chosen
- * (e.g. while the user is mid-selection in the calendar, or for the `CUSTOM`
- * preset before Save).
- */
 export type DateRange = {
   from: Date | null;
   to: Date | null;
 };
 
-/**
- * The named presets offered in the filter dropdown, plus `CUSTOM` for a range
- * picked by hand in the calendar. Manually committing dates always resolves to
- * `CUSTOM` — a hand-picked span is never snapped back to a named preset.
- */
 export type DateRangePreset =
   | 'LAST_7_DAYS'
   | 'LAST_30_DAYS'
@@ -20,7 +10,6 @@ export type DateRangePreset =
   | 'YEAR_TO_DATE'
   | 'CUSTOM';
 
-/** The shared filter state: the active preset and its resolved range. */
 export type DateRangeFilterState = {
   preset: DateRangePreset;
   range: DateRange;


### PR DESCRIPTION
**📚 Stack — date-range filter** (merge order, top → bottom):
1. **#2190 — foundation 👈 (1/6)** · 2. #2191 — Calendar · 3. #2192 — YearGrid · 4. #2193 — presets · 5. #2194 — popover · 6. #2195 — toolbar

---

## Problem

The operator Overview/reporting dashboard can't be scoped to a date range. The filter that fixes this is built from several UI pieces (a presets dropdown and a custom calendar) that must agree on one range and one default — without a shared contract they drift.

## Solution

Establishes the shared vocabulary the rest of the feature builds on: the named presets (Last 7 / 30 Days, Month-To-Date, Year-To-Date, Custom), the rule that turns each preset into a concrete range, and one piece of shared state that defaults to **Last 30 Days**. Every later PR reads and writes this single source of truth, so the dropdown and calendar can never disagree. No UI ships here.
