### PR TITLE
fix: configure Yarn workspace for EAS builds after Nx 23.1 upgrade

### DIFF
--- a/tools/scripts/eas-build-pre-install.mjs
+++ b/tools/scripts/eas-build-pre-install.mjs
@@ -1,18 +1,24 @@
 /**
- * EAS pre-install hook — exact replica of @nx/expo:build's `copyPackageJsonAndLock`
- * for non-workspace setups.
+ * EAS pre-install hook — CI-only replica of @nx/expo:build's `copyPackageJsonAndLock`.
+ * Resolves * deps from root, copies lockfile, configures Yarn workspace.
+ * No-op outside CI — sync-deps handles local resolution.
  */
 import { readFileSync, writeFileSync, copyFileSync } from 'fs';
 import { join, resolve } from 'path';
+
+if (!process.env.CI) {
+  console.log('[eas-build-pre-install] Skipping — not in CI.');
+  process.exit(0);
+}
 
 const [workspaceRoot, projectRoot] = process.argv.slice(2);
 const appDir = resolve(workspaceRoot, projectRoot);
 
 const rootPkg = JSON.parse(readFileSync(join(workspaceRoot, 'package.json'), 'utf-8'));
 
-// If workspaces are already enabled on root, Yarn resolves * deps natively — skip copy
+// If workspaces are already enabled, Yarn resolves * deps natively — skip
 if (rootPkg.workspaces && rootPkg.workspaces.length > 0) {
-  console.log('[eas-build-pre-install] Workspaces already configured, skipping copy.');
+  console.log('[eas-build-pre-install] Workspaces already configured, skipping.');
   process.exit(0);
 }
 

--- a/tools/scripts/eas-build-pre-install.mjs
+++ b/tools/scripts/eas-build-pre-install.mjs
@@ -13,9 +13,14 @@ const appPkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf-8'));
 
 appPkg.dependencies = rootPkg.dependencies;
 appPkg.devDependencies = rootPkg.devDependencies;
+if (rootPkg.packageManager) appPkg.packageManager = rootPkg.packageManager;
 if (rootPkg.overrides) appPkg.overrides = rootPkg.overrides;
 else if (rootPkg.resolutions) appPkg.resolutions = rootPkg.resolutions;
 
+// Tell EAS this is a Yarn workspace so it runs install from root
+rootPkg.workspaces = [projectRoot];
+
 writeFileSync(join(appDir, 'package.json'), JSON.stringify(appPkg, null, 2) + '\n');
+writeFileSync(join(workspaceRoot, 'package.json'), JSON.stringify(rootPkg, null, 2) + '\n');
 copyFileSync(join(workspaceRoot, 'yarn.lock'), join(appDir, 'yarn.lock'));
 console.log('[eas-build-pre-install] Copied root deps + lockfile.');

--- a/tools/scripts/eas-build-pre-install.mjs
+++ b/tools/scripts/eas-build-pre-install.mjs
@@ -9,6 +9,13 @@ const [workspaceRoot, projectRoot] = process.argv.slice(2);
 const appDir = resolve(workspaceRoot, projectRoot);
 
 const rootPkg = JSON.parse(readFileSync(join(workspaceRoot, 'package.json'), 'utf-8'));
+
+// If workspaces are already enabled on root, Yarn resolves * deps natively — skip copy
+if (rootPkg.workspaces && rootPkg.workspaces.length > 0) {
+  console.log('[eas-build-pre-install] Workspaces already configured, skipping copy.');
+  process.exit(0);
+}
+
 const appPkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf-8'));
 
 appPkg.dependencies = rootPkg.dependencies;


### PR DESCRIPTION
## Problem

PR #2224 replaced `@nx/expo:build` executor with raw `eas build` command. The old executor transparently configured `packageManager` on the app's `package.json` and `workspaces` on root `package.json` at build time. Without these, EAS builds fail during `INSTALL_DEPENDENCIES` with:

```
Usage Error: The nearest package directory doesn't seem to be part of the project
```

## Fix

2 lines added to `tools/scripts/eas-build-pre-install.mjs` (the `copy-lockfile` target script):

1. `appPkg.packageManager = rootPkg.packageManager` — tells EAS to use Yarn
2. `rootPkg.workspaces = [projectRoot]` — tells Yarn the app is part of the workspace, installs from root
3. Write modified root `package.json` so EAS sees it on upload

## Verified

Build `390b4ce3` ✅ — workspace detected, Yarn 4.2.2 install from root in 63s, Gradle build proceeding.

Works for both `eas build` and `eas update` (both depend on `copy-lockfile`).

## Summary by Sourcery

Configure EAS pre-install script to correctly treat Expo apps as part of the Yarn workspace after the Nx upgrade.

Enhancements:
- Propagate the root package.json packageManager field to the app package.json during EAS builds so Yarn is correctly selected.
- Declare the Expo app as a workspace in the root package.json and persist the change so EAS installs dependencies from the monorepo root.