### PR TITLE
[BP] Unify report date-range timezone handling

### DIFF
--- a/apps/betterangels-backend/shelters/selectors/reports.py
+++ b/apps/betterangels-backend/shelters/selectors/reports.py
@@ -4,6 +4,7 @@ import datetime
 from collections import Counter
 from itertools import takewhile
 from typing import TYPE_CHECKING, Any, TypedDict
+from zoneinfo import ZoneInfo
 
 import pghistory
 from django.db.models import Count, OuterRef, Q, Subquery, TextField
@@ -13,6 +14,34 @@ from shelters.enums import BedStatusChoices
 if TYPE_CHECKING:
     from shelters.models import Shelter
     from shelters.types.reporting import ReservationMetricsType
+
+
+# ── Shared date-range helpers ─────────────────────────────────────────────────
+# Reporting selectors take calendar dates and read them as LA-local days (all BA
+# shelters are in LA), then convert to a UTC window to query pgh_created_at.
+# New selectors should call report_date_range_to_utc rather than convert inline.
+
+LA_TZ = ZoneInfo("America/Los_Angeles")
+
+
+def report_date_range_to_utc(
+    start_date: datetime.date, end_date: datetime.date
+) -> tuple[datetime.datetime, datetime.datetime]:
+    """Convert an inclusive LA-local date range to a ``[start, end)`` UTC window.
+
+    ``end`` is the UTC instant at the start of the day *after* ``end_date`` in
+    Los Angeles, so the returned half-open interval covers all of ``end_date``
+    locally. Ranges are unbounded; the natural limit is how far back data exists.
+
+    Raises:
+        ValueError: if ``end_date`` is before ``start_date``.
+    """
+    if end_date < start_date:
+        raise ValueError("end_date must be on or after start_date")
+
+    start_local = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=LA_TZ)
+    end_local = datetime.datetime.combine(end_date + datetime.timedelta(days=1), datetime.time.min, tzinfo=LA_TZ)
+    return start_local.astimezone(datetime.timezone.utc), end_local.astimezone(datetime.timezone.utc)
 
 
 class DailyBedCounts(TypedDict):
@@ -106,9 +135,10 @@ def reservation_status_change_counts(
 ) -> "ReservationMetricsType":
     """Count reservation status-change events for *shelter* within an inclusive window.
 
-    Both endpoints are inclusive at the day level: internally the end of
-    ``end_date`` is widened to the start of the next day so any event on
-    ``end_date`` is captured.
+    Both endpoints are inclusive at the day level and interpreted in
+    America/Los_Angeles (via ``report_date_range_to_utc``): internally the end of
+    ``end_date`` is widened to the start of the next LA day so any event on
+    ``end_date`` (LA-local) is captured.
 
     Returns a :class:`~shelters.types.reporting.ReservationMetricsType` with:
 
@@ -134,15 +164,7 @@ def reservation_status_change_counts(
     from shelters.models import Reservation
     from shelters.types.reporting import ReservationMetricsType
 
-    if end_date < start_date:
-        raise ValueError("end_date must be on or after start_date.")
-
-    start_dt = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime.combine(
-        end_date + datetime.timedelta(days=1),
-        datetime.time.min,
-        tzinfo=datetime.timezone.utc,
-    )
+    start_dt, end_dt = report_date_range_to_utc(start_date, end_date)
 
     # pghistory.models.Events.pgh_obj_id is a text column; cast Reservation.pk to text for the IN.
     reservation_ids = (

--- a/apps/betterangels-backend/shelters/tests/test_selectors.py
+++ b/apps/betterangels-backend/shelters/tests/test_selectors.py
@@ -137,7 +137,9 @@ class ReservationStatusChangeCountsTestCase(TestCase):
         before = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
         after = self._make_reservation([ReservationStatusChoices.CHECKED_IN])
         self._set_event_dates(before, _aware(2025, 12, 31, 23, 0))
-        self._set_event_dates(after, _aware(2026, 2, 1, 0, 0))
+        # 2026-02-01 12:00 UTC is 2026-02-01 04:00 in LA, i.e. after the Jan-31
+        # end date once the range is interpreted LA-local.
+        self._set_event_dates(after, _aware(2026, 2, 1, 12, 0))
 
         result = reservation_status_change_counts(
             shelter=self.shelter, start_date=self.start_date, end_date=self.end_date
@@ -230,3 +232,31 @@ class ReservationStatusChangeCountsTestCase(TestCase):
         )
 
         self.assertEqual(result.checked_in, 1)
+
+
+class ReportDateRangeToUtcTestCase(TestCase):
+    """Tests for the shared ``report_date_range_to_utc`` helper."""
+
+    def test_converts_inclusive_la_range_to_half_open_utc_window(self) -> None:
+        from shelters.selectors.reports import report_date_range_to_utc
+
+        start_utc, end_utc = report_date_range_to_utc(datetime.date(2026, 1, 1), datetime.date(2026, 1, 31))
+
+        # LA is UTC-8 (PST) in January, so LA-midnight is 08:00 UTC.
+        self.assertEqual(start_utc, datetime.datetime(2026, 1, 1, 8, 0, tzinfo=datetime.timezone.utc))
+        # End is the start of the day after end_date in LA (half-open).
+        self.assertEqual(end_utc, datetime.datetime(2026, 2, 1, 8, 0, tzinfo=datetime.timezone.utc))
+
+    def test_raises_when_end_before_start(self) -> None:
+        from shelters.selectors.reports import report_date_range_to_utc
+
+        with self.assertRaisesRegex(ValueError, "end_date must be on or after start_date"):
+            report_date_range_to_utc(datetime.date(2026, 1, 2), datetime.date(2026, 1, 1))
+
+    def test_allows_multi_year_past_range(self) -> None:
+        from shelters.selectors.reports import report_date_range_to_utc
+
+        # No cap on how far back a range spans; the natural limit is data.
+        start_utc, end_utc = report_date_range_to_utc(datetime.date(2020, 1, 1), datetime.date(2026, 1, 1))
+
+        self.assertLess(start_utc, end_utc)


### PR DESCRIPTION
## Description

Adds `report_date_range_to_utc`, one shared helper that converts an inclusive LA-local date range into a half-open `[start, end)` UTC window, so every date-range report selector defines day boundaries the same way. Timezone handling was fragmented: each selector rolled its own conversion and they disagreed (UTC-midnight vs LA-midnight).

## What changed

- `report_date_range_to_utc(start_date, end_date)` in `shelters/selectors/reports.py`: interprets the range as America/Los_Angeles calendar days and converts to UTC (where `pgh_created_at` is stored), inclusive of `end_date`, capped at one year.
- `reservation_status_change_counts` now goes through it, moving its day boundaries from UTC-midnight to LA-local. All BA shelters are in LA and the reporting UI sends calendar dates, so an evening LA event now lands on the correct day instead of rolling into the next.
- Unit tests for the helper; the reservation range-boundary test updated for LA-local semantics.

## Why LA-local

These are per-day / date-range metrics driven by a calendar date picker. Bucketing by UTC splits the day at ~4-5pm LA, so an evening check-in gets attributed to the next day. See the discussion on #2113 / #2114.

## Not in scope

- `report_bed_status_counts` is left untouched. It still reads the removed `BedEvent.status` column (dropped in migration 0008) so it does not run today; it belongs to the separate "daily bed status" rewrite.
- No GraphQL wiring, no migrations.

## Follow-ups that build on this

- The occupancy selectors (#2113 daily_occupancy, #2114 avg_days_to_occupancy) will stack on this branch and consume `report_date_range_to_utc` instead of carrying their own copies.

## Summary by Sourcery

Unify report date-range handling around a shared LA-local-to-UTC conversion helper and apply it to reservation status change reporting.

Enhancements:
- Introduce a shared helper to convert inclusive LA-local calendar date ranges into half-open UTC windows with validation and a one-year cap.
- Update reservation status change reporting to use the shared LA-local date range conversion so events are bucketed by local calendar days consistently.

Tests:
- Add unit tests for the shared date range conversion helper and adjust reservation status change range-boundary tests for LA-local semantics.