### PR TITLE
fix: use cache-and-network for ClientProfile query (DEV-2460)

### DIFF
--- a/libs/expo/betterangels/src/lib/screens/Client/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/index.tsx
@@ -78,6 +78,7 @@ export default function Client({
     ClientProfileDocument,
     {
       variables: { id: clientProfileId },
+      fetchPolicy: 'cache-and-network',
     }
   );
 


### PR DESCRIPTION
## Summary

After a merge happens server-side via Django admin, Apollo's default `cache-first` fetch policy serves stale `docReadyDocuments` data. The Outreach user has to close and reopen the app to see merged documents.

## Fix

Change the `ClientProfile` query in `Client/index.tsx` to use `fetchPolicy: 'cache-and-network'` so Apollo fires a background network request on mount, updating the cache with newly merged documents automatically.

## Closes

[DEV-2460](https://betterangels.atlassian.net/browse/DEV-2460)

[DEV-2460]: https://betterangels.atlassian.net/browse/DEV-2460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Ensure ClientProfile data reflects server-side merges by triggering a background network request on screen mount.