### PR TITLE
fix ba-platform codegen target

### DIFF
--- a/libs/ba-platform/project.json
+++ b/libs/ba-platform/project.json
@@ -15,7 +15,7 @@
         "jestConfig": "libs/ba-platform/jest.config.ts"
       }
     },
-    "generate": {
+    "generate-graphql-types": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "libs/ba-platform",


### PR DESCRIPTION
`yarn nx run-many -t generate-graphql-types` skipping ba-platform because target typo