### PR TITLE
feat(shelter-operator): add functional logout button to NavBar

### DIFF
--- a/libs/react/shelter-operator/src/lib/components/NavBar.tsx
+++ b/libs/react/shelter-operator/src/lib/components/NavBar.tsx
@@ -1,6 +1,7 @@
+import { Dropdown as MenuDropdown } from '@monorepo/react/components';
 import { BetterAngelsLogoIcon } from '@monorepo/react/icons';
 import { mergeCss } from '@monorepo/react/shared';
-import { operatorPath } from '@monorepo/react/shelter';
+import { operatorPath, useSignOut } from '@monorepo/react/shelter';
 import { Plus, UserCog } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Fragment, useCallback, useMemo } from 'react';
@@ -15,17 +16,39 @@ import {
   type BreadcrumbItem,
 } from './NavBar/breadcrumbs';
 
-function NavBarActions({ children }: { children?: ReactNode }) {
+enum AccountOption {
+  SignOut = 'Sign Out',
+}
+
+function NavBarActions({
+  children,
+  onSignOut,
+}: {
+  children?: ReactNode;
+  onSignOut: () => void;
+}) {
+  const handleAccountSelect = (option: AccountOption) => {
+    if (option === AccountOption.SignOut) {
+      onSignOut();
+    }
+  };
+
   return (
     <div className="flex items-center gap-3">
       {children}
-      <button
-        type="button"
-        aria-label="Account settings"
-        className="inline-flex size-11 items-center justify-center rounded-full border border-[#D3D9E3] bg-white text-[#3E4652] transition-colors hover:bg-[#F8FAFC] pl-1"
-      >
-        <UserCog size={20} />
-      </button>
+      <MenuDropdown
+        title={
+          <div
+            aria-label="Account settings"
+            className="inline-flex size-11 items-center justify-center rounded-full border border-[#D3D9E3] bg-white text-[#3E4652] transition-colors hover:bg-[#F8FAFC] pl-1"
+          >
+            <UserCog size={20} />
+          </div>
+        }
+        options={[AccountOption.SignOut]}
+        onSelect={handleAccountSelect}
+        position="dropdown-end"
+      />
     </div>
   );
 }
@@ -40,6 +63,7 @@ export function NavBar(props: TNavProps) {
   const { activeOrg, organizations, setActiveOrgId } = useActiveOrg();
   const location = useLocation();
   const navigate = useNavigate();
+  const { signOut } = useSignOut();
   const selectedOrganizationId = activeOrg?.id ?? '';
 
   const isDashboardPage =
@@ -112,7 +136,7 @@ export function NavBar(props: TNavProps) {
           )}
         </div>
 
-        <NavBarActions>
+        <NavBarActions onSignOut={signOut}>
           {showCreateButton && (
             <Button
               leftIcon={<Plus size={20} />}


### PR DESCRIPTION
## Summary

Replaces the inert **UserCog** account settings button in the shelter-operator NavBar with a functional dropdown menu that includes a **Sign Out** option.

## Changes

- **`libs/react/shelter-operator/src/lib/components/NavBar.tsx`**
  - Imports `useSignOut` from `@monorepo/react/shelter` (existing hook)
  - Imports `Dropdown` from `@monorepo/react/components` (same component used in betterangels-admin)
  - Adds `AccountOption` enum following the betterangels-admin pattern
  - Replaces the inert `<button>` with a `MenuDropdown` that opens a "Sign Out" option
  - `NavBar` calls `useSignOut()` and passes `signOut` to `NavBarActions`

## How it works

1. Clicking the ⚙️ icon opens a dropdown menu
2. Selecting "Sign Out" triggers the existing `useSignOut` hook which:
   - Calls the GraphQL `logout` mutation
   - Clears user state
   - Navigates to `/`
   - Resets the Apollo cache

## Screenshots

| Before | After |
|--------|-------|
| Button does nothing | Dropdown with Sign Out → logs user out |

## Related

Follows the same `Dropdown` + `useSignOut` pattern used in `betterangels-admin`'s Navbar.

## Summary by Sourcery

Add a functional account dropdown to the shelter-operator NavBar that allows users to sign out from the application.

New Features:
- Introduce an account dropdown menu on the shelter-operator NavBar with a Sign Out option that logs the user out.

Enhancements:
- Wire the NavBar actions to the existing useSignOut hook so account interactions trigger the logout flow consistently across apps.