### PR TITLE
fix: use reports.view_reports instead of organizations.view_reports in template config (DEV-2455)

### DIFF
--- a/apps/betterangels-backend/accounts/groups.py
+++ b/apps/betterangels-backend/accounts/groups.py
@@ -1,5 +1,6 @@
-from accounts.permissions import ReportOrgPermissions, UserOrganizationPermissions
+from accounts.permissions import UserOrganizationPermissions
 from common.permissions.config import TemplateConfig
+from reports.permissions import ReportPermissions
 from teams.models import Team
 
 ORG_ADMIN = TemplateConfig(
@@ -9,7 +10,7 @@ ORG_ADMIN = TemplateConfig(
         UserOrganizationPermissions.ADD_ORG_MEMBER,
         UserOrganizationPermissions.REMOVE_ORG_MEMBER,
         UserOrganizationPermissions.VIEW_ORG_MEMBERS,
-        ReportOrgPermissions.VIEW_REPORTS,
+        ReportPermissions.VIEW_REPORTS,
         Team.perms.ADD,
         Team.perms.CHANGE,
         Team.perms.DELETE,

--- a/apps/betterangels-backend/accounts/permissions.py
+++ b/apps/betterangels-backend/accounts/permissions.py
@@ -26,11 +26,6 @@ class UserOrganizationPermissions(models.TextChoices):
     VIEW_ORG_MEMBERS = "organizations.view_org_members", _("Can view organization members")
 
 
-@strawberry.enum
-class ReportOrgPermissions(models.TextChoices):
-    VIEW_REPORTS = "organizations.view_reports", _("Can view reports")
-
-
 # ── Organization permission check ─────────────────────────────────────────────
 
 

--- a/apps/betterangels-backend/accounts/tests/test_template_permissions.py
+++ b/apps/betterangels-backend/accounts/tests/test_template_permissions.py
@@ -33,8 +33,7 @@ def test_all_template_permissions_resolve() -> None:
     if not expected:
         if REGISTRY.template_names():
             pytest.fail(
-                f"No permissions defined for any registered template: "
-                f"{', '.join(sorted(REGISTRY.template_names()))}"
+                f"No permissions defined for any registered template: {', '.join(sorted(REGISTRY.template_names()))}"
             )
         return
 
@@ -44,9 +43,7 @@ def test_all_template_permissions_resolve() -> None:
         (Q(codename=c, content_type__app_label=a) for a, c in expected),
         Q(),
     )
-    existing = set(
-        Permission.objects.filter(q).values_list("content_type__app_label", "codename")
-    )
+    existing = set(Permission.objects.filter(q).values_list("content_type__app_label", "codename"))
 
     # Missing = config expects it but DB doesn't have it.
     missing = {pair: templates for pair, templates in expected.items() if pair not in existing}

--- a/apps/betterangels-backend/accounts/tests/test_template_permissions.py
+++ b/apps/betterangels-backend/accounts/tests/test_template_permissions.py
@@ -1,0 +1,59 @@
+"""Tests that validate all registered template permissions resolve to
+actual Django ``Permission`` objects.
+
+This is a safety net: if a migration moves a permission to a different
+content type but the corresponding ``TemplateConfig`` is not updated,
+this test will catch it before it silently strips permissions from groups.
+"""
+
+from functools import reduce
+
+import pytest
+from common.org_types import REGISTRY
+from django.contrib.auth.models import Permission
+from django.db.models import Q
+
+
+@pytest.mark.django_db
+def test_all_template_permissions_resolve() -> None:
+    """Every permission string in every registered ``TemplateConfig``
+    must map to an existing Django ``Permission``.
+
+    One query fetches all existing permissions; unresolved ones are
+    the set difference between config expectations and DB reality."""
+    # Map (app_label, codename) → list of template names that expect it.
+    expected: dict[tuple[str, str], list[str]] = {}
+    for tn in REGISTRY.template_names():
+        cfg = REGISTRY.template(tn)
+        if cfg and cfg.permissions:
+            for ps in cfg.permissions:
+                a, c = ps.split(".", 1)
+                expected.setdefault((a, c), []).append(tn)
+
+    if not expected:
+        return
+
+    # Single OR-filter to find all expected permissions that exist.
+    q = reduce(
+        lambda acc, pair: acc | Q(codename=pair[1], content_type__app_label=pair[0]),
+        expected,
+        Q(),
+    )
+    existing = set(
+        Permission.objects.filter(q).values_list("content_type__app_label", "codename")
+    )
+
+    # Missing = config expects it but DB doesn't have it.
+    missing = {pair: templates for pair, templates in expected.items() if pair not in existing}
+
+    if missing:
+        lines = ["Template permissions that do not resolve to a Django Permission:"]
+        for (app_label, codename), templates in sorted(missing.items()):
+            perm_str = f"{app_label}.{codename}"
+            lines.append(f"  {perm_str}  (expected by: {', '.join(templates)})")
+        lines.append(
+            "\nA migration may have moved the permission to a different content "
+            "type. Update the TemplateConfig in the corresponding app's groups.py "
+            "to use the correct app_label.codename."
+        )
+        pytest.fail("\n".join(lines))

--- a/apps/betterangels-backend/accounts/tests/test_template_permissions.py
+++ b/apps/betterangels-backend/accounts/tests/test_template_permissions.py
@@ -6,6 +6,7 @@ content type but the corresponding ``TemplateConfig`` is not updated,
 this test will catch it before it silently strips permissions from groups.
 """
 
+from collections import defaultdict
 from functools import reduce
 
 import pytest
@@ -22,21 +23,25 @@ def test_all_template_permissions_resolve() -> None:
     One query fetches all existing permissions; unresolved ones are
     the set difference between config expectations and DB reality."""
     # Map (app_label, codename) → list of template names that expect it.
-    expected: dict[tuple[str, str], list[str]] = {}
+    expected: dict[tuple[str, str], list[str]] = defaultdict(list)
     for tn in REGISTRY.template_names():
-        cfg = REGISTRY.template(tn)
-        if cfg and cfg.permissions:
-            for ps in cfg.permissions:
+        if cfg := REGISTRY.template(tn):
+            for ps in cfg.permissions or []:
                 a, c = ps.split(".", 1)
-                expected.setdefault((a, c), []).append(tn)
+                expected[(a, c)].append(tn)
 
     if not expected:
+        if REGISTRY.template_names():
+            pytest.fail(
+                f"No permissions defined for any registered template: "
+                f"{', '.join(sorted(REGISTRY.template_names()))}"
+            )
         return
 
     # Single OR-filter to find all expected permissions that exist.
     q = reduce(
-        lambda acc, pair: acc | Q(codename=pair[1], content_type__app_label=pair[0]),
-        expected,
+        Q.__or__,
+        (Q(codename=c, content_type__app_label=a) for a, c in expected),
         Q(),
     )
     existing = set(


### PR DESCRIPTION
The view_reports permission was moved to the reports namespace by a migration, but accounts/groups.py still referenced the old namespace. This caused _sync_template_permissions() to strip the permission from all templates and groups on every post_migrate.

**Fix:** Use `ReportPermissions.VIEW_REPORTS` (`reports.view_reports`) instead of the removed `ReportOrgPermissions.VIEW_REPORTS` (`organizations.view_reports`). Also removes the dead `ReportOrgPermissions` enum.

**Safeguard:** Adds a test that validates all `TemplateConfig` permissions resolve to Django `Permission` objects — prevents this class of regression in CI.

Closes [DEV-2455](https://betterangels.atlassian.net/browse/DEV-2455)

[DEV-2455]: https://betterangels.atlassian.net/browse/DEV-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ