### PR TITLE
fix: switch to local versioning and bump version codes

### DIFF
--- a/apps/betterangels/eas.json
+++ b/apps/betterangels/eas.json
@@ -56,7 +56,6 @@
     }
   },
   "cli": {
-    "version": ">= 5",
-    "appVersionSource": "remote"
+    "version": ">= 5"
   }
 }


### PR DESCRIPTION
## Problem

`appVersionSource: "remote"` was introduced in the Expo SDK 56 upgrade (commit 95bea499f). This caused EAS to ignore the local `versionCode: 76` and start tracking versions remotely from 1. The Android submission failed with "You've already submitted this version of the app" since version code 1 was already consumed by the first remote build.

## Fix

- **Reverted to local versioning** — removed `appVersionSource: "remote"` from `eas.json`. Version codes now come from `app.config.js` and are tracked in git.
- `app.config.js` version bumps were already applied in #2231.

## Why local?

- Version history stays in git (fully auditable)
- One source of truth
- No EAS server dependency for version codes
- Fingerprint behavior is identical either way