### PR TITLE
[BP] fix(bar-chart): remount on container resize to fix sidebar toggle layout

### DIFF
--- a/libs/react/shelter-operator/src/lib/components/BarChart/BarChart.tsx
+++ b/libs/react/shelter-operator/src/lib/components/BarChart/BarChart.tsx
@@ -40,7 +40,7 @@ export function BarChart({
 }: BarChartProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('count');
   const chartContainerRef = useRef<HTMLDivElement>(null);
-  const [resizeKey, setResizeKey] = useState(0);
+  const [_resizeKey, setResizeKey] = useState(0);
 
   useLayoutEffect(() => {
     const el = chartContainerRef.current;

--- a/libs/react/shelter-operator/src/lib/components/BarChart/BarChart.tsx
+++ b/libs/react/shelter-operator/src/lib/components/BarChart/BarChart.tsx
@@ -246,7 +246,8 @@ export function BarChart({
         </div>
       )}
       <div ref={chartContainerRef} className="flex-1 min-h-0">
-        <Column key={`${viewMode}-${resizeKey}`} {...withState} />
+        {/* Remount only when viewMode changes; rely on autoFit for resize instead of resizeKey */}
+        <Column key={viewMode} {...withState} />
       </div>
     </div>
   );

--- a/libs/react/shelter-operator/src/lib/components/BarChart/BarChart.tsx
+++ b/libs/react/shelter-operator/src/lib/components/BarChart/BarChart.tsx
@@ -1,9 +1,10 @@
 import type { ColumnConfig } from '@ant-design/plots';
 import { Column } from '@ant-design/plots';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { mergeDeep } from 'remeda';
 const FONT_FAMILY = "'Poppins', ui-sans-serif, system-ui, sans-serif";
+const RESIZE_DEBOUNCE_MS = 150;
 function darkenHex(hex: string, amount = 0.18): string {
   const h = hex.replace('#', '');
   const full =
@@ -38,6 +39,24 @@ export function BarChart({
   ...config
 }: BarChartProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('count');
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const [resizeKey, setResizeKey] = useState(0);
+
+  useLayoutEffect(() => {
+    const el = chartContainerRef.current;
+    if (!el) return;
+    let timer: ReturnType<typeof setTimeout>;
+    const observer = new ResizeObserver((entries) => {
+      const width = Math.round(entries[0]?.contentRect.width ?? 0);
+      clearTimeout(timer);
+      timer = setTimeout(() => setResizeKey(width), RESIZE_DEBOUNCE_MS);
+    });
+    observer.observe(el);
+    return () => {
+      clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, []);
 
   const defaultConfig: Partial<ColumnConfig> = {
     autoFit: true,
@@ -226,8 +245,8 @@ export function BarChart({
           )}
         </div>
       )}
-      <div className="flex-1 min-h-0">
-        <Column key={viewMode} {...withState} />
+      <div ref={chartContainerRef} className="flex-1 min-h-0">
+        <Column key={`${viewMode}-${resizeKey}`} {...withState} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Problem
When toggling the sidebar, the bar chart would render with the wrong width
because `@ant-design/plots` doesn't detect indirect container resizes.

## Solution
Added a `ResizeObserver` on the chart container that debounces (150ms) and
remounts the `Column` by updating its `key` to the current container width.
The width-based key ensures React skips the remount if only height changes.

## Summary by Sourcery

Ensure the bar chart re-renders correctly when its container size changes by reacting to container resize events.

Bug Fixes:
- Fix bar chart rendering with incorrect width when the surrounding layout (e.g., sidebar toggle) changes the container size without a direct window resize.

Enhancements:
- Add a debounced ResizeObserver on the bar chart container to trigger a remount keyed by container width for more reliable layout updates.