### PR TITLE
feat(shelter-operator): presets dropdown wired to shared state (PR5)

### DIFF
--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.stories.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta } from '@storybook/react';
+import { format } from 'date-fns';
+import { useAtomValue } from 'jotai';
+import { useState } from 'react';
+import { dateRangeFilterAtom } from './dateRangeFilterAtom';
+import { DateRangePresetDropdown } from './DateRangePresetDropdown';
+
+const meta: Meta<typeof DateRangePresetDropdown> = {
+  component: DateRangePresetDropdown,
+  title: 'Date Range Filter/PresetDropdown',
+};
+export default meta;
+
+const fmt = (date: Date | null) => (date ? format(date, 'MM/dd/yyyy') : '—');
+
+export const WiredToAtom = () => {
+  const { preset, range } = useAtomValue(dateRangeFilterAtom);
+  const [customRequested, setCustomRequested] = useState(false);
+  return (
+    <div className="w-[20rem] space-y-3 p-4">
+      <DateRangePresetDropdown
+        onCustomSelected={() => setCustomRequested(true)}
+      />
+      <p className="font-sans text-sm text-neutral-50">
+        preset: <b>{preset}</b> · {fmt(range.from)} – {fmt(range.to)}
+      </p>
+      {customRequested && (
+        <p className="font-sans text-sm text-primary-main">
+          Custom selected → toolbar would open the calendar.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.test.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { getDefaultStore } from 'jotai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  dateRangeFilterAtom,
+  initialDateRangeFilter,
+} from './dateRangeFilterAtom';
+import { DateRangePresetDropdown } from './DateRangePresetDropdown';
+
+const store = getDefaultStore();
+
+// The dropdown positions its portal with usePortalPosition, which jsdom has no
+// ResizeObserver for.
+class NoopResizeObserver {
+  observe() {
+    return undefined;
+  }
+  unobserve() {
+    return undefined;
+  }
+  disconnect() {
+    return undefined;
+  }
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByRole('combobox'));
+}
+
+describe('DateRangePresetDropdown', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', NoopResizeObserver);
+    store.set(dateRangeFilterAtom, initialDateRangeFilter);
+  });
+
+  it('reports a Custom selection without touching the shared filter', () => {
+    const onCustomSelected = vi.fn();
+    render(<DateRangePresetDropdown onCustomSelected={onCustomSelected} />);
+
+    openMenu();
+    fireEvent.click(screen.getByText('Custom'));
+
+    expect(onCustomSelected).toHaveBeenCalledTimes(1);
+    expect(store.get(dateRangeFilterAtom)).toEqual(initialDateRangeFilter);
+  });
+
+  it('commits a non-custom preset to the shared filter', () => {
+    const onCustomSelected = vi.fn();
+    render(<DateRangePresetDropdown onCustomSelected={onCustomSelected} />);
+
+    openMenu();
+    fireEvent.click(screen.getByText('Last 7 Days'));
+
+    expect(onCustomSelected).not.toHaveBeenCalled();
+    expect(store.get(dateRangeFilterAtom).preset).toBe('LAST_7_DAYS');
+  });
+
+  it('does not throw when Custom is selected with no handler', () => {
+    render(<DateRangePresetDropdown />);
+
+    openMenu();
+    expect(() => fireEvent.click(screen.getByText('Custom'))).not.toThrow();
+    expect(store.get(dateRangeFilterAtom)).toEqual(initialDateRangeFilter);
+  });
+});

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.tsx
@@ -1,0 +1,66 @@
+import { useAtom } from 'jotai';
+import { Dropdown, toDropdownOptions, toDropdownValue } from '../base-ui/dropdown';
+import type { DropdownOption } from '../base-ui/dropdown';
+import { dateRangeFilterAtom } from './dateRangeFilterAtom';
+import { PRESET_LABELS, resolvePreset } from './presets';
+import type { DateRangePreset } from './types';
+
+export interface DateRangePresetDropdownProps {
+  /**
+   * Called when the user picks "Custom". The toolbar opens the calendar in
+   * response; the atom's range is committed later, on Save. The atom preset is
+   * intentionally not changed here.
+   */
+  onCustomSelected?: () => void;
+  /**
+   * Preset to show as selected, overriding the committed atom value. The
+   * toolbar uses it to preview "Custom" while the user edits an uncommitted
+   * calendar draft. Display-only — it does not change what selecting an option
+   * does.
+   */
+  displayPreset?: DateRangePreset;
+  className?: string;
+}
+
+// Order follows PRESET_LABELS' key order (CUSTOM last — it opens the calendar).
+const OPTIONS = toDropdownOptions(PRESET_LABELS);
+
+/**
+ * Presets dropdown wired to the shared filter atom. Picking a named preset
+ * resolves its range and writes the atom (one source of truth); picking
+ * "Custom" defers to the toolbar to open the calendar.
+ */
+export function DateRangePresetDropdown({
+  onCustomSelected,
+  displayPreset,
+  className,
+}: DateRangePresetDropdownProps) {
+  const [filter, setFilter] = useAtom(dateRangeFilterAtom);
+
+  const value = toDropdownValue(displayPreset ?? filter.preset, PRESET_LABELS);
+
+  function handleChange(option: DropdownOption<DateRangePreset> | null) {
+    // Re-clicking the active option clears the selection; keep the current
+    // filter rather than emptying it.
+    if (!option) return;
+
+    if (option.value === 'CUSTOM') {
+      onCustomSelected?.();
+      return;
+    }
+
+    setFilter({
+      preset: option.value,
+      range: resolvePreset(option.value),
+    });
+  }
+
+  return (
+    <Dropdown<DateRangePreset>
+      options={OPTIONS}
+      value={value}
+      onChange={handleChange}
+      className={className}
+    />
+  );
+}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangePresetDropdown.tsx
@@ -6,30 +6,13 @@ import { PRESET_LABELS, resolvePreset } from './presets';
 import type { DateRangePreset } from './types';
 
 export interface DateRangePresetDropdownProps {
-  /**
-   * Called when the user picks "Custom". The toolbar opens the calendar in
-   * response; the atom's range is committed later, on Save. The atom preset is
-   * intentionally not changed here.
-   */
   onCustomSelected?: () => void;
-  /**
-   * Preset to show as selected, overriding the committed atom value. The
-   * toolbar uses it to preview "Custom" while the user edits an uncommitted
-   * calendar draft. Display-only — it does not change what selecting an option
-   * does.
-   */
   displayPreset?: DateRangePreset;
   className?: string;
 }
 
-// Order follows PRESET_LABELS' key order (CUSTOM last — it opens the calendar).
 const OPTIONS = toDropdownOptions(PRESET_LABELS);
 
-/**
- * Presets dropdown wired to the shared filter atom. Picking a named preset
- * resolves its range and writes the atom (one source of truth); picking
- * "Custom" defers to the toolbar to open the calendar.
- */
 export function DateRangePresetDropdown({
   onCustomSelected,
   displayPreset,
@@ -40,8 +23,6 @@ export function DateRangePresetDropdown({
   const value = toDropdownValue(displayPreset ?? filter.preset, PRESET_LABELS);
 
   function handleChange(option: DropdownOption<DateRangePreset> | null) {
-    // Re-clicking the active option clears the selection; keep the current
-    // filter rather than emptying it.
     if (!option) return;
 
     if (option.value === 'CUSTOM') {

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -12,3 +12,5 @@ export { Calendar } from './Calendar';
 export type { CalendarProps, RdpDateRange } from './Calendar';
 export { YearGrid } from './YearGrid';
 export type { YearGridProps } from './YearGrid';
+export { DateRangePresetDropdown } from './DateRangePresetDropdown';
+export type { DateRangePresetDropdownProps } from './DateRangePresetDropdown';

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -11,3 +11,5 @@ export { Calendar } from './Calendar';
 export type { CalendarProps } from './Calendar';
 export { YearGrid } from './YearGrid';
 export type { YearGridProps } from './YearGrid';
+export { DateRangePresetDropdown } from './DateRangePresetDropdown';
+export type { DateRangePresetDropdownProps } from './DateRangePresetDropdown';


### PR DESCRIPTION
**📚 Stack — date-range filter**: #2190 → #2191 → #2192 → **#2193 (4/6)** → #2194 → #2195

---

## Problem

Most users want a common window (last 30 days, year-to-date) without hand-picking dates.

## Solution

A presets dropdown that resolves the chosen window to a concrete range and updates the shared filter, so the calendar reflects it too. "Custom" is the exception — it doesn't resolve to a range; it signals the toolbar to open the calendar for hand-picking, and nothing commits until the user saves.

## How to test

Storybook → `Date Range Filter/DateRangePresetDropdown`.

## Summary by Sourcery

Wire date-range presets into shared state while preserving custom calendar selection behavior.

New Features:
- Add a date-range preset dropdown that updates the shared filter for standard presets and delegates custom selection to the toolbar.

Enhancements:
- Expose the preset dropdown through the date-range filter component exports.

Tests:
- Add Storybook coverage and tests for shared-state updates, custom selection behavior, and optional handlers.