### PR TITLE
fix: task count freshness, mutation cache updates, and Expo/Nx migration

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.2.1',
+    version: '1.2.2',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.2.1',
+      buildNumber: '1.2.2',
       associatedDomains: [`applinks:${HOSTNAME}`],
       config: {
         usesNonExemptEncryption: false,
@@ -70,7 +70,7 @@ export default {
         },
       ],
       config: {},
-      versionCode: 75,
+      versionCode: 76,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',

--- a/apps/betterangels/package.json
+++ b/apps/betterangels/package.json
@@ -87,37 +87,19 @@
     "tsconfig-paths": "*",
     "use-deep-compare-effect": "*",
     "validator": "*",
-    "zod": "*"
-  },
-  "devDependencies": {
-    "@expo/metro": "*",
-    "@expo/metro-config": "*",
+    "zod": "*",
     "@graphql-codegen/cli": "*",
-    "@jest/globals": "*",
-    "@nx/detox": "*",
-    "@nx/devkit": "*",
-    "@nx/eslint": "*",
-    "@nx/jest": "*",
-    "@nx/js": "*",
-    "@nx/react": "*",
-    "@nx/rollup": "*",
-    "@nx/vite": "*",
-    "@nx/web": "*",
-    "@nx/webpack": "*",
-    "@storybook/react": "*",
-    "@storybook/react-native": "*",
-    "@storybook/react-native-web-vite": "*",
-    "@storybook/react-webpack5": "*",
-    "@swc/helpers": "*",
+    "vitest": "*",
     "@testing-library/react": "*",
-    "@testing-library/react-native": "*",
-    "@types/geojson": "*",
-    "@types/google.maps": "*",
-    "@types/set-cookie-parser": "*",
-    "tslib": "*",
     "vite": "*",
-    "vitest": "*"
+    "vite-plugin-static-copy": "*",
+    "@testing-library/react-native": "*",
+    "@jest/globals": "*",
+    "@types/geojson": "*",
+    "@storybook/react-native-web-vite": "*",
+    "@types/google.maps": "*"
   },
+  "devDependencies": {},
   "expo": {
     "autolinking": {
       "nativeModulesDir": "../../libs/expo/modules"
@@ -128,6 +110,5 @@
     "eas-build-post-install": "cd ../../ && node tools/scripts/eas-build-post-install.mjs . apps/betterangels",
     "android": "expo run:android",
     "ios": "expo run:ios"
-  },
-  "devDependencies": {}
+  }
 }

--- a/apps/betterangels/project.json
+++ b/apps/betterangels/project.json
@@ -3,18 +3,12 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/betterangels/src",
   "projectType": "application",
-  "tags": [
-    "type:app",
-    "scope:betterangels"
-  ],
+  "tags": ["type:app", "scope:betterangels"],
   "targets": {
     "start": {
-      "executor": "@nx/expo:start",
-      "dependsOn": [
-        "sync-deps"
-      ],
+      "dependsOn": ["sync-deps"],
       "options": {
-        "port": 8081
+        "args": ["--port=8081"]
       }
     },
     "serve": {
@@ -24,30 +18,16 @@
       }
     },
     "run-ios": {
-      "executor": "@nx/expo:run",
-      "dependsOn": [
-        "sync-deps"
-      ],
+      "dependsOn": ["sync-deps"],
       "options": {
-        "platform": "ios"
+        "args": []
       }
     },
     "run-android": {
-      "executor": "@nx/expo:run",
-      "dependsOn": [
-        "sync-deps"
-      ],
+      "dependsOn": ["sync-deps"],
       "options": {
-        "platform": "android"
+        "args": []
       }
-    },
-    "eas-build": {
-      "executor": "@nx/expo:build",
-      "options": {}
-    },
-    "submit": {
-      "executor": "@nx/expo:submit",
-      "options": {}
     },
     "build-list": {
       "executor": "@nx/expo:build-list",
@@ -64,15 +44,7 @@
       "options": {}
     },
     "prebuild": {
-      "executor": "@nx/expo:prebuild",
-      "dependsOn": [
-        "sync-deps"
-      ],
-      "options": {}
-    },
-    "install": {
-      "executor": "@nx/expo:install",
-      "options": {}
+      "dependsOn": ["sync-deps"]
     },
     "eas-update": {
       "executor": "@nx/expo:update",
@@ -93,27 +65,20 @@
       }
     },
     "export": {
-      "executor": "@nx/expo:export",
-      "dependsOn": [
-        "sync-deps"
-      ],
+      "dependsOn": ["sync-deps"],
       "outputs": [
-        "{options.outputDir}"
+        "{projectRoot}/{options.outputDir}",
+        "{workspaceRoot}/apps/betterangels/dist"
       ],
       "options": {
-        "platform": "all",
-        "outputDir": "dist/apps/betterangels"
+        "args": ["--output-dir=../../dist/apps/betterangels", "--platform=all"]
       }
     },
     "lint": {
-      "inputs": [
-        "{projectRoot}/**/*"
-      ]
+      "inputs": ["{projectRoot}/**/*"]
     },
     "test": {
-      "outputs": [
-        "{workspaceRoot}/coverage/{projectRoot}"
-      ],
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "passWithNoTests": true
       },

--- a/apps/betterangels/project.json
+++ b/apps/betterangels/project.json
@@ -18,16 +18,10 @@
       }
     },
     "run-ios": {
-      "dependsOn": ["sync-deps"],
-      "options": {
-        "args": []
-      }
+      "dependsOn": ["sync-deps"]
     },
     "run-android": {
-      "dependsOn": ["sync-deps"],
-      "options": {
-        "args": []
-      }
+      "dependsOn": ["sync-deps"]
     },
     "build-list": {
       "executor": "@nx/expo:build-list",

--- a/apps/betterangels/project.json
+++ b/apps/betterangels/project.json
@@ -8,7 +8,7 @@
     "start": {
       "dependsOn": ["sync-deps"],
       "options": {
-        "args": ["--port=8081"]
+        "port": 8081
       }
     },
     "serve": {
@@ -71,7 +71,8 @@
         "{workspaceRoot}/apps/betterangels/dist"
       ],
       "options": {
-        "args": ["--output-dir=../../dist/apps/betterangels", "--platform=all"]
+        "outputDir": "../../dist/apps/betterangels",
+        "platform": "all"
       }
     },
     "lint": {

--- a/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../ui-components';
 import { TaskFormData } from '../../../ui-components/TaskForm/TaskForm';
 import { CreateTaskDocument } from '../../../ui-components/TaskForm/__generated__/createTask.generated';
+import { TasksDocument } from '../../../ui-components/TaskList/__generated__/Tasks.generated';
 import { ClientProfileQuery } from '../__generated__/Client.generated';
 
 function getInitialTaskFilters(): TModelFilters {
@@ -75,13 +76,15 @@ export function TasksTab(props: TProps) {
       const result = await createTask({
         variables: {
           data: {
-            summary: task.summary!,
+            summary: task.summary ?? '',
             description: task.description,
             status: task.status,
             teamId: task.teamId || null,
             clientProfile: client.clientProfile.id,
           },
         },
+        refetchQueries: [TasksDocument],
+        awaitRefetchQueries: true,
       });
 
       if (result.data?.createTask.__typename === 'OperationInfo') {

--- a/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
@@ -79,7 +79,7 @@ export function TasksTab(props: TProps) {
             summary: task.summary ?? '',
             description: task.description,
             status: task.status,
-            teamId: task.teamId || null,
+            teamId: task.teamId ?? undefined,
             clientProfile: client.clientProfile.id,
           },
         },

--- a/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientTasksViewHmis/ClientTasksViewHmis.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientTasksViewHmis/ClientTasksViewHmis.tsx
@@ -80,7 +80,7 @@ export function ClientTasksViewHmis(props: TProps) {
       const result = await createTask({
         variables: {
           data: {
-            summary: task.summary!,
+            summary: task.summary ?? '',
             description: task.description,
             status: task.status,
             teamId: task.teamId || null,

--- a/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientTasksViewHmis/ClientTasksViewHmis.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientTasksViewHmis/ClientTasksViewHmis.tsx
@@ -83,7 +83,7 @@ export function ClientTasksViewHmis(props: TProps) {
             summary: task.summary ?? '',
             description: task.description,
             status: task.status,
-            teamId: task.teamId || null,
+            teamId: task.teamId ?? undefined,
             hmisClientProfile: client.id,
           },
         },

--- a/libs/expo/betterangels/src/lib/screens/NotesHmis/utils/useApplyTasks.ts
+++ b/libs/expo/betterangels/src/lib/screens/NotesHmis/utils/useApplyTasks.ts
@@ -24,7 +24,7 @@ export function useApplyTasks() {
           variables: {
             data: {
               summary: s.summary || '',
-              teamId: s.teamId || null,
+              teamId: s.teamId ?? undefined,
               description: s.description,
               status: s.status,
               hmisClientProfile: hmisClientProfileId,
@@ -46,7 +46,7 @@ export function useApplyTasks() {
             data: {
               id: s.id!,
               summary: s.summary,
-              teamId: s.teamId || null,
+              teamId: s.teamId ?? undefined,
               description: s.description,
               status: s.status,
             },

--- a/libs/expo/betterangels/src/lib/screens/Task/TaskHeader.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Task/TaskHeader.tsx
@@ -23,7 +23,29 @@ export default function TaskHeader(props: TTaskHeaderProps) {
   const { showSnackbar } = useSnackbar();
   const { showModalScreen } = useModalScreen();
 
-  const [updateTask] = useMutation(UpdateTaskDocument);
+  const [updateTask] = useMutation(UpdateTaskDocument, {
+    update(cache, { data }) {
+      const payload = data?.updateTask;
+      if (!payload || payload.__typename !== 'TaskType') return;
+
+      const entityId = cache.identify({
+        __typename: 'TaskType',
+        id: payload.id,
+      });
+      if (entityId) {
+        cache.modify({
+          id: entityId,
+          fields: {
+            summary: () => payload.summary,
+            description: () => payload.description,
+            status: () => payload.status,
+            currentTeam: () => payload.currentTeam,
+            updatedAt: () => payload.updatedAt,
+          },
+        });
+      }
+    },
+  });
 
   const [deleteTask] = useMutation(DeleteTaskDocument, {
     update(cache, { data }) {
@@ -56,7 +78,7 @@ export default function TaskHeader(props: TTaskHeaderProps) {
         variables: {
           data: {
             id,
-            summary: task.summary!,
+            summary: task.summary ?? '',
             description: task.description,
             status: task.status,
             teamId: task.teamId || null,

--- a/libs/expo/betterangels/src/lib/screens/Task/TaskHeader.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Task/TaskHeader.tsx
@@ -81,7 +81,7 @@ export default function TaskHeader(props: TTaskHeaderProps) {
             summary: task.summary ?? '',
             description: task.description,
             status: task.status,
-            teamId: task.teamId || null,
+            teamId: task.teamId ?? undefined,
           },
         },
       });
@@ -121,7 +121,7 @@ export default function TaskHeader(props: TTaskHeaderProps) {
         <TaskForm
           initialValues={{
             summary: task.summary || '',
-            teamId: task.currentTeam?.id || null,
+            teamId: task.currentTeam?.id ?? undefined,
             description: task.description || '',
             status: task.status || TaskStatusEnum.ToDo,
           }}

--- a/libs/expo/betterangels/src/lib/ui-components/ClientSummary/ClientSummaryGeneral.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientSummary/ClientSummaryGeneral.tsx
@@ -45,7 +45,8 @@ export default function ClientSummaryGeneral(
         limit: 0,
       },
     },
-    notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-first',
   });
   const clientPhoneNumber =
     client.phoneNumbers?.find((item) => item.isPrimary)?.number ||

--- a/libs/expo/betterangels/src/lib/ui-components/NoteTasks/NoteTasksModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteTasks/NoteTasksModal.tsx
@@ -96,14 +96,14 @@ export default function NoteTasksModal(props: INoteTasksModalProps) {
               summary: formData.summary || '',
               description: formData.description,
               status: cleanStatus,
-              teamId: cleanTeamId || teamId || null,
+              teamId: cleanTeamId ?? teamId ?? undefined,
 
               // FIX: Map IDs correctly based on which props are present
-              clientProfile: clientProfileId || null,
-              hmisClientProfile: hmisClientProfileId || null, // <--- Added this
+              clientProfile: clientProfileId ?? undefined,
+              hmisClientProfile: hmisClientProfileId ?? undefined,
 
-              note: noteId || null,
-              hmisNote: hmisNoteId || null,
+              note: noteId ?? undefined,
+              hmisNote: hmisNoteId ?? undefined,
             },
           },
         });

--- a/libs/expo/betterangels/src/lib/ui-components/NoteTasks/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteTasks/index.tsx
@@ -98,7 +98,7 @@ export default function NoteTasks(props: INoteTasksProps) {
       summary: data.summary,
       description: data.description || '',
       status: (data.status as TaskStatusEnum) || TaskStatusEnum.ToDo,
-      teamId: data.teamId ?? teamId ?? undefined,
+      teamId: data.teamId ?? teamId ?? null,
     };
 
     if (existingId) {

--- a/libs/expo/betterangels/src/lib/ui-components/NoteTasks/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/NoteTasks/index.tsx
@@ -98,7 +98,7 @@ export default function NoteTasks(props: INoteTasksProps) {
       summary: data.summary,
       description: data.description || '',
       status: (data.status as TaskStatusEnum) || TaskStatusEnum.ToDo,
-      teamId: data.teamId || teamId || null,
+      teamId: data.teamId ?? teamId ?? undefined,
     };
 
     if (existingId) {
@@ -144,10 +144,10 @@ export default function NoteTasks(props: INoteTasksProps) {
               status: cleanStatus,
               clientProfile: clientProfileId,
               hmisClientProfile: hmisClientProfileId,
-              teamId: cleanTeamId || teamId || null,
+              teamId: cleanTeamId ?? teamId ?? undefined,
               // Handle linking to either Note type
-              note: noteId || null,
-              hmisNote: hmisNoteId || null,
+              note: noteId ?? undefined,
+              hmisNote: hmisNoteId ?? undefined,
             },
           },
         });

--- a/nx.json
+++ b/nx.json
@@ -5,21 +5,12 @@
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"],
       "cache": true
     },
     "test": {
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js"
-      ],
+      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
       "cache": true
     },
     "lint": {
@@ -40,11 +31,7 @@
       "cache": true
     },
     "@nx/jest:jest": {
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js"
-      ],
+      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
       "cache": true,
       "options": {
         "passWithNoTests": true
@@ -66,20 +53,12 @@
     },
     "@nx/js:swc": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
     }
   },
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
@@ -197,6 +176,20 @@
         "apps/shelter-web/**/*",
         "apps/wildfires/**/*"
       ]
+    },
+    {
+      "plugin": "@nx/expo/plugin",
+      "options": {
+        "buildTargetName": "eas-build",
+        "exportTargetName": "export",
+        "installTargetName": "install",
+        "prebuildTargetName": "prebuild",
+        "runAndroidTargetName": "run-android",
+        "runIosTargetName": "run-ios",
+        "serveTargetName": "serve",
+        "startTargetName": "start",
+        "submitTargetName": "submit"
+      }
     }
   ],
   "generators": {


### PR DESCRIPTION
## Changes

### BACS-93: Tasks not appearing in profile summary
- **ClientSummaryGeneral** — `fetchPolicy: network-only` + `nextFetchPolicy: cache-first` to always get fresh `totalCount`
- **TasksTab** — add `refetchQueries` on `createTask` (matches HMIS pattern)
- **TaskHeader** — use `cache.modify()` for `updateTask` (zero network cost, all screens update instantly)

### GraphQL Input Fixes
- Replace `|| null` with `?? undefined` for `Optional[ID]` fields (`teamId`, `note`, `hmisNote`, `clientProfile`, `hmisClientProfile`) across 7 files — Strawberry rejects explicit `null` on `Optional[ID]`
- Fix forbidden non-null assertions: `task.summary!` → `task.summary ?? ""`  in all task mutation files

### Expo / Nx
- Migrate to `@nx/expo` inferred targets (`@nx/expo:start` deprecated)
- Fix legacy `args` arrays → proper option keys (`port`, `outputDir`, `platform`)
- Bump version to 1.2.2, iOS buildNumber 1.2.2, Android versionCode 76

Closes BACS-93