### PR TITLE
fix(ci): install eas-cli on bare runners, cleanup e2e & eas-branch workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,6 +116,9 @@ jobs:
       - name: 📦 Install dependencies
         run: yarn install
 
+      - name: 📱 Install EAS CLI
+        run: npm install -g eas-cli@20.5.1
+
       - name: 🧪 Run E2E orchestration
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/eas-branch-cleanup.yml
+++ b/.github/workflows/eas-branch-cleanup.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 🔀 Track main if PR
-        if: github.ref != 'refs/heads/main'
+      - name: 🔀 Track main
         run: git branch --track main origin/main
 
       - name: 🔧 Configure NX SHAs
@@ -27,15 +26,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.21.1'
+          cache: 'yarn'
 
       - name: 🧶 Setup Yarn
         run: corepack enable
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'yarn'
 
       - name: 📦 Install dependencies
         run: yarn install
+
+      - name: 📱 Install EAS CLI
+        run: npm install -g eas-cli@20.5.1
 
       - name: ️ Delete EAS Branches for Affected Projects
         env:
@@ -49,14 +49,15 @@ jobs:
           fi
           for project in $affected; do
             echo "Deleting EAS branch for project: $project"
-            cd apps/$project
-            output=$(npx eas branch:delete --non-interactive "$BRANCH_NAME" 2>&1) || {
+            pushd apps/$project > /dev/null
+            output=$(eas branch:delete --non-interactive "$BRANCH_NAME" 2>&1) || {
               if echo "$output" | grep -q "Could not find branch"; then
                 echo "Branch $BRANCH_NAME does not exist on $project, skipping."
               else
                 echo "$output" >&2
+                popd > /dev/null
                 exit 1
               fi
             }
-            cd -
+            popd > /dev/null
           done


### PR DESCRIPTION
## Problem
After removing `@nx/expo:build` in favor of raw `eas build` commands (#2224), the **Maestro E2E Tests** workflow failed with `/bin/sh: 1: eas: not found` because the `eas` CLI is only installed in the Docker image, not on bare GitHub runners. The `eas-branch-cleanup` workflow had the same latent issue.

Example failure: https://github.com/BetterAngelsLA/monorepo/actions/runs/29369333422/job/87208616142

## Fix
- **e2e.yml**: Added `npm install -g eas-cli@20.5.1` step before E2E orchestration
- **eas-branch-cleanup.yml**: Same `eas-cli` install, plus:
  - Merged duplicate `actions/setup-node@v4` calls into one
  - Removed dead `if: github.ref != 'refs/heads/main'` guard
  - Replaced fragile `cd`/`cd -` with `pushd`/`popd`
  - Replaced unnecessary `npx eas` with `eas` (now globally installed)

## Summary by Sourcery

Ensure EAS CLI is available on GitHub-hosted runners and streamline EAS branch cleanup workflow.

New Features:
- Install global EAS CLI in Maestro E2E workflow to support raw eas build and related commands.
- Install global EAS CLI in eas-branch-cleanup workflow to enable non-Docker EAS operations.

Enhancements:
- Simplify eas-branch-cleanup workflow setup by consolidating Node/Yarn configuration and adding Yarn caching.
- Improve EAS branch deletion script reliability by using pushd/popd and relying on globally installed eas CLI instead of npx.
- Remove obsolete branch condition from eas-branch-cleanup workflow so main tracking always occurs.

CI:
- Update Maestro E2E and eas-branch-cleanup GitHub Actions workflows to work on bare runners by installing EAS CLI explicitly.