### PR TITLE
feat(shelter-operator): YearGrid year picker (PR3)

### DIFF
--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.stories.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta } from '@storybook/react';
+import { useState } from 'react';
+import { YearGrid } from './YearGrid';
+
+const meta: Meta<typeof YearGrid> = {
+  component: YearGrid,
+  title: 'Date Range Filter/YearGrid',
+};
+export default meta;
+
+const storyWrapperClass =
+  'w-[18rem] rounded-2xl border border-gray-200 bg-white p-4';
+
+export const Default = () => {
+  const [year, setYear] = useState(2026);
+  return (
+    <div className={storyWrapperClass}>
+      <YearGrid selectedYear={year} currentYear={2026} onSelect={setYear} />
+    </div>
+  );
+};
+
+export const NoSelection = () => {
+  const [year, setYear] = useState<number | undefined>();
+  return (
+    <div className={storyWrapperClass}>
+      <YearGrid selectedYear={year} currentYear={2026} onSelect={setYear} />
+    </div>
+  );
+};

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.test.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { YearGrid } from './YearGrid';
+
+const CURRENT_YEAR = 2026;
+
+function renderGrid(props: Partial<Parameters<typeof YearGrid>[0]> = {}) {
+  const onSelect = vi.fn();
+  render(
+    <YearGrid currentYear={CURRENT_YEAR} onSelect={onSelect} {...props} />,
+  );
+  return onSelect;
+}
+
+const yearButton = (year: number) =>
+  screen.getByRole('button', { name: String(year) });
+
+describe('YearGrid', () => {
+  it('spans five years back and ten forward from the current year', () => {
+    renderGrid();
+
+    const labels = screen
+      .getAllByRole('button')
+      .map((button) => button.textContent);
+
+    expect(labels).toEqual(
+      Array.from({ length: 16 }, (_, i) => String(CURRENT_YEAR - 5 + i)),
+    );
+  });
+
+  it('moves the window when the current year moves', () => {
+    renderGrid({ currentYear: 2031 });
+
+    expect(screen.getByRole('button', { name: '2041' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: '2021' })).toBeNull();
+  });
+
+  it('marks only the selected year as pressed', () => {
+    renderGrid({ selectedYear: 2024 });
+
+    expect(yearButton(2024).getAttribute('aria-pressed')).toBe('true');
+    expect(yearButton(2025).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('marks the current year for assistive tech', () => {
+    renderGrid();
+
+    expect(yearButton(CURRENT_YEAR).getAttribute('aria-current')).toBe('date');
+    expect(yearButton(2024).getAttribute('aria-current')).toBeNull();
+  });
+
+  it('reports the year that was clicked', () => {
+    const onSelect = renderGrid({ selectedYear: 2026 });
+
+    fireEvent.click(yearButton(2023));
+
+    expect(onSelect).toHaveBeenCalledWith(2023);
+  });
+});

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.test.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.test.tsx
@@ -48,6 +48,19 @@ describe('YearGrid', () => {
     expect(yearButton(2024).getAttribute('aria-current')).toBeNull();
   });
 
+  it('falls back to this year when none is given', () => {
+    vi.useFakeTimers({ now: new Date(2030, 0, 15) });
+    try {
+      render(<YearGrid onSelect={vi.fn()} />);
+
+      expect(yearButton(2030).getAttribute('aria-current')).toBe('date');
+      expect(screen.getByRole('button', { name: '2040' })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: '2024' })).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('reports the year that was clicked', () => {
     const onSelect = renderGrid({ selectedYear: 2026 });
 

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
@@ -1,0 +1,65 @@
+import { mergeCss } from '@monorepo/react/shared';
+
+// TODO(date-range-filter): these years are hard-coded to match Figma
+// (a fixed 4x4 grid). Replace with a dynamic/relative window — e.g. derived
+// from today or the data's earliest year — once design confirms the range.
+// See docs/plans/date-range-filter-plan.md (Phase 0 decision #2).
+const FIRST_YEAR = 2021;
+const LAST_YEAR = 2036;
+
+const YEARS = Array.from(
+  { length: LAST_YEAR - FIRST_YEAR + 1 },
+  (_, i) => FIRST_YEAR + i
+);
+
+export interface YearGridProps {
+  /** The year currently selected (filled). */
+  selectedYear?: number;
+  /** The year to outline as "current" (defaults to today's year). */
+  currentYear?: number;
+  /** Fired when a year cell is chosen. */
+  onSelect: (year: number) => void;
+  className?: string;
+}
+
+/**
+ * 4x4 grid of selectable years. Presentational leaf — the selected year is
+ * filled (`primary-main`) and the current year is outlined.
+ */
+export function YearGrid({
+  selectedYear,
+  currentYear = new Date().getFullYear(),
+  onSelect,
+  className,
+}: YearGridProps) {
+  return (
+    <div
+      role="grid"
+      className={mergeCss(['grid grid-cols-4 gap-2 font-sans', className])}
+    >
+      {YEARS.map((year) => {
+        const isSelected = year === selectedYear;
+        const isCurrent = year === currentYear;
+        return (
+          <button
+            key={year}
+            type="button"
+            role="gridcell"
+            aria-selected={isSelected}
+            onClick={() => onSelect(year)}
+            className={mergeCss([
+              'h-10 rounded-full text-sm transition-colors',
+              isSelected
+                ? 'bg-[#008CEE] text-white hover:bg-[#0374c4]'
+                : 'text-[#383B40] hover:bg-[#F2FAFF]',
+              // outline the current year, unless it is also the filled selection
+              isCurrent && !isSelected && 'ring-1 ring-inset ring-[#008CEE]',
+            ])}
+          >
+            {year}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
@@ -50,7 +50,7 @@ export function YearGrid({
             className={mergeCss([
               'h-10 rounded-full text-sm transition-colors',
               isSelected
-                ? 'bg-[#008CEE] text-white hover:bg-[#0374c4]'
+                ? 'bg-[#008CEE] text-white hover:bg-[#0071C0]'
                 : 'text-[#383B40] hover:bg-[#F2FAFF]',
               // outline the current year, unless it is also the filled selection
               isCurrent && !isSelected && 'ring-1 ring-inset ring-[#008CEE]',

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
@@ -40,7 +40,7 @@ export function YearGrid({
               'h-10 rounded-full text-sm transition-colors',
               isSelected
                 ? 'bg-[#008CEE] text-white hover:bg-[#0071C0]'
-                : 'text-[#383B40] hover:bg-[#F2FAFF]',
+                : 'text-[#383B40] hover:bg-[#F4F6FD]',
               isCurrent && !isSelected && 'ring-1 ring-inset ring-[#008CEE]',
             ])}
           >

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
@@ -1,9 +1,5 @@
 import { mergeCss } from '@monorepo/react/shared';
 
-// TODO(date-range-filter): these years are hard-coded to match Figma
-// (a fixed 4x4 grid). Replace with a dynamic/relative window — e.g. derived
-// from today or the data's earliest year — once design confirms the range.
-// See docs/plans/date-range-filter-plan.md (Phase 0 decision #2).
 const FIRST_YEAR = 2021;
 const LAST_YEAR = 2036;
 
@@ -13,19 +9,12 @@ const YEARS = Array.from(
 );
 
 export interface YearGridProps {
-  /** The year currently selected (filled). */
   selectedYear?: number;
-  /** The year to outline as "current" (defaults to today's year). */
   currentYear?: number;
-  /** Fired when a year cell is chosen. */
   onSelect: (year: number) => void;
   className?: string;
 }
 
-/**
- * 4x4 grid of selectable years. Presentational leaf — the selected year is
- * filled (`primary-main`) and the current year is outlined.
- */
 export function YearGrid({
   selectedYear,
   currentYear = new Date().getFullYear(),
@@ -52,7 +41,6 @@ export function YearGrid({
               isSelected
                 ? 'bg-[#008CEE] text-white hover:bg-[#0071C0]'
                 : 'text-[#383B40] hover:bg-[#F2FAFF]',
-              // outline the current year, unless it is also the filled selection
               isCurrent && !isSelected && 'ring-1 ring-inset ring-[#008CEE]',
             ])}
           >

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
@@ -23,7 +23,8 @@ export function YearGrid({
 }: YearGridProps) {
   return (
     <div
-      role="grid"
+      role="group"
+      aria-label="Select year"
       className={mergeCss(['grid grid-cols-4 gap-2 font-sans', className])}
     >
       {YEARS.map((year) => {
@@ -33,8 +34,8 @@ export function YearGrid({
           <button
             key={year}
             type="button"
-            role="gridcell"
-            aria-selected={isSelected}
+            aria-pressed={isSelected}
+            aria-current={isCurrent ? 'date' : undefined}
             onClick={() => onSelect(year)}
             className={mergeCss([
               'h-10 rounded-full text-sm transition-colors',

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
@@ -1,12 +1,24 @@
 import { mergeCss } from '@monorepo/react/shared';
+import {
+  ACCENT_BG,
+  ACCENT_HOVER_BG,
+  ACCENT_RING,
+  HOVER_BG,
+  TEXT_PRIMARY,
+} from './colors';
 
-const FIRST_YEAR = 2021;
-const LAST_YEAR = 2036;
+// The window is anchored on the current year rather than fixed, so the grid
+// does not run out of future years as time passes. Sixteen years fills the
+// four-column layout exactly.
+const YEARS_BEFORE = 5;
+const YEARS_AFTER = 10;
 
-const YEARS = Array.from(
-  { length: LAST_YEAR - FIRST_YEAR + 1 },
-  (_, i) => FIRST_YEAR + i
-);
+function yearsAround(anchor: number): number[] {
+  return Array.from(
+    { length: YEARS_BEFORE + YEARS_AFTER + 1 },
+    (_, i) => anchor - YEARS_BEFORE + i,
+  );
+}
 
 export interface YearGridProps {
   selectedYear?: number;
@@ -27,7 +39,7 @@ export function YearGrid({
       aria-label="Select year"
       className={mergeCss(['grid grid-cols-4 gap-2 font-sans', className])}
     >
-      {YEARS.map((year) => {
+      {yearsAround(currentYear).map((year) => {
         const isSelected = year === selectedYear;
         const isCurrent = year === currentYear;
         return (
@@ -40,9 +52,9 @@ export function YearGrid({
             className={mergeCss([
               'h-10 rounded-full text-sm transition-colors',
               isSelected
-                ? 'bg-[#008CEE] text-white hover:bg-[#0071C0]'
-                : 'text-[#383B40] hover:bg-[#F4F6FD]',
-              isCurrent && !isSelected && 'ring-1 ring-inset ring-[#008CEE]',
+                ? `${ACCENT_BG} text-white ${ACCENT_HOVER_BG}`
+                : `${TEXT_PRIMARY} ${HOVER_BG}`,
+              isCurrent && !isSelected && `ring-1 ring-inset ${ACCENT_RING}`,
             ])}
           >
             {year}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/YearGrid.tsx
@@ -1,4 +1,5 @@
 import { mergeCss } from '@monorepo/react/shared';
+import { useState } from 'react';
 import {
   ACCENT_BG,
   ACCENT_HOVER_BG,
@@ -29,19 +30,23 @@ export interface YearGridProps {
 
 export function YearGrid({
   selectedYear,
-  currentYear = new Date().getFullYear(),
+  currentYear,
   onSelect,
   className,
 }: YearGridProps) {
+  // @eslint-react/purity: reading the clock during render is impure.
+  const [thisYear] = useState(() => new Date().getFullYear());
+  const anchorYear = currentYear ?? thisYear;
+
   return (
     <div
       role="group"
       aria-label="Select year"
       className={mergeCss(['grid grid-cols-4 gap-2 font-sans', className])}
     >
-      {yearsAround(currentYear).map((year) => {
+      {yearsAround(anchorYear).map((year) => {
         const isSelected = year === selectedYear;
-        const isCurrent = year === currentYear;
+        const isCurrent = year === anchorYear;
         return (
           <button
             key={year}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/colors.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/colors.ts
@@ -28,6 +28,22 @@ export const HOVER_BG = 'hover:bg-neutral-99';
  */
 export const RANGE_BG = 'bg-[#DCF1FF]';
 
+/** Primary accent blue fill on a selected control */
+export const ACCENT_BG = 'bg-[#008CEE]';
+
+/** Darker primary blue – hover on a selected control */
+export const ACCENT_HOVER_BG = 'hover:bg-[#0071C0]';
+
+/** Primary accent blue ring marking the current day or year */
+export const ACCENT_RING = 'ring-[#008CEE]';
+
+/*
+ * The same three scoped to react-day-picker's day cell, which renders its
+ * <button> inside the element carrying the class. Spelled out in full rather
+ * than composed from the constants above, for the reason at the top of this
+ * file.
+ */
+
 /** Primary accent blue fill on a selected day button */
 export const DAY_SELECTED_BG = '[&>button]:bg-[#008CEE]';
 

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/colors.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/colors.ts
@@ -37,12 +37,8 @@ export const ACCENT_HOVER_BG = 'hover:bg-[#0071C0]';
 /** Primary accent blue ring marking the current day or year */
 export const ACCENT_RING = 'ring-[#008CEE]';
 
-/*
- * The same three scoped to react-day-picker's day cell, which renders its
- * <button> inside the element carrying the class. Spelled out in full rather
- * than composed from the constants above, for the reason at the top of this
- * file.
- */
+// [&>button]: react-day-picker renders the day <button> inside the cell that
+// carries the class.
 
 /** Primary accent blue fill on a selected day button */
 export const DAY_SELECTED_BG = '[&>button]:bg-[#008CEE]';

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -10,3 +10,5 @@ export {
 } from './dateRangeFilterAtom';
 export { Calendar } from './Calendar';
 export type { CalendarProps, RdpDateRange } from './Calendar';
+export { YearGrid } from './YearGrid';
+export type { YearGridProps } from './YearGrid';

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -9,3 +9,5 @@ export { Calendar } from './Calendar';
 // this folder: exporting it alongside DateRange would put two different
 // "date range" shapes in the package's public API.
 export type { CalendarProps } from './Calendar';
+export { YearGrid } from './YearGrid';
+export type { YearGridProps } from './YearGrid';


### PR DESCRIPTION
**📚 Stack — date-range filter**: #2190 → #2191 → **#2192 (3/6)** → #2193 → #2194 → #2195

---

## Problem

Reaching a far-off month with next/prev arrows is slow; the design offers a year grid to jump straight to a year.

## Solution

A year picker the calendar caption opens — pick a year and the view jumps there, keeping the month. The year window is a fixed 2021–2036 to match the design, with a marked follow-up to make it dynamic once design confirms the range.

## How to test

Storybook → `Date Range Filter/YearGrid`.

## Summary by Sourcery

Add a reusable year picker for quickly selecting a year in the date-range filter.

New Features:
- Add an accessible year-selection grid with selectable years anchored around the current year.
- Expose the YearGrid component and provide Storybook examples for selected and unselected states.

Enhancements:
- Centralize shared accent styling for selected and current calendar controls.

Tests:
- Add coverage for year ranges, selection state, current-year marking, default date behavior, and selection callbacks.