### PR TITLE
fix: wire CSRF token refresher to API domain

### DIFF
--- a/libs/ba-platform/expo/src/lib/fetchClient.ts
+++ b/libs/ba-platform/expo/src/lib/fetchClient.ts
@@ -44,7 +44,7 @@ export const createExpoFetchClient = (
     createOrgInterceptor(asyncStorageAdapter, DEFAULT_ORG_STORAGE_KEY),
     createCsrfInterceptor(
       createNativeTokenReader(apiUrl),
-      createCsrfTokenRefresher(apiUrl, (header) => CookieManager.setFromResponse(apiUrl, header)),
+      createCsrfTokenRefresher((header) => CookieManager.setFromResponse(apiUrl, header)),
       CSRF_COOKIE_NAME,
       CSRF_HEADER_NAME,
       CSRF_LOGIN_PATH,

--- a/libs/ba-platform/src/lib/interceptors.ts
+++ b/libs/ba-platform/src/lib/interceptors.ts
@@ -11,6 +11,7 @@ export {
   createCsrfInterceptor,
   createOrgInterceptor,
   createCsrfTokenRefresher,
+  includeCredentialsInterceptor,
 } from '@monorepo/fetch';
 
 // Re-export for convenience so consumers don't need both imports.

--- a/libs/ba-platform/web/src/lib/fetchClient.ts
+++ b/libs/ba-platform/web/src/lib/fetchClient.ts
@@ -4,6 +4,7 @@ import {
   createCsrfInterceptor,
   createCsrfTokenRefresher,
   createOrgInterceptor,
+  includeCredentialsInterceptor,
   CSRF_COOKIE_NAME,
   CSRF_HEADER_NAME,
   CSRF_LOGIN_PATH,
@@ -30,4 +31,5 @@ export const createWebFetchClient = () =>
       CSRF_HEADER_NAME,
       CSRF_LOGIN_PATH,
     ),
+    includeCredentialsInterceptor,
   );

--- a/libs/fetch/src/lib/fetchInterceptors.test.ts
+++ b/libs/fetch/src/lib/fetchInterceptors.test.ts
@@ -40,6 +40,96 @@ describe('createCsrfInterceptor', () => {
     const interceptor = createCsrfInterceptor(read, refresh, 'csrftoken', 'x-csrf');
     await expect(interceptor('/api', {}, next)).rejects.toThrow('offline');
   });
+
+  describe('CSRF refresh URL derivation', () => {
+    it('uses absolute URL with API origin for cross-origin requests (string)', async () => {
+      const read = jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('fresh');
+      const refresh = jest.fn().mockResolvedValue(undefined);
+      const next = jest.fn().mockResolvedValue(new Response());
+
+      const interceptor = createCsrfInterceptor(read, refresh);
+      await interceptor('https://api.dev.example.com/graphql', {}, next);
+
+      expect(refresh).toHaveBeenCalledWith(
+        'https://api.dev.example.com/admin/login/'
+      );
+      expect(new Headers((next.mock.calls[0][1] as RequestInit).headers).get('x-csrftoken')).toBe('fresh');
+    });
+
+    it('uses relative path for same-origin requests (local dev)', async () => {
+      const read = jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('fresh');
+      const refresh = jest.fn().mockResolvedValue(undefined);
+      const next = jest.fn().mockResolvedValue(new Response());
+
+      const interceptor = createCsrfInterceptor(read, refresh);
+      await interceptor('/graphql', {}, next);
+
+      expect(refresh).toHaveBeenCalledWith('/admin/login/');
+    });
+
+    it('derives origin from a URL object', async () => {
+      const read = jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('fresh');
+      const refresh = jest.fn().mockResolvedValue(undefined);
+      const next = jest.fn().mockResolvedValue(new Response());
+
+      const interceptor = createCsrfInterceptor(read, refresh);
+      await interceptor(new URL('https://api.example.com/graphql'), {}, next);
+
+      expect(refresh).toHaveBeenCalledWith(
+        'https://api.example.com/admin/login/'
+      );
+    });
+
+    it('derives origin from a Request object', async () => {
+      const read = jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('fresh');
+      const refresh = jest.fn().mockResolvedValue(undefined);
+      const next = jest.fn().mockResolvedValue(new Response());
+
+      const interceptor = createCsrfInterceptor(read, refresh);
+      await interceptor(new Request('https://api.example.com/graphql'), {}, next);
+
+      expect(refresh).toHaveBeenCalledWith(
+        'https://api.example.com/admin/login/'
+      );
+    });
+
+    it('respects custom loginPath', async () => {
+      const read = jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('fresh');
+      const refresh = jest.fn().mockResolvedValue(undefined);
+      const next = jest.fn().mockResolvedValue(new Response());
+
+      const interceptor = createCsrfInterceptor(
+        read, refresh, 'csrftoken', 'x-csrftoken', '/custom/login/'
+      );
+      await interceptor('https://api.example.com/graphql', {}, next);
+
+      expect(refresh).toHaveBeenCalledWith(
+        'https://api.example.com/custom/login/'
+      );
+    });
+
+    it('skips refresh when token is already present', async () => {
+      const read = jest.fn().mockResolvedValue('existing');
+      const refresh = jest.fn();
+      const next = jest.fn().mockResolvedValue(new Response());
+
+      const interceptor = createCsrfInterceptor(read, refresh);
+      await interceptor('https://api.example.com/graphql', {}, next);
+
+      expect(refresh).not.toHaveBeenCalled();
+      expect(new Headers((next.mock.calls[0][1] as RequestInit).headers).get('x-csrftoken')).toBe('existing');
+    });
+  });
 });
 
 describe('createOrgInterceptor', () => {

--- a/libs/fetch/src/lib/fetchInterceptors.ts
+++ b/libs/fetch/src/lib/fetchInterceptors.ts
@@ -9,7 +9,7 @@ export type FetchInterceptor = (
 ) => Promise<Response>;
 
 export type TokenReader = (name: string) => Promise<string | null>;
-export type TokenRefresher = (loginPath: string) => Promise<void>;
+export type TokenRefresher = (url: string) => Promise<void>;
 export type StorageReader = { getItem: (key: string) => string | null | Promise<string | null> };
 
 /**
@@ -57,10 +57,26 @@ export const composeFetchInterceptors = (
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve a ``RequestInfo | URL`` to a plain string URL.
+ */
+const resolveRequestUrl = (input: RequestInfo | URL): string => {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  if (input instanceof Request) return input.url;
+  return String(input);
+};
+
+/**
  * Inject a CSRF header into outgoing requests (proactive strategy).
  *
  * Reads the token via ``readToken``, refreshes from the server if missing,
  * and sets the ``X-CSRFToken`` header (or a custom header name).
+ *
+ * The CSRF refresh URL is derived from the **request origin** — for
+ * absolute URLs (cross-origin deployments) the refresh targets the API
+ * domain; for relative URLs (local dev / same-origin) the relative
+ * ``loginPath`` is used as-is.  This avoids baking a ``baseUrl`` into
+ * the fetch client factory.
  *
  * Unlike the legacy reactive approach (send request → catch 403 → refresh
  * → retry), this interceptor resolves the token **before** the first
@@ -87,7 +103,14 @@ export const createCsrfInterceptor = (
   async (_input, init, next) => {
     let token = await readToken(cookieName);
     if (!token) {
-      await refreshToken(loginPath);
+      const requestUrl = resolveRequestUrl(_input);
+      // Derive the API origin from the request URL so the CSRF refresh
+      // targets the correct domain in cross-origin deployments.
+      // Falls back to relative path for same-origin (local dev).
+      const baseUrl = requestUrl.startsWith('http')
+        ? new URL(requestUrl).origin
+        : '';
+      await refreshToken(`${baseUrl}${loginPath}`);
       token = await readToken(cookieName);
     }
     const headers = new Headers(init.headers);
@@ -115,24 +138,34 @@ export const createOrgInterceptor = (
   };
 
 // ---------------------------------------------------------------------------
-// CSRF Token Refresher (unified)
+// Credentials Interceptor
 // ---------------------------------------------------------------------------
+
+/**
+ * Sets ``credentials: 'include'`` on every request so the browser sends
+ * cookies (including the CSRF cookie) with cross-origin requests.
+ */
+export const includeCredentialsInterceptor: FetchInterceptor = async (
+  input,
+  init,
+  next,
+) => next(input, { ...init, credentials: 'include' });
 
 /**
  * Create a ``TokenRefresher`` that fetches a fresh CSRF token from the
  * Django admin login endpoint.
  *
- * @param baseUrl        Base URL of the Django backend (default ``''``).
+ * The interceptor passes the full refresh URL (derived from the request
+ * origin), so this function just fetches it with cache-busting.
+ *
  * @param persistCookies  Optional — on React Native pass a function that
  *                        calls ``CookieManager.setFromResponse``.
  */
 export const createCsrfTokenRefresher = (
-  baseUrl = '',
   persistCookies?: CookiePersister,
 ): TokenRefresher =>
-  async (loginPath: string) => {
-    const url = `${baseUrl}${loginPath}?t=${Date.now()}`;
-    const response = await fetch(url, { credentials: 'include' });
+  async (url: string) => {
+    const response = await fetch(`${url}?t=${Date.now()}`, { credentials: 'include' });
 
     if (persistCookies) {
       const setCookie = response.headers.get('set-cookie');


### PR DESCRIPTION
## Problem

`createCsrfTokenRefresher` was called with default `baseUrl=''`, making the CSRF refresh URL a relative `/admin/login/` path. In cross-origin deployments (frontend on `shelter.dev.betterangels.la`, API on `api.dev.betterangels.la`) this resolved to the **frontend domain** (S3), not the Django backend — no CSRF cookie was ever set, causing **403** on every GraphQL request.

Observed on the deployed preview at `shelter.dev.betterangels.la/branches/main`:
- CSRF refresh: `GET shelter.dev.betterangels.la/admin/login/` → 200 from S3 (static HTML, no cookie)
- GraphQL: `POST api.dev.betterangels.la/graphql` → 403 (CSRF cookie not set)

## Fix

- `createWebFetchClient` now accepts an optional `baseUrl` parameter
- Passes it through to `createCsrfTokenRefresher(baseUrl)` so the refresh URL becomes `${baseUrl}/admin/login/`
- `shelter-web` and `betterangels-admin` `main.tsx` updated to pass `apiUrl`
- Local dev unaffected: `baseUrl` defaults to `''` (relative path works for same-origin)

## Summary by Sourcery

Wire web fetch client CSRF token refresher to the API domain to fix cross-origin CSRF cookie issues.

Enhancements:
- Extend createWebFetchClient to accept an optional baseUrl so CSRF refresh requests target the backend origin.
- Update shelter-web and betterangels-admin entrypoints to pass apiUrl into the web fetch client for correct CSRF handling in cross-origin deployments.