### PR TITLE
feat(shelter-operator): custom-range calendar popover (PR4)

### DIFF
--- a/libs/react/shelter-operator/src/lib/components/base-ui/dropdown/MenuPanel.tsx
+++ b/libs/react/shelter-operator/src/lib/components/base-ui/dropdown/MenuPanel.tsx
@@ -10,9 +10,10 @@ type MenuPanelProps = {
   /**
    * Which edge of the trigger the menu aligns to.
    * - `'left'` (default): menu left edge = trigger left edge, menu width matches trigger.
+   * - `'left-auto'`: menu left edge = trigger left edge, menu sizes to content.
    * - `'right'`: menu right edge = trigger right edge, menu sizes to content.
    */
-  align?: 'left' | 'right';
+  align?: 'left' | 'left-auto' | 'right';
 };
 
 /**
@@ -23,21 +24,16 @@ type MenuPanelProps = {
 export function MenuPanel(props: MenuPanelProps) {
   const { menuRef, menuPos, onClose, children, id, align = 'left' } = props;
 
-  const positionStyle =
-    align === 'right'
-      ? {
-          position: 'fixed' as const,
-          top: menuPos.top,
-          right: window.innerWidth - (menuPos.left + (menuPos.width ?? 0)),
-          zIndex: Z_MENU,
-        }
-      : {
-          position: 'fixed' as const,
-          top: menuPos.top,
-          left: menuPos.left,
-          width: menuPos.width,
-          zIndex: Z_MENU,
-        };
+  const positionStyle = {
+    position: 'fixed' as const,
+    top: menuPos.top,
+    zIndex: Z_MENU,
+    ...(align === 'right'
+      ? { right: window.innerWidth - (menuPos.left + (menuPos.width ?? 0)) }
+      : align === 'left-auto'
+        ? { left: menuPos.left }
+        : { left: menuPos.left, width: menuPos.width }),
+  };
 
   return (
     <>

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.stories.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta } from '@storybook/react';
+import { format } from 'date-fns';
+import { useState } from 'react';
+import { DateRangeCalendar } from './DateRangeCalendar';
+import type { DateRange } from './types';
+
+const meta: Meta<typeof DateRangeCalendar> = {
+  component: DateRangeCalendar,
+  title: 'Date Range Filter/DateRangeCalendar',
+};
+export default meta;
+
+const fmt = (date: Date | null) => (date ? format(date, 'MM/dd/yyyy') : '—');
+
+export const Default = () => {
+  const [range, setRange] = useState<DateRange>({
+    from: new Date(2026, 5, 10),
+    to: new Date(2026, 5, 18),
+  });
+  return (
+    <div className="w-[24rem] space-y-3 p-4">
+      <DateRangeCalendar value={range} onCommit={setRange} />
+      <p className="font-sans text-sm text-neutral-50">
+        committed: {fmt(range.from)} – {fmt(range.to)}
+      </p>
+    </div>
+  );
+};
+
+export const Empty = () => {
+  const [range, setRange] = useState<DateRange>({ from: null, to: null });
+  return (
+    <div className="w-[24rem] space-y-3 p-4">
+      <DateRangeCalendar value={range} onCommit={setRange} />
+      <p className="font-sans text-sm text-neutral-50">
+        committed: {fmt(range.from)} – {fmt(range.to)}
+      </p>
+    </div>
+  );
+};

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.test.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DateRangeCalendar } from './DateRangeCalendar';
+
+// The popover positions itself with usePortalPosition, which jsdom has no
+// ResizeObserver for.
+class NoopResizeObserver {
+  observe() {
+    return undefined;
+  }
+  unobserve() {
+    return undefined;
+  }
+  disconnect() {
+    return undefined;
+  }
+}
+
+function renderCalendar() {
+  const onCommit = vi.fn();
+  render(
+    <DateRangeCalendar value={{ from: null, to: null }} onCommit={onCommit} />
+  );
+  return {
+    onCommit,
+    toggle: screen.getByRole('button', { name: 'Toggle calendar' }),
+  };
+}
+
+describe('DateRangeCalendar', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', NoopResizeObserver);
+  });
+
+  it('closes on Escape and restores focus to the toggle', () => {
+    const { toggle } = renderCalendar();
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole('dialog', { name: 'Select date range' })).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(document.activeElement).toBe(toggle);
+  });
+
+  it('leaves the committed value alone when dismissed with Escape', () => {
+    const { toggle, onCommit } = renderCalendar();
+
+    fireEvent.click(toggle);
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('ignores other keys while open', () => {
+    const { toggle } = renderCalendar();
+
+    fireEvent.click(toggle);
+    fireEvent.keyDown(document, { key: 'a' });
+
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+});

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -9,8 +9,10 @@ import { usePortalPosition } from '../base-ui/dropdown/usePortalPosition';
 import { Calendar, type RdpDateRange } from './Calendar';
 import {
   computeFieldCommit,
+  coupleMonths,
   defaultMonths,
   formatDate,
+  maskDateInput,
   toDomain,
   toRdp,
 } from './dateRangeCalendarUtils';
@@ -54,14 +56,14 @@ function DateField({
       placeholder="MM/DD/YYYY"
       value={value}
       onFocus={onOpen}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => onChange(maskDateInput(e.target.value))}
       onBlur={onCommit}
       onKeyDown={(e) => {
         if (e.key === 'Enter') onCommit();
       }}
       className={mergeCss([
-        'w-[6.5rem] border-0 bg-transparent p-0 text-center text-sm outline-none placeholder:text-gray-400',
-        invalid ? 'text-red-600' : 'text-gray-900',
+        'w-[6rem] border-0 bg-transparent p-0 text-center text-sm tracking-[-0.02em] outline-none placeholder:text-[#676767]',
+        invalid ? 'text-red-600' : 'text-[#676767]',
       ])}
     />
   );
@@ -155,16 +157,31 @@ export function DateRangeCalendar({
     if (!open) openPopover();
   };
 
+  const changeLeftMonth = useCallback((next: Date) => {
+    setLeftMonth(next);
+    setRightMonth((right) => coupleMonths(next, right, 'left'));
+  }, []);
+  const changeRightMonth = useCallback((next: Date) => {
+    setRightMonth(next);
+    setLeftMonth((left) => coupleMonths(next, left, 'right'));
+  }, []);
+
   const openLeftYear = useCallback(() => setYearGridSide('left'), []);
   const openRightYear = useCallback(() => setYearGridSide('right'), []);
-  const selectLeftYear = useCallback((year: number) => {
-    setLeftMonth((current) => new Date(year, current.getMonth(), 1));
-    setYearGridSide(null);
-  }, []);
-  const selectRightYear = useCallback((year: number) => {
-    setRightMonth((current) => new Date(year, current.getMonth(), 1));
-    setYearGridSide(null);
-  }, []);
+  const selectLeftYear = useCallback(
+    (year: number) => {
+      changeLeftMonth(new Date(year, leftMonth.getMonth(), 1));
+      setYearGridSide(null);
+    },
+    [changeLeftMonth, leftMonth]
+  );
+  const selectRightYear = useCallback(
+    (year: number) => {
+      changeRightMonth(new Date(year, rightMonth.getMonth(), 1));
+      setYearGridSide(null);
+    },
+    [changeRightMonth, rightMonth]
+  );
 
   const menuPos = usePortalPosition(anchorRef, open, close, menuRef);
 
@@ -173,13 +190,13 @@ export function DateRangeCalendar({
   const panes = {
     left: {
       month: leftMonth,
-      onMonthChange: setLeftMonth,
+      onMonthChange: changeLeftMonth,
       openYear: openLeftYear,
       selectYear: selectLeftYear,
     },
     right: {
       month: rightMonth,
-      onMonthChange: setRightMonth,
+      onMonthChange: changeRightMonth,
       openYear: openRightYear,
       selectYear: selectRightYear,
     },
@@ -209,12 +226,12 @@ export function DateRangeCalendar({
       <div
         ref={anchorRef}
         className={mergeCss([
-          'flex h-12 w-full items-center gap-1 rounded-full border bg-white px-4 transition-colors',
+          'flex h-[45px] w-full items-center gap-2 rounded-[20px] border bg-white px-5 transition-colors',
           hasError
             ? 'border-red-500'
             : open
               ? 'border-[#008CEE]'
-              : 'border-gray-200',
+              : 'border-[#E7E7E7]',
         ])}
       >
         <DateField
@@ -225,7 +242,7 @@ export function DateRangeCalendar({
           onCommit={commitTyped}
           onOpen={openOnFocus}
         />
-        <span className="shrink-0 text-gray-400">–</span>
+        <span className="shrink-0 text-[#676767]">–</span>
         <DateField
           label="End date"
           value={toText}
@@ -240,7 +257,7 @@ export function DateRangeCalendar({
           onClick={() => (open ? close() : openPopover())}
           className="ml-auto shrink-0"
         >
-          <CalendarIcon className="h-4 w-4 text-gray-400" />
+          <CalendarIcon className="h-6 w-6 text-[#676767]" />
         </button>
       </div>
 
@@ -253,16 +270,29 @@ export function DateRangeCalendar({
             align="right"
           >
             <div className="flex flex-col gap-4 p-4">
-              <div className="flex gap-8">
-                {renderPane('left')}
-                {renderPane('right')}
-              </div>
+              {yearGridSide ? (
+                renderPane(yearGridSide)
+              ) : (
+                <div className="flex gap-4">
+                  {renderPane('left')}
+                  {renderPane('right')}
+                </div>
+              )}
 
-              <div className="flex justify-end gap-2 border-t border-gray-200 pt-3">
-                <Button variant="primary" onClick={close}>
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="primary"
+                  onClick={close}
+                  className="rounded-lg border-transparent bg-[#EBECEF] text-[#747A82] hover:bg-[#DEE0E4]"
+                >
                   Cancel
                 </Button>
-                <Button variant="primary" color="blue" onClick={handleSave}>
+                <Button
+                  variant="primary"
+                  color="blue"
+                  onClick={handleSave}
+                  className="rounded-lg"
+                >
                   Save
                 </Button>
               </div>

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -267,13 +267,13 @@ export function DateRangeCalendar({
             menuRef={menuRef}
             menuPos={menuPos}
             onClose={close}
-            align="right"
+            align="left-auto"
           >
-            <div className="flex flex-col gap-4 p-4">
+            <div className="flex flex-col gap-3 p-3">
               {yearGridSide ? (
                 renderPane(yearGridSide)
               ) : (
-                <div className="flex gap-4">
+                <div className="flex gap-3">
                   {renderPane('left')}
                   {renderPane('right')}
                 </div>

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -1,0 +1,180 @@
+import { mergeCss } from '@monorepo/react/shared';
+import { format } from 'date-fns';
+import { CalendarClock } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '../base-ui/buttons';
+import { MenuPanel } from '../base-ui/dropdown/MenuPanel';
+import { usePortalPosition } from '../base-ui/dropdown/usePortalPosition';
+import { Text } from '../base-ui/text/text';
+import { Calendar, type RdpDateRange } from './Calendar';
+import type { DateRange } from './types';
+import { YearGrid } from './YearGrid';
+
+export interface DateRangeCalendarProps {
+  /** The committed range shown in the field and used as the draft's seed. */
+  value?: DateRange;
+  /** Fired only on Save, with the committed range. */
+  onCommit: (range: DateRange) => void;
+  /**
+   * Fired when the user first edits the draft (clicks a day in the grid),
+   * before Save. Lets the toolbar preview "Custom" while editing. The edit is
+   * still discarded if the popover closes without Save.
+   */
+  onDirty?: () => void;
+  /** Controlled open state (optional); falls back to internal state. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+}
+
+const EMPTY_LABEL = 'MM/DD/YYYY – MM/DD/YYYY';
+const fmt = (date: Date) => format(date, 'MM/dd/yyyy');
+
+function toRdp(range?: DateRange): RdpDateRange | undefined {
+  if (!range?.from) return undefined;
+  return { from: range.from, to: range.to ?? undefined };
+}
+
+function toDomain(range?: RdpDateRange): DateRange {
+  return { from: range?.from ?? null, to: range?.to ?? null };
+}
+
+function formatRange(range?: RdpDateRange): string {
+  if (!range?.from) return EMPTY_LABEL;
+  return range.to ? `${fmt(range.from)} – ${fmt(range.to)}` : fmt(range.from);
+}
+
+/**
+ * Custom-range popover: an input field that opens a two-month calendar. The
+ * month/year caption swaps to a year grid. The range is held as a local draft
+ * and only committed on Save — Cancel discards it.
+ */
+export function DateRangeCalendar({
+  value,
+  onCommit,
+  onDirty,
+  open: openProp,
+  onOpenChange,
+  className,
+}: DateRangeCalendarProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : internalOpen;
+
+  const [draft, setDraft] = useState<RdpDateRange | undefined>(() =>
+    toRdp(value)
+  );
+  const [displayMonth, setDisplayMonth] = useState<Date>(
+    () => value?.from ?? new Date()
+  );
+  const [showYearGrid, setShowYearGrid] = useState(false);
+  const openYearGrid = useCallback(() => setShowYearGrid(true), []);
+
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  function setOpen(next: boolean) {
+    if (!isControlled) setInternalOpen(next);
+    onOpenChange?.(next);
+  }
+
+  function openPopover() {
+    // Seed the draft from the committed value each time the popover opens.
+    setDraft(toRdp(value));
+    setDisplayMonth(value?.from ?? new Date());
+    setShowYearGrid(false);
+    setOpen(true);
+  }
+
+  function close() {
+    setShowYearGrid(false);
+    setOpen(false);
+  }
+
+  function handleSelect(range: RdpDateRange | undefined) {
+    setDraft(range);
+    // Any day click means the user is hand-picking a range → preview "Custom".
+    onDirty?.();
+  }
+
+  function handleSave() {
+    onCommit(toDomain(draft));
+    close();
+  }
+
+  function handleYearSelect(year: number) {
+    setDisplayMonth((current) => new Date(year, current.getMonth(), 1));
+    setShowYearGrid(false);
+  }
+
+  const menuPos = usePortalPosition(anchorRef, open, close, menuRef);
+
+  // While open, the field tracks the live draft; when closed, it reflects the
+  // committed value (so a cancelled draft never lingers in the field).
+  const fieldRange = open ? draft : toRdp(value);
+
+  return (
+    <div className={mergeCss(['relative font-sans', className])}>
+      <div ref={anchorRef}>
+        <button
+          type="button"
+          onClick={() => (open ? close() : openPopover())}
+          className={mergeCss([
+            'flex h-12 w-full items-center justify-between gap-2 rounded-full border bg-white px-4 transition-colors',
+            open ? 'border-[#008CEE]' : 'border-gray-200',
+          ])}
+        >
+          <Text
+            variant="body"
+            className={mergeCss([
+              'text-sm',
+              fieldRange?.from ? 'text-gray-900' : 'text-gray-400',
+            ])}
+          >
+            {formatRange(fieldRange)}
+          </Text>
+          <CalendarClock className="h-4 w-4 shrink-0 text-gray-400" />
+        </button>
+      </div>
+
+      {open &&
+        createPortal(
+          <MenuPanel
+            menuRef={menuRef}
+            menuPos={menuPos}
+            onClose={close}
+            align="right"
+          >
+            <div className="flex flex-col gap-4 p-4">
+              {showYearGrid ? (
+                <YearGrid
+                  selectedYear={displayMonth.getFullYear()}
+                  onSelect={handleYearSelect}
+                  className="w-[18rem]"
+                />
+              ) : (
+                <Calendar
+                  selected={draft}
+                  onSelect={handleSelect}
+                  month={displayMonth}
+                  onMonthChange={setDisplayMonth}
+                  onMonthLabelClick={openYearGrid}
+                />
+              )}
+
+              <div className="flex justify-end gap-2 border-t border-gray-200 pt-3">
+                <Button variant="primary" onClick={close}>
+                  Cancel
+                </Button>
+                <Button variant="primary" color="blue" onClick={handleSave}>
+                  Save
+                </Button>
+              </div>
+            </div>
+          </MenuPanel>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -1,12 +1,5 @@
 import { mergeCss } from '@monorepo/react/shared';
-import {
-  addMonths,
-  format,
-  isSameMonth,
-  isValid,
-  parse,
-  startOfMonth,
-} from 'date-fns';
+import { startOfMonth } from 'date-fns';
 import { Calendar as CalendarIcon } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -14,6 +7,13 @@ import { Button } from '../base-ui/buttons';
 import { MenuPanel } from '../base-ui/dropdown/MenuPanel';
 import { usePortalPosition } from '../base-ui/dropdown/usePortalPosition';
 import { Calendar, type RdpDateRange } from './Calendar';
+import {
+  defaultMonths,
+  formatDate,
+  parseField,
+  toDomain,
+  toRdp,
+} from './dateRangeCalendarUtils';
 import type { DateRange } from './types';
 import { YearGrid } from './YearGrid';
 
@@ -27,37 +27,6 @@ export interface DateRangeCalendarProps {
 }
 
 type Side = 'left' | 'right';
-
-const DATE_FORMAT = 'MM/dd/yyyy';
-const FIELD_PATTERN = /^\d{2}\/\d{2}\/\d{4}$/;
-const MIN_YEAR = 1900;
-const fmt = (date: Date) => format(date, DATE_FORMAT);
-
-function toRdp(range?: DateRange): RdpDateRange | undefined {
-  if (!range?.from) return undefined;
-  return { from: range.from, to: range.to ?? undefined };
-}
-
-function toDomain(range?: RdpDateRange): DateRange {
-  return { from: range?.from ?? null, to: range?.to ?? null };
-}
-
-function parseField(text: string): Date | null {
-  const trimmed = text.trim();
-  if (!FIELD_PATTERN.test(trimmed)) return null;
-  const parsed = parse(trimmed, DATE_FORMAT, new Date());
-  if (!isValid(parsed) || parsed.getFullYear() < MIN_YEAR) return null;
-  return parsed;
-}
-
-function defaultMonths(range?: RdpDateRange): [Date, Date] {
-  const left = startOfMonth(range?.from ?? new Date());
-  const right =
-    range?.to && !isSameMonth(range.to, left)
-      ? startOfMonth(range.to)
-      : addMonths(left, 1);
-  return [left, right];
-}
 
 interface DateFieldProps {
   label: string;
@@ -131,8 +100,8 @@ export function DateRangeCalendar({
 
   useEffect(() => {
     const src = open ? draft : toRdp(value);
-    setFromText(src?.from ? fmt(src.from) : '');
-    setToText(src?.to ? fmt(src.to) : '');
+    setFromText(src?.from ? formatDate(src.from) : '');
+    setToText(src?.to ? formatDate(src.to) : '');
     setFromError(false);
     setToError(false);
   }, [open, draft, value]);

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -8,9 +8,9 @@ import { MenuPanel } from '../base-ui/dropdown/MenuPanel';
 import { usePortalPosition } from '../base-ui/dropdown/usePortalPosition';
 import { Calendar, type RdpDateRange } from './Calendar';
 import {
+  computeFieldCommit,
   defaultMonths,
   formatDate,
-  parseField,
   toDomain,
   toRdp,
 } from './dateRangeCalendarUtils';
@@ -135,31 +135,15 @@ export function DateRangeCalendar({
   );
 
   const commitTyped = useCallback(() => {
-    const from = parseField(fromText);
-    const to = parseField(toText);
-    const fromBad = fromText.trim() !== '' && !from;
-    const toBad = toText.trim() !== '' && !to;
-    const orderBad = !!from && !!to && from > to;
+    const result = computeFieldCommit(fromText, toText, value);
+    setFromError(result.fromError);
+    setToError(result.toError);
+    if (!result.valid) return;
 
-    setFromError(fromBad || orderBad);
-    setToError(toBad || orderBad);
-    if (fromBad || toBad || orderBad) return;
-
-    let next: RdpDateRange | undefined;
-    if (from && to) next = { from, to };
-    else if (from) next = { from, to: undefined };
-    else if (to) next = { from: to, to: undefined };
-    else next = undefined;
-
-    const committed = toRdp(value);
-    const unchanged =
-      (next?.from?.getTime() ?? null) === (committed?.from?.getTime() ?? null) &&
-      (next?.to?.getTime() ?? null) === (committed?.to?.getTime() ?? null);
-
-    setDraft(next);
-    if (from) setLeftMonth(startOfMonth(from));
-    if (to) setRightMonth(startOfMonth(to));
-    if (!unchanged) onDirty?.();
+    setDraft(result.next);
+    if (result.from) setLeftMonth(startOfMonth(result.from));
+    if (result.to) setRightMonth(startOfMonth(result.to));
+    if (result.changed) onDirty?.();
   }, [fromText, toText, value, onDirty]);
 
   function handleSave() {

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -1,35 +1,37 @@
 import { mergeCss } from '@monorepo/react/shared';
-import { format } from 'date-fns';
-import { CalendarClock } from 'lucide-react';
-import { useCallback, useRef, useState } from 'react';
+import {
+  addMonths,
+  format,
+  isSameMonth,
+  isValid,
+  parse,
+  startOfMonth,
+} from 'date-fns';
+import { Calendar as CalendarIcon } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '../base-ui/buttons';
 import { MenuPanel } from '../base-ui/dropdown/MenuPanel';
 import { usePortalPosition } from '../base-ui/dropdown/usePortalPosition';
-import { Text } from '../base-ui/text/text';
 import { Calendar, type RdpDateRange } from './Calendar';
 import type { DateRange } from './types';
 import { YearGrid } from './YearGrid';
 
 export interface DateRangeCalendarProps {
-  /** The committed range shown in the field and used as the draft's seed. */
   value?: DateRange;
-  /** Fired only on Save, with the committed range. */
   onCommit: (range: DateRange) => void;
-  /**
-   * Fired when the user first edits the draft (clicks a day in the grid),
-   * before Save. Lets the toolbar preview "Custom" while editing. The edit is
-   * still discarded if the popover closes without Save.
-   */
   onDirty?: () => void;
-  /** Controlled open state (optional); falls back to internal state. */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   className?: string;
 }
 
-const EMPTY_LABEL = 'MM/DD/YYYY – MM/DD/YYYY';
-const fmt = (date: Date) => format(date, 'MM/dd/yyyy');
+type Side = 'left' | 'right';
+
+const DATE_FORMAT = 'MM/dd/yyyy';
+const FIELD_PATTERN = /^\d{2}\/\d{2}\/\d{4}$/;
+const MIN_YEAR = 1900;
+const fmt = (date: Date) => format(date, DATE_FORMAT);
 
 function toRdp(range?: DateRange): RdpDateRange | undefined {
   if (!range?.from) return undefined;
@@ -40,16 +42,62 @@ function toDomain(range?: RdpDateRange): DateRange {
   return { from: range?.from ?? null, to: range?.to ?? null };
 }
 
-function formatRange(range?: RdpDateRange): string {
-  if (!range?.from) return EMPTY_LABEL;
-  return range.to ? `${fmt(range.from)} – ${fmt(range.to)}` : fmt(range.from);
+function parseField(text: string): Date | null {
+  const trimmed = text.trim();
+  if (!FIELD_PATTERN.test(trimmed)) return null;
+  const parsed = parse(trimmed, DATE_FORMAT, new Date());
+  if (!isValid(parsed) || parsed.getFullYear() < MIN_YEAR) return null;
+  return parsed;
 }
 
-/**
- * Custom-range popover: an input field that opens a two-month calendar. The
- * month/year caption swaps to a year grid. The range is held as a local draft
- * and only committed on Save — Cancel discards it.
- */
+function defaultMonths(range?: RdpDateRange): [Date, Date] {
+  const left = startOfMonth(range?.from ?? new Date());
+  const right =
+    range?.to && !isSameMonth(range.to, left)
+      ? startOfMonth(range.to)
+      : addMonths(left, 1);
+  return [left, right];
+}
+
+interface DateFieldProps {
+  label: string;
+  value: string;
+  invalid: boolean;
+  onChange: (value: string) => void;
+  onCommit: () => void;
+  onOpen: () => void;
+}
+
+function DateField({
+  label,
+  value,
+  invalid,
+  onChange,
+  onCommit,
+  onOpen,
+}: DateFieldProps) {
+  return (
+    <input
+      type="text"
+      inputMode="numeric"
+      aria-label={label}
+      aria-invalid={invalid}
+      placeholder="MM/DD/YYYY"
+      value={value}
+      onFocus={onOpen}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={onCommit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onCommit();
+      }}
+      className={mergeCss([
+        'w-[6.5rem] border-0 bg-transparent p-0 text-center text-sm outline-none placeholder:text-gray-400',
+        invalid ? 'text-red-600' : 'text-gray-900',
+      ])}
+    />
+  );
+}
+
 export function DateRangeCalendar({
   value,
   onCommit,
@@ -65,14 +113,29 @@ export function DateRangeCalendar({
   const [draft, setDraft] = useState<RdpDateRange | undefined>(() =>
     toRdp(value)
   );
-  const [displayMonth, setDisplayMonth] = useState<Date>(
-    () => value?.from ?? new Date()
+  const [leftMonth, setLeftMonth] = useState<Date>(
+    () => defaultMonths(toRdp(value))[0]
   );
-  const [showYearGrid, setShowYearGrid] = useState(false);
-  const openYearGrid = useCallback(() => setShowYearGrid(true), []);
+  const [rightMonth, setRightMonth] = useState<Date>(
+    () => defaultMonths(toRdp(value))[1]
+  );
+  const [yearGridSide, setYearGridSide] = useState<Side | null>(null);
+
+  const [fromText, setFromText] = useState('');
+  const [toText, setToText] = useState('');
+  const [fromError, setFromError] = useState(false);
+  const [toError, setToError] = useState(false);
 
   const anchorRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const src = open ? draft : toRdp(value);
+    setFromText(src?.from ? fmt(src.from) : '');
+    setToText(src?.to ? fmt(src.to) : '');
+    setFromError(false);
+    setToError(false);
+  }, [open, draft, value]);
 
   function setOpen(next: boolean) {
     if (!isControlled) setInternalOpen(next);
@@ -80,61 +143,151 @@ export function DateRangeCalendar({
   }
 
   function openPopover() {
-    // Seed the draft from the committed value each time the popover opens.
-    setDraft(toRdp(value));
-    setDisplayMonth(value?.from ?? new Date());
-    setShowYearGrid(false);
+    const seeded = toRdp(value);
+    const [left, right] = defaultMonths(seeded);
+    setDraft(seeded);
+    setLeftMonth(left);
+    setRightMonth(right);
+    setYearGridSide(null);
     setOpen(true);
   }
 
   function close() {
-    setShowYearGrid(false);
+    setYearGridSide(null);
     setOpen(false);
   }
 
-  function handleSelect(range: RdpDateRange | undefined) {
-    setDraft(range);
-    // Any day click means the user is hand-picking a range → preview "Custom".
-    onDirty?.();
-  }
+  const handleSelect = useCallback(
+    (range: RdpDateRange | undefined) => {
+      setDraft(range);
+      onDirty?.();
+    },
+    [onDirty]
+  );
+
+  const commitTyped = useCallback(() => {
+    const from = parseField(fromText);
+    const to = parseField(toText);
+    const fromBad = fromText.trim() !== '' && !from;
+    const toBad = toText.trim() !== '' && !to;
+    const orderBad = !!from && !!to && from > to;
+
+    setFromError(fromBad || orderBad);
+    setToError(toBad || orderBad);
+    if (fromBad || toBad || orderBad) return;
+
+    let next: RdpDateRange | undefined;
+    if (from && to) next = { from, to };
+    else if (from) next = { from, to: undefined };
+    else if (to) next = { from: to, to: undefined };
+    else next = undefined;
+
+    const committed = toRdp(value);
+    const unchanged =
+      (next?.from?.getTime() ?? null) === (committed?.from?.getTime() ?? null) &&
+      (next?.to?.getTime() ?? null) === (committed?.to?.getTime() ?? null);
+
+    setDraft(next);
+    if (from) setLeftMonth(startOfMonth(from));
+    if (to) setRightMonth(startOfMonth(to));
+    if (!unchanged) onDirty?.();
+  }, [fromText, toText, value, onDirty]);
 
   function handleSave() {
     onCommit(toDomain(draft));
     close();
   }
 
-  function handleYearSelect(year: number) {
-    setDisplayMonth((current) => new Date(year, current.getMonth(), 1));
-    setShowYearGrid(false);
-  }
+  const openOnFocus = () => {
+    if (!open) openPopover();
+  };
+
+  const openLeftYear = useCallback(() => setYearGridSide('left'), []);
+  const openRightYear = useCallback(() => setYearGridSide('right'), []);
+  const selectLeftYear = useCallback((year: number) => {
+    setLeftMonth((current) => new Date(year, current.getMonth(), 1));
+    setYearGridSide(null);
+  }, []);
+  const selectRightYear = useCallback((year: number) => {
+    setRightMonth((current) => new Date(year, current.getMonth(), 1));
+    setYearGridSide(null);
+  }, []);
 
   const menuPos = usePortalPosition(anchorRef, open, close, menuRef);
 
-  // While open, the field tracks the live draft; when closed, it reflects the
-  // committed value (so a cancelled draft never lingers in the field).
-  const fieldRange = open ? draft : toRdp(value);
+  const hasError = fromError || toError;
+
+  const panes = {
+    left: {
+      month: leftMonth,
+      onMonthChange: setLeftMonth,
+      openYear: openLeftYear,
+      selectYear: selectLeftYear,
+    },
+    right: {
+      month: rightMonth,
+      onMonthChange: setRightMonth,
+      openYear: openRightYear,
+      selectYear: selectRightYear,
+    },
+  } as const;
+
+  const renderPane = (side: Side) => {
+    const pane = panes[side];
+    return yearGridSide === side ? (
+      <YearGrid
+        selectedYear={pane.month.getFullYear()}
+        onSelect={pane.selectYear}
+        className="w-[18rem]"
+      />
+    ) : (
+      <Calendar
+        selected={draft}
+        onSelect={handleSelect}
+        month={pane.month}
+        onMonthChange={pane.onMonthChange}
+        onMonthLabelClick={pane.openYear}
+      />
+    );
+  };
 
   return (
     <div className={mergeCss(['relative font-sans', className])}>
-      <div ref={anchorRef}>
+      <div
+        ref={anchorRef}
+        className={mergeCss([
+          'flex h-12 w-full items-center gap-1 rounded-full border bg-white px-4 transition-colors',
+          hasError
+            ? 'border-red-500'
+            : open
+              ? 'border-[#008CEE]'
+              : 'border-gray-200',
+        ])}
+      >
+        <DateField
+          label="Start date"
+          value={fromText}
+          invalid={fromError}
+          onChange={setFromText}
+          onCommit={commitTyped}
+          onOpen={openOnFocus}
+        />
+        <span className="shrink-0 text-gray-400">–</span>
+        <DateField
+          label="End date"
+          value={toText}
+          invalid={toError}
+          onChange={setToText}
+          onCommit={commitTyped}
+          onOpen={openOnFocus}
+        />
         <button
           type="button"
+          aria-label="Toggle calendar"
           onClick={() => (open ? close() : openPopover())}
-          className={mergeCss([
-            'flex h-12 w-full items-center justify-between gap-2 rounded-full border bg-white px-4 transition-colors',
-            open ? 'border-[#008CEE]' : 'border-gray-200',
-          ])}
+          className="ml-auto shrink-0"
         >
-          <Text
-            variant="body"
-            className={mergeCss([
-              'text-sm',
-              fieldRange?.from ? 'text-gray-900' : 'text-gray-400',
-            ])}
-          >
-            {formatRange(fieldRange)}
-          </Text>
-          <CalendarClock className="h-4 w-4 shrink-0 text-gray-400" />
+          <CalendarIcon className="h-4 w-4 text-gray-400" />
         </button>
       </div>
 
@@ -147,21 +300,10 @@ export function DateRangeCalendar({
             align="right"
           >
             <div className="flex flex-col gap-4 p-4">
-              {showYearGrid ? (
-                <YearGrid
-                  selectedYear={displayMonth.getFullYear()}
-                  onSelect={handleYearSelect}
-                  className="w-[18rem]"
-                />
-              ) : (
-                <Calendar
-                  selected={draft}
-                  onSelect={handleSelect}
-                  month={displayMonth}
-                  onMonthChange={setDisplayMonth}
-                  onMonthLabelClick={openYearGrid}
-                />
-              )}
+              <div className="flex gap-8">
+                {renderPane('left')}
+                {renderPane('right')}
+              </div>
 
               <div className="flex justify-end gap-2 border-t border-gray-200 pt-3">
                 <Button variant="primary" onClick={close}>

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -243,7 +243,7 @@ export function DateRangeCalendar({
       <div
         ref={anchorRef}
         className={mergeCss([
-          'flex h-[45px] w-full items-center gap-2 rounded-[20px] border bg-white px-5 transition-colors',
+          'flex h-12 w-full items-center gap-2 rounded-full border bg-white px-5 transition-colors',
           hasError
             ? 'border-red-500'
             : open

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/DateRangeCalendar.tsx
@@ -99,6 +99,7 @@ export function DateRangeCalendar({
 
   const anchorRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const src = open ? draft : toRdp(value);
@@ -108,10 +109,13 @@ export function DateRangeCalendar({
     setToError(false);
   }, [open, draft, value]);
 
-  function setOpen(next: boolean) {
-    if (!isControlled) setInternalOpen(next);
-    onOpenChange?.(next);
-  }
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange]
+  );
 
   function openPopover() {
     const seeded = toRdp(value);
@@ -123,10 +127,23 @@ export function DateRangeCalendar({
     setOpen(true);
   }
 
-  function close() {
+  const close = useCallback(() => {
     setYearGridSide(null);
     setOpen(false);
-  }
+  }, [setOpen]);
+
+  // The date fields sit outside the popover, so Escape has to be caught at the
+  // document rather than on the panel.
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      close();
+      toggleRef.current?.focus();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, close]);
 
   const handleSelect = useCallback(
     (range: RdpDateRange | undefined) => {
@@ -252,8 +269,10 @@ export function DateRangeCalendar({
           onOpen={openOnFocus}
         />
         <button
+          ref={toggleRef}
           type="button"
           aria-label="Toggle calendar"
+          aria-expanded={open}
           onClick={() => (open ? close() : openPopover())}
           className="ml-auto shrink-0"
         >
@@ -269,7 +288,11 @@ export function DateRangeCalendar({
             onClose={close}
             align="left-auto"
           >
-            <div className="flex flex-col gap-3 p-3">
+            <div
+              role="dialog"
+              aria-label="Select date range"
+              className="flex flex-col gap-3 p-3"
+            >
               {yearGridSide ? (
                 renderPane(yearGridSide)
               ) : (

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.test.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  computeFieldCommit,
   defaultMonths,
   formatDate,
   parseField,
@@ -95,5 +96,84 @@ describe('toRdp / toDomain', () => {
 describe('formatDate', () => {
   it('formats to MM/dd/yyyy', () => {
     expect(formatDate(new Date(2026, 4, 8))).toBe('05/08/2026');
+  });
+});
+
+describe('computeFieldCommit', () => {
+  it('commits a valid ordered range', () => {
+    const r = computeFieldCommit('05/18/2026', '06/20/2026');
+    expect(r.valid).toBe(true);
+    expect(r.fromError).toBe(false);
+    expect(r.toError).toBe(false);
+    expect(r.next).toEqual({
+      from: new Date(2026, 4, 18),
+      to: new Date(2026, 5, 20),
+    });
+    expect(r.changed).toBe(true);
+  });
+
+  it('commits a start-only range (to left undefined)', () => {
+    const r = computeFieldCommit('05/18/2026', '');
+    expect(r.valid).toBe(true);
+    expect(r.next).toEqual({ from: new Date(2026, 4, 18), to: undefined });
+  });
+
+  it('promotes an end-only value to the start', () => {
+    const r = computeFieldCommit('', '06/20/2026');
+    expect(r.valid).toBe(true);
+    expect(r.next).toEqual({ from: new Date(2026, 5, 20), to: undefined });
+  });
+
+  it('flags an invalid start and does not commit', () => {
+    const r = computeFieldCommit('05/1', '06/20/2026');
+    expect(r.valid).toBe(false);
+    expect(r.fromError).toBe(true);
+    expect(r.toError).toBe(false);
+  });
+
+  it('flags an impossible end date and does not commit', () => {
+    const r = computeFieldCommit('05/18/2026', '02/30/2026');
+    expect(r.valid).toBe(false);
+    expect(r.toError).toBe(true);
+  });
+
+  it('flags an out-of-order range on both fields and does not commit', () => {
+    const r = computeFieldCommit('07/15/2026', '06/20/2026');
+    expect(r.valid).toBe(false);
+    expect(r.fromError).toBe(true);
+    expect(r.toError).toBe(true);
+    expect(r.next).toBeUndefined();
+  });
+
+  it('rejects a 0000 year', () => {
+    const r = computeFieldCommit('05/20/0000', '06/20/2026');
+    expect(r.valid).toBe(false);
+    expect(r.fromError).toBe(true);
+  });
+
+  it('treats two empty fields as a valid empty selection', () => {
+    const r = computeFieldCommit('', '');
+    expect(r.valid).toBe(true);
+    expect(r.next).toBeUndefined();
+    expect(r.changed).toBe(false);
+  });
+
+  it('reports unchanged when the typed range equals the committed value', () => {
+    const committed = {
+      from: new Date(2026, 4, 18),
+      to: new Date(2026, 5, 20),
+    };
+    const r = computeFieldCommit('05/18/2026', '06/20/2026', committed);
+    expect(r.valid).toBe(true);
+    expect(r.changed).toBe(false);
+  });
+
+  it('reports changed when the typed range differs from the committed value', () => {
+    const committed = {
+      from: new Date(2026, 4, 18),
+      to: new Date(2026, 5, 20),
+    };
+    const r = computeFieldCommit('05/18/2026', '06/21/2026', committed);
+    expect(r.changed).toBe(true);
   });
 });

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.test.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.test.ts
@@ -1,7 +1,9 @@
 import {
   computeFieldCommit,
+  coupleMonths,
   defaultMonths,
   formatDate,
+  maskDateInput,
   parseField,
   toDomain,
   toRdp,
@@ -90,6 +92,53 @@ describe('toRdp / toDomain', () => {
   it('toRdp and toDomain round-trip a full range', () => {
     const range = { from: new Date(2026, 4, 18), to: new Date(2026, 5, 20) };
     expect(toDomain(toRdp(range))).toEqual(range);
+  });
+});
+
+describe('maskDateInput', () => {
+  it('inserts slashes as digits are typed', () => {
+    expect(maskDateInput('0')).toBe('0');
+    expect(maskDateInput('06')).toBe('06');
+    expect(maskDateInput('060')).toBe('06/0');
+    expect(maskDateInput('0601')).toBe('06/01');
+    expect(maskDateInput('06012026')).toBe('06/01/2026');
+  });
+
+  it('ignores non-digits the user types and re-masks', () => {
+    expect(maskDateInput('06/01/2026')).toBe('06/01/2026');
+    expect(maskDateInput('ab06cd01')).toBe('06/01');
+  });
+
+  it('caps at eight digits (MMDDYYYY)', () => {
+    expect(maskDateInput('060120261234')).toBe('06/01/2026');
+  });
+});
+
+describe('coupleMonths', () => {
+  it('pushes the end month to start+1 when start reaches or passes end', () => {
+    const may = new Date(2026, 4, 1);
+    const april = new Date(2026, 3, 1);
+    expect(coupleMonths(may, april, 'left')).toEqual(new Date(2026, 5, 1));
+    expect(coupleMonths(may, may, 'left')).toEqual(new Date(2026, 5, 1));
+  });
+
+  it('leaves the end month alone when start stays before it', () => {
+    const march = new Date(2026, 2, 1);
+    const june = new Date(2026, 5, 1);
+    expect(coupleMonths(march, june, 'left')).toEqual(june);
+  });
+
+  it('pulls the start month to end-1 when end reaches or passes start', () => {
+    const may = new Date(2026, 4, 1);
+    const june = new Date(2026, 5, 1);
+    expect(coupleMonths(may, june, 'right')).toEqual(new Date(2026, 3, 1));
+    expect(coupleMonths(may, may, 'right')).toEqual(new Date(2026, 3, 1));
+  });
+
+  it('leaves the start month alone when end stays after it', () => {
+    const august = new Date(2026, 7, 1);
+    const march = new Date(2026, 2, 1);
+    expect(coupleMonths(august, march, 'right')).toEqual(march);
   });
 });
 

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.test.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.test.ts
@@ -1,0 +1,99 @@
+import {
+  defaultMonths,
+  formatDate,
+  parseField,
+  toDomain,
+  toRdp,
+} from './dateRangeCalendarUtils';
+
+describe('parseField', () => {
+  it('parses a fully-typed MM/DD/YYYY date', () => {
+    expect(parseField('05/18/2026')).toEqual(new Date(2026, 4, 18));
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseField('  06/20/2026  ')).toEqual(new Date(2026, 5, 20));
+  });
+
+  it('rejects partial / non-matching input', () => {
+    expect(parseField('05/1')).toBeNull();
+    expect(parseField('5/1/2026')).toBeNull();
+    expect(parseField('2026-05-18')).toBeNull();
+    expect(parseField('')).toBeNull();
+  });
+
+  it('rejects impossible dates', () => {
+    expect(parseField('13/01/2026')).toBeNull();
+    expect(parseField('02/30/2026')).toBeNull();
+  });
+
+  it('rejects implausible years (0000 / before 1900)', () => {
+    expect(parseField('05/20/0000')).toBeNull();
+    expect(parseField('05/20/1899')).toBeNull();
+    expect(parseField('05/20/1900')).toEqual(new Date(1900, 4, 20));
+  });
+});
+
+describe('defaultMonths', () => {
+  it('uses from month on the left and to month on the right when they differ', () => {
+    const [left, right] = defaultMonths({
+      from: new Date(2025, 4, 18),
+      to: new Date(2026, 5, 20),
+    });
+    expect(left).toEqual(new Date(2025, 4, 1));
+    expect(right).toEqual(new Date(2026, 5, 1));
+  });
+
+  it('falls back to the month after `from` when there is no distinct `to`', () => {
+    const [left, right] = defaultMonths({ from: new Date(2026, 5, 10) });
+    expect(left).toEqual(new Date(2026, 5, 1));
+    expect(right).toEqual(new Date(2026, 6, 1));
+  });
+
+  it('treats a same-month range as from + next month', () => {
+    const [left, right] = defaultMonths({
+      from: new Date(2026, 5, 3),
+      to: new Date(2026, 5, 20),
+    });
+    expect(left).toEqual(new Date(2026, 5, 1));
+    expect(right).toEqual(new Date(2026, 6, 1));
+  });
+
+  it('defaults an empty range to this month + next', () => {
+    const [left, right] = defaultMonths(undefined);
+    const now = new Date();
+    expect(left).toEqual(new Date(now.getFullYear(), now.getMonth(), 1));
+    expect(right.getMonth()).toBe((now.getMonth() + 1) % 12);
+  });
+});
+
+describe('toRdp / toDomain', () => {
+  it('toRdp returns undefined when there is no start', () => {
+    expect(toRdp(undefined)).toBeUndefined();
+    expect(toRdp({ from: null, to: null })).toBeUndefined();
+  });
+
+  it('toRdp maps a domain range to a react-day-picker range', () => {
+    const from = new Date(2026, 4, 18);
+    const to = new Date(2026, 5, 20);
+    expect(toRdp({ from, to })).toEqual({ from, to });
+    expect(toRdp({ from, to: null })).toEqual({ from, to: undefined });
+  });
+
+  it('toDomain maps back, nulling missing endpoints', () => {
+    const from = new Date(2026, 4, 18);
+    expect(toDomain(undefined)).toEqual({ from: null, to: null });
+    expect(toDomain({ from, to: undefined })).toEqual({ from, to: null });
+  });
+
+  it('toRdp and toDomain round-trip a full range', () => {
+    const range = { from: new Date(2026, 4, 18), to: new Date(2026, 5, 20) };
+    expect(toDomain(toRdp(range))).toEqual(range);
+  });
+});
+
+describe('formatDate', () => {
+  it('formats to MM/dd/yyyy', () => {
+    expect(formatDate(new Date(2026, 4, 8))).toBe('05/08/2026');
+  });
+});

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.ts
@@ -5,6 +5,7 @@ import {
   isValid,
   parse,
   startOfMonth,
+  subMonths,
 } from 'date-fns';
 import type { RdpDateRange } from './Calendar';
 import type { DateRange } from './types';
@@ -14,6 +15,30 @@ const FIELD_PATTERN = /^\d{2}\/\d{2}\/\d{4}$/;
 const MIN_YEAR = 1900;
 
 export const formatDate = (date: Date) => format(date, DATE_FORMAT);
+
+export function maskDateInput(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 8);
+  if (digits.length > 4) {
+    return `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4)}`;
+  }
+  if (digits.length > 2) {
+    return `${digits.slice(0, 2)}/${digits.slice(2)}`;
+  }
+  return digits;
+}
+
+export function coupleMonths(
+  anchor: Date,
+  other: Date,
+  edge: 'left' | 'right'
+): Date {
+  const a = startOfMonth(anchor);
+  const o = startOfMonth(other);
+  if (edge === 'left') {
+    return a.getTime() >= o.getTime() ? addMonths(a, 1) : o;
+  }
+  return a.getTime() <= o.getTime() ? subMonths(a, 1) : o;
+}
 
 export function toRdp(range?: DateRange): RdpDateRange | undefined {
   if (!range?.from) return undefined;

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.ts
@@ -40,3 +40,43 @@ export function defaultMonths(range?: RdpDateRange): [Date, Date] {
       : addMonths(left, 1);
   return [left, right];
 }
+
+export interface FieldCommitResult {
+  from: Date | null;
+  to: Date | null;
+  fromError: boolean;
+  toError: boolean;
+  valid: boolean;
+  next?: RdpDateRange;
+  changed: boolean;
+}
+
+export function computeFieldCommit(
+  fromText: string,
+  toText: string,
+  committed?: DateRange
+): FieldCommitResult {
+  const from = parseField(fromText);
+  const to = parseField(toText);
+  const fromBad = fromText.trim() !== '' && !from;
+  const toBad = toText.trim() !== '' && !to;
+  const orderBad = !!from && !!to && from > to;
+  const fromError = fromBad || orderBad;
+  const toError = toBad || orderBad;
+
+  if (fromError || toError) {
+    return { from, to, fromError, toError, valid: false, changed: false };
+  }
+
+  let next: RdpDateRange | undefined;
+  if (from && to) next = { from, to };
+  else if (from) next = { from, to: undefined };
+  else if (to) next = { from: to, to: undefined };
+
+  const prev = toRdp(committed);
+  const changed =
+    (next?.from?.getTime() ?? null) !== (prev?.from?.getTime() ?? null) ||
+    (next?.to?.getTime() ?? null) !== (prev?.to?.getTime() ?? null);
+
+  return { from, to, fromError: false, toError: false, valid: true, next, changed };
+}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/dateRangeCalendarUtils.ts
@@ -1,0 +1,42 @@
+import {
+  addMonths,
+  format,
+  isSameMonth,
+  isValid,
+  parse,
+  startOfMonth,
+} from 'date-fns';
+import type { RdpDateRange } from './Calendar';
+import type { DateRange } from './types';
+
+export const DATE_FORMAT = 'MM/dd/yyyy';
+const FIELD_PATTERN = /^\d{2}\/\d{2}\/\d{4}$/;
+const MIN_YEAR = 1900;
+
+export const formatDate = (date: Date) => format(date, DATE_FORMAT);
+
+export function toRdp(range?: DateRange): RdpDateRange | undefined {
+  if (!range?.from) return undefined;
+  return { from: range.from, to: range.to ?? undefined };
+}
+
+export function toDomain(range?: RdpDateRange): DateRange {
+  return { from: range?.from ?? null, to: range?.to ?? null };
+}
+
+export function parseField(text: string): Date | null {
+  const trimmed = text.trim();
+  if (!FIELD_PATTERN.test(trimmed)) return null;
+  const parsed = parse(trimmed, DATE_FORMAT, new Date());
+  if (!isValid(parsed) || parsed.getFullYear() < MIN_YEAR) return null;
+  return parsed;
+}
+
+export function defaultMonths(range?: RdpDateRange): [Date, Date] {
+  const left = startOfMonth(range?.from ?? new Date());
+  const right =
+    range?.to && !isSameMonth(range.to, left)
+      ? startOfMonth(range.to)
+      : addMonths(left, 1);
+  return [left, right];
+}

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -14,3 +14,5 @@ export { YearGrid } from './YearGrid';
 export type { YearGridProps } from './YearGrid';
 export { DateRangePresetDropdown } from './DateRangePresetDropdown';
 export type { DateRangePresetDropdownProps } from './DateRangePresetDropdown';
+export { DateRangeCalendar } from './DateRangeCalendar';
+export type { DateRangeCalendarProps } from './DateRangeCalendar';

--- a/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
+++ b/libs/react/shelter-operator/src/lib/components/date-range-filter/index.ts
@@ -13,3 +13,5 @@ export { YearGrid } from './YearGrid';
 export type { YearGridProps } from './YearGrid';
 export { DateRangePresetDropdown } from './DateRangePresetDropdown';
 export type { DateRangePresetDropdownProps } from './DateRangePresetDropdown';
+export { DateRangeCalendar } from './DateRangeCalendar';
+export type { DateRangeCalendarProps } from './DateRangeCalendar';


### PR DESCRIPTION
**📚 Stack — date-range filter**: #2190 → #2191 → #2192 → #2193 → **#2194 (5/6)** → #2195

---

## Problem

Users need to pick an arbitrary date range both by clicking a calendar and by typing exact dates — without the two drifting out of sync, without bad input corrupting the range, and with the two month panes staying in a sensible order.

## Solution

The custom-range popover: two months with a per-side year picker, plus typable From/To fields. Typing and clicking drive the same draft so they always agree; slashes fill in as you type (`06012026` → `06/01/2026`), and an invalid or out-of-order date is flagged inline and never committed. The two panes stay ordered — navigating the start past the end pushes the end forward, and vice-versa. The range applies on Save; Cancel discards. Styling follows the design: neutral day hover, grey Cancel, tighter calendar gap, and no divider above the actions.

## How to test

Storybook → `Date Range Filter/DateRangeCalendar`:
- Type `05/20/0000` (or `13/40/2026`) → field turns red, nothing commits.
- Type `06012026` → slashes fill in automatically.
- Pick a range on the grid → the From/To fields update to match.
- Page the start month past the end → the end month follows (and vice-versa).

## Summary by Sourcery

Add a synchronized custom date-range calendar for selecting, typing, validating, and committing arbitrary date ranges.

New Features:
- Add a custom date-range calendar with dual month views, per-side year selection, editable From/To fields, and draft-based Save/Cancel behavior.

Bug Fixes:
- Prevent invalid, incomplete, or out-of-order typed dates from being committed and keep the two calendar months in chronological order.

Enhancements:
- Support automatic date-input masking and synchronization between calendar selections and typed date fields.
- Allow menu panels to size to their content when left-aligned.
- Export the date-range calendar component and its props for reuse.

Documentation:
- Add Storybook examples for populated and empty date-range calendar states.

Tests:
- Add utility and interaction coverage for date parsing, input masking, range validation, month coupling, Escape dismissal, and commit behavior.