### PR TITLE
fix django admin shelter availability

### DIFF
--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -34,6 +34,7 @@ from import_export.results import RowResult
 from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
 from organizations.models import Organization
 from pghistory.models import MiddlewareEvents
+
 from shelters.managers import BedQuerySet, RoomQuerySet
 
 from .enums import (
@@ -1604,7 +1605,7 @@ class ShelterAvailabilityAdmin(admin.ModelAdmin):
     list_filter = ("updated_at",)
     search_fields = ("shelter__name",)
     autocomplete_fields = ["shelter"]
-    readonly_fields = ("created_at", "updated_at")
+    readonly_fields = ("created_at", "updated_at", "updated_by")
     fieldsets = (
         (
             None,


### PR DESCRIPTION
`ShelterAvailabilityAdmin` breaking because computed `updated_by` field not included in `readonly_fields`

## Summary by Sourcery

Bug Fixes:
- Fix ShelterAvailabilityAdmin configuration by adding the updated_by field to readonly_fields so the admin page no longer breaks.