### PR TITLE
chore: bump outreach app version to 1.2.3 (build 77)

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.2.2',
+    version: '1.2.3',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.2.2',
+      buildNumber: '1.2.3',
       associatedDomains: [`applinks:${HOSTNAME}`],
       config: {
         usesNonExemptEncryption: false,
@@ -70,7 +70,7 @@ export default {
         },
       ],
       config: {},
-      versionCode: 76,
+      versionCode: 77,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update app.config.js to reflect new semantic version and platform-specific build numbers for the BetterAngels app.