### PR TITLE
fix lint warnings in apollo lib (DEV-2472)

### DIFF
--- a/libs/apollo/src/lib/cachePolicy/generateCachePolicies.test.ts
+++ b/libs/apollo/src/lib/cachePolicy/generateCachePolicies.test.ts
@@ -14,27 +14,28 @@ import { TCachePolicyConfig } from './types';
 function fp(partial: Partial<FieldPolicy>): FieldPolicy {
   return {
     ...(partial.read ? { read: partial.read } : {}),
-    ...(partial.merge ? { merge: partial.merge as any } : {}),
+    ...(partial.merge ? { merge: partial.merge as FieldPolicy['merge'] } : {}),
     ...(partial.keyArgs !== undefined ? { keyArgs: partial.keyArgs } : {}),
   };
 }
 
 const getType = (p: TypePolicies, name: string) =>
-  p[name] as unknown as { keyFields?: any };
+  p[name] as unknown as { keyFields?: unknown };
 
 const getQueryFields = (p: TypePolicies) =>
   (p['Query'] as unknown as { fields: Record<string, FieldPolicy> }).fields;
 
 describe('generateCachePolicies', () => {
-  let warnSpy: MockInstance<[message?: any, ...optionalParams: any[]], void>;
+  let warnSpy: MockInstance<
+    (message?: unknown, ...optionalParams: unknown[]) => void
+  >;
 
   beforeEach(() => {
     warnSpy = vi
       .spyOn(console, 'warn')
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .mockImplementation(() => {}) as unknown as MockInstance<
-      [message?: any, ...optionalParams: any[]],
-      void
+      (message?: unknown, ...optionalParams: unknown[]) => void
     >;
   });
 
@@ -100,7 +101,7 @@ describe('generateCachePolicies', () => {
 
     expect(getType(policies, 'Thing').keyFields).toEqual(['id']);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Conflicting keyFields for Thing')
+      expect.stringContaining('Conflicting keyFields for Thing'),
     );
   });
 });

--- a/libs/apollo/src/lib/cachePolicy/generateCachePolicies.ts
+++ b/libs/apollo/src/lib/cachePolicy/generateCachePolicies.ts
@@ -6,7 +6,7 @@ import { TCachePolicyConfig } from './types';
 type TKeyFields = TypePolicy['keyFields'];
 
 export function generateCachePolicies(
-  registry: TCachePolicyConfig
+  registry: TCachePolicyConfig,
 ): TypePolicies {
   const queryFieldPolicies: Record<string, FieldPolicy> = {};
   const policiesByTypename: Record<string, TypePolicy> = {};
@@ -19,7 +19,8 @@ export function generateCachePolicies(
       const finalFieldPolicy: FieldPolicy = { ...fieldPolicy };
 
       if (queryPolicyConfig) {
-        (finalFieldPolicy as any).__queryPolicyConfig = queryPolicyConfig;
+        (finalFieldPolicy as Record<string, unknown>)['__queryPolicyConfig'] =
+          queryPolicyConfig;
       }
 
       queryFieldPolicies[fieldName] = finalFieldPolicy;
@@ -41,8 +42,8 @@ export function generateCachePolicies(
       if (!isDeepEqual(existingKeyFields, desiredKeyFields)) {
         console.warn(
           `[generateCachePolicies] Conflicting keyFields for ${entityTypename}. existing=${JSON.stringify(
-            existingKeyFields
-          )}, ignored=${JSON.stringify(desiredKeyFields)}`
+            existingKeyFields,
+          )}, ignored=${JSON.stringify(desiredKeyFields)}`,
         );
       }
 

--- a/libs/apollo/src/lib/cachePolicy/generateFieldPolicy.test.ts
+++ b/libs/apollo/src/lib/cachePolicy/generateFieldPolicy.test.ts
@@ -13,12 +13,17 @@ import type { QueryPolicyConfig } from './types';
 
 // mock the module we delegate to
 vi.mock('./merge', () => {
-  const generateMergeFn = vi.fn((_mergeOpts?: any, _paginationVars?: any) => {
-    // return a dummy merge function Apollo would call
-    return vi.fn((existing: any, incoming: any) => {
-      return incoming ?? existing;
-    });
-  });
+  const generateMergeFn = vi.fn(
+    (
+      _mergeOpts?: Record<string, unknown>,
+      _paginationVars?: Record<string, unknown>,
+    ) => {
+      // return a dummy merge function Apollo would call
+      return vi.fn((existing: unknown, incoming: unknown) => {
+        return incoming ?? existing;
+      });
+    },
+  );
 
   return { generateMergeFn };
 });
@@ -59,7 +64,7 @@ describe('generateFieldPolicy', () => {
 
     expect(policy.keyArgs).toEqual(['filters', 'order']);
     expect(
-      typeof policy.merge === 'function' || typeof policy.merge === 'boolean'
+      typeof policy.merge === 'function' || typeof policy.merge === 'boolean',
     ).toBe(true);
 
     // use dynamic import so ESM/vitest is happy
@@ -84,7 +89,7 @@ describe('generateFieldPolicy', () => {
 
     expect(policy.keyArgs).toBe(false);
     expect(
-      typeof policy.merge === 'function' || typeof policy.merge === 'boolean'
+      typeof policy.merge === 'function' || typeof policy.merge === 'boolean',
     ).toBe(true);
 
     const mockedModule = await import('./merge');
@@ -101,7 +106,7 @@ describe('generateFieldPolicy', () => {
   it('forwards mergeOpts and uses pagination derived from queryPolicyConfig', async () => {
     const mergeOpts = {
       mode: 'ARRAY',
-    } as any;
+    } as Record<string, unknown>;
 
     const policy = generateFieldPolicy({
       keyArgs: ['filters'],
@@ -113,7 +118,11 @@ describe('generateFieldPolicy', () => {
 
     // narrow to callable (Apollo types allow true/false)
     if (typeof mergeFn === 'function') {
-      mergeFn({ results: [1] }, { results: [2] }, {} as any);
+      mergeFn(
+        { results: [1] },
+        { results: [2] },
+        {} as unknown as Parameters<typeof mergeFn>[2],
+      );
     } else {
       throw new Error('mergeFn was not a function');
     }
@@ -145,7 +154,7 @@ describe('generateFieldPolicy', () => {
     if (typeof mergeFn === 'function') {
       const result = mergeFn({ results: [1, 2, 3] }, [9, 8], {
         args: { offset: 0 },
-      } as any);
+      } as unknown as Parameters<typeof mergeFn>[2]);
 
       expect(result).toEqual([9, 8]);
     } else {

--- a/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/mergeObjectPayloadTests/infiniteScrollBasic.test.ts
+++ b/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/mergeObjectPayloadTests/infiniteScrollBasic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mergeObjectPayload } from '../../mergeObjectPayload';
 import {
   TItem,
+  TMergedPayload,
   adaptPagination,
   generateIncoming,
   makeOptions,
@@ -11,7 +12,7 @@ describe('mergeObjectPayload – wrapper strategy (infinite scroll)', () => {
   it('merges sequential pages at offsets and preserves metadata', () => {
     // wrapper to satisfy ResolveMergePagination type
     const resolvePaginationStrict = (
-      vars: { pagination?: { offset?: number; limit?: number } } | undefined
+      vars: { pagination?: { offset?: number; limit?: number } } | undefined,
     ) => {
       const base = adaptPagination(vars);
       return {
@@ -36,35 +37,45 @@ describe('mergeObjectPayload – wrapper strategy (infinite scroll)', () => {
           { id: 2, name: 'B' },
           { id: 3, name: 'C' },
         ],
-        { totalCount: 6, pageInfo: { offset: 0, limit: 3 } }
-      ) as any,
-      makeOptions({ pagination: { offset: 0, limit: 3 } })
+        { totalCount: 6, pageInfo: { offset: 0, limit: 3 } },
+      ) as TMergedPayload,
+      makeOptions({ pagination: { offset: 0, limit: 3 } }),
     );
 
-    expect((afterPage1 as any).results.map((it: TItem) => it?.id)).toEqual([
-      1, 2, 3,
-    ]);
-    expect((afterPage1 as any).totalCount).toBe(6);
-    expect((afterPage1 as any).pageInfo).toEqual({ offset: 0, limit: 3 });
+    expect(
+      (afterPage1 as TMergedPayload).results.map(
+        (it: TItem | undefined) => it?.id,
+      ),
+    ).toEqual([1, 2, 3]);
+    expect((afterPage1 as TMergedPayload).totalCount).toBe(6);
+    expect((afterPage1 as TMergedPayload).pageInfo).toEqual({
+      offset: 0,
+      limit: 3,
+    });
 
     // --- Page 2 (offset 3), omit totalCount to verify carry-forward ---
     const afterPage2 = mergeFn(
-      afterPage1 as any,
+      afterPage1 as TMergedPayload,
       generateIncoming(
         [
           { id: 4, name: 'D' },
           { id: 5, name: 'E' },
           { id: 6, name: 'F' },
         ],
-        { pageInfo: { offset: 3, limit: 3 } }
-      ) as any,
-      makeOptions({ pagination: { offset: 3, limit: 3 } })
+        { pageInfo: { offset: 3, limit: 3 } },
+      ) as TMergedPayload,
+      makeOptions({ pagination: { offset: 3, limit: 3 } }),
     );
 
     expect(
-      (afterPage2 as any).results.map((it: TItem | undefined) => it?.id)
+      (afterPage2 as TMergedPayload).results.map(
+        (it: TItem | undefined) => it?.id,
+      ),
     ).toEqual([1, 2, 3, 4, 5, 6]);
-    expect((afterPage2 as any).totalCount).toBe(6); // carried forward
-    expect((afterPage2 as any).pageInfo).toEqual({ offset: 3, limit: 3 });
+    expect((afterPage2 as TMergedPayload).totalCount).toBe(6); // carried forward
+    expect((afterPage2 as TMergedPayload).pageInfo).toEqual({
+      offset: 3,
+      limit: 3,
+    });
   });
 });

--- a/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/mergeObjectPayloadTests/infiniteScrollDedupe.test.ts
+++ b/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/mergeObjectPayloadTests/infiniteScrollDedupe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mergeObjectPayload } from '../../mergeObjectPayload';
 import {
   TItem,
+  TMergedPayload,
   adaptPagination,
   generateIncoming,
   makeOptions,
@@ -11,7 +12,7 @@ describe('mergeObjectPayload – wrapper strategy (infinite scroll)', () => {
   it('dedupes when a later page reuses an earlier id', () => {
     // strict resolver to match ResolveMergePagination<TVars>
     const resolvePaginationStrict = (
-      vars: { pagination?: { offset?: number; limit?: number } } | undefined
+      vars: { pagination?: { offset?: number; limit?: number } } | undefined,
     ) => {
       const base = adaptPagination(vars);
       return {
@@ -36,37 +37,47 @@ describe('mergeObjectPayload – wrapper strategy (infinite scroll)', () => {
           { id: 2, name: 'B' },
           { id: 3, name: 'C' },
         ],
-        { totalCount: 6, pageInfo: { offset: 0, limit: 3 } }
-      ) as any,
-      makeOptions({ pagination: { offset: 0, limit: 3 } })
+        { totalCount: 6, pageInfo: { offset: 0, limit: 3 } },
+      ) as TMergedPayload,
+      makeOptions({ pagination: { offset: 0, limit: 3 } }),
     );
 
-    expect((afterPage1 as any).results.map((it: TItem) => it?.id)).toEqual([
-      1, 2, 3,
-    ]);
-    expect((afterPage1 as any).totalCount).toBe(6);
-    expect((afterPage1 as any).pageInfo).toEqual({ offset: 0, limit: 3 });
+    expect(
+      (afterPage1 as TMergedPayload).results.map(
+        (it: TItem | undefined) => it?.id,
+      ),
+    ).toEqual([1, 2, 3]);
+    expect((afterPage1 as TMergedPayload).totalCount).toBe(6);
+    expect((afterPage1 as TMergedPayload).pageInfo).toEqual({
+      offset: 0,
+      limit: 3,
+    });
 
     // Page 2 (offset 3), but second item is a DUPE of id=2
     const afterPage2 = mergeFn(
-      afterPage1 as any,
+      afterPage1 as TMergedPayload,
       generateIncoming(
         [
           { id: 4, name: 'D' },
           { id: 2, name: 'DUPE' },
           { id: 6, name: 'F' },
         ],
-        { pageInfo: { offset: 3, limit: 3 } }
-      ) as any,
-      makeOptions({ pagination: { offset: 3, limit: 3 } })
+        { pageInfo: { offset: 3, limit: 3 } },
+      ) as TMergedPayload,
+      makeOptions({ pagination: { offset: 3, limit: 3 } }),
     );
 
     // your mergeObjectPayload removes the earlier occurrence when the same id
     // appears again at a different index, so index 1 becomes undefined
     expect(
-      (afterPage2 as any).results.map((it: TItem | undefined) => it?.id)
+      (afterPage2 as TMergedPayload).results.map(
+        (it: TItem | undefined) => it?.id,
+      ),
     ).toEqual([1, undefined, 3, 4, 2, 6]);
-    expect((afterPage2 as any).totalCount).toBe(6);
-    expect((afterPage2 as any).pageInfo).toEqual({ offset: 3, limit: 3 });
+    expect((afterPage2 as TMergedPayload).totalCount).toBe(6);
+    expect((afterPage2 as TMergedPayload).pageInfo).toEqual({
+      offset: 3,
+      limit: 3,
+    });
   });
 });

--- a/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/mergeObjectPayloadTests/paginatedBasic.test.ts
+++ b/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/mergeObjectPayloadTests/paginatedBasic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mergeObjectPayload } from '../../mergeObjectPayload';
 import {
   TItem,
+  TMergedPayload,
   adaptPagination,
   generateIncoming,
   makeOptions,
@@ -13,7 +14,7 @@ describe('mergeObjectPayload – paginated (sparse) jumps with offsets', () => {
 
     // stricter wrapper that matches ResolveMergePagination<TVars>
     const resolvePaginationStrict = (
-      vars: { pagination?: { offset?: number; limit?: number } } | undefined
+      vars: { pagination?: { offset?: number; limit?: number } } | undefined,
     ) => {
       const base = adaptPagination(vars);
       return {
@@ -43,52 +44,58 @@ describe('mergeObjectPayload – paginated (sparse) jumps with offsets', () => {
           { id: 2, name: 'B' },
           { id: 3, name: 'C' },
         ],
-        { totalCount: 9, pageInfo: { offset: 0, limit } }
-      ) as any,
-      makeOptions({ pagination: { offset: 0, limit } })
+        { totalCount: 9, pageInfo: { offset: 0, limit } },
+      ) as TMergedPayload,
+      makeOptions({ pagination: { offset: 0, limit } }),
     );
 
     expect(
-      (afterPage1 as any).results.map((it: TItem | undefined) => it?.id)
+      (afterPage1 as TMergedPayload).results.map(
+        (it: TItem | undefined) => it?.id,
+      ),
     ).toEqual([1, 2, 3]);
-    expect((afterPage1 as any).totalCount).toBe(9);
+    expect((afterPage1 as TMergedPayload).totalCount).toBe(9);
 
     // --- page 3 ---
     const afterPage3 = mergeFn(
-      afterPage1 as any,
+      afterPage1 as TMergedPayload,
       generateIncoming(
         [
           { id: 7, name: 'G' },
           { id: 8, name: 'H' },
           { id: 9, name: 'I' },
         ],
-        { pageInfo: { offset: 6, limit } }
-      ) as any,
-      makeOptions({ pagination: { offset: 6, limit } })
+        { pageInfo: { offset: 6, limit } },
+      ) as TMergedPayload,
+      makeOptions({ pagination: { offset: 6, limit } }),
     );
 
     expect(
-      (afterPage3 as any).results.map((it: TItem | undefined) => it?.id)
+      (afterPage3 as TMergedPayload).results.map(
+        (it: TItem | undefined) => it?.id,
+      ),
     ).toEqual([1, 2, 3, undefined, undefined, undefined, 7, 8, 9]);
-    expect((afterPage3 as any).totalCount).toBe(9);
+    expect((afterPage3 as TMergedPayload).totalCount).toBe(9);
 
     // --- page 2 ---
     const afterPage2 = mergeFn(
-      afterPage3 as any,
+      afterPage3 as TMergedPayload,
       generateIncoming(
         [
           { id: 4, name: 'D' },
           { id: 5, name: 'E' },
           { id: 6, name: 'F' },
         ],
-        { pageInfo: { offset: 3, limit } }
-      ) as any,
-      makeOptions({ pagination: { offset: 3, limit } })
+        { pageInfo: { offset: 3, limit } },
+      ) as TMergedPayload,
+      makeOptions({ pagination: { offset: 3, limit } }),
     );
 
     expect(
-      (afterPage2 as any).results.map((it: TItem | undefined) => it?.id)
+      (afterPage2 as TMergedPayload).results.map(
+        (it: TItem | undefined) => it?.id,
+      ),
     ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    expect((afterPage2 as any).totalCount).toBe(9);
+    expect((afterPage2 as TMergedPayload).totalCount).toBe(9);
   });
 });

--- a/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/testUtils.ts
+++ b/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/Tests/testUtils.ts
@@ -1,10 +1,17 @@
 import type { FieldFunctionOptions } from '@apollo/client';
+import type { FieldMergeFunctionOptions } from '@apollo/client/cache';
 import { Kind, type FieldNode } from 'graphql';
 
 export type TItem = { id: number; name: string };
 
+export type TMergedPayload = {
+  results: (TItem | undefined)[];
+  totalCount?: number;
+  pageInfo?: Record<string, unknown>;
+};
+
 export const adaptPagination = (
-  vars: { pagination?: { offset?: number; limit?: number } } | undefined
+  vars: { pagination?: { offset?: number; limit?: number } } | undefined,
 ) => vars?.pagination ?? {};
 
 export const paginationKeys = {
@@ -19,18 +26,18 @@ type TestReadField = FieldFunctionOptions<
   Record<string, unknown>
 >['readField'];
 
-const readFieldFn: TestReadField = (fieldNameOrOpts: any, from?: any) => {
+const readFieldFn = ((fieldNameOrOpts: unknown, from?: unknown) => {
   const fieldName =
     typeof fieldNameOrOpts === 'string'
       ? fieldNameOrOpts
-      : fieldNameOrOpts?.fieldName;
+      : (fieldNameOrOpts as { fieldName?: string })?.fieldName;
 
   if (!fieldName) {
     return undefined;
   }
 
-  return from?.[fieldName];
-};
+  return (from as Record<string, unknown>)?.[fieldName];
+}) as TestReadField;
 
 // Minimal FieldNode
 export const testFieldNode: FieldNode = {
@@ -39,8 +46,8 @@ export const testFieldNode: FieldNode = {
 };
 
 export function makeOptions(
-  args: any
-): FieldFunctionOptions<Record<string, unknown>, Record<string, unknown>> {
+  args: Record<string, unknown>,
+): FieldMergeFunctionOptions<Record<string, unknown>, Record<string, unknown>> {
   return {
     args,
     readField: readFieldFn,
@@ -48,18 +55,28 @@ export function makeOptions(
     field: testFieldNode,
     storeFieldName: 'testField',
     variables: undefined,
-    toReference: ((v: any) => v) as any,
-    canRead: (() => true) as any,
-    isReference: ((v: any) => !!v && typeof v.__ref === 'string') as any,
-    mergeObjects: ((a: any, b: any) => ({ ...a, ...b })) as any,
-    cache: {} as any,
-    storage: {} as any,
-  };
+    toReference: ((v: unknown) =>
+      v) as unknown as FieldFunctionOptions['toReference'],
+    canRead: (() => true) as unknown as FieldFunctionOptions['canRead'],
+    isReference: ((v: Record<string, unknown> | null) =>
+      !!v &&
+      typeof v['__ref'] ===
+        'string') as unknown as FieldFunctionOptions['isReference'],
+    mergeObjects: ((
+      a: Record<string, unknown>,
+      b: Record<string, unknown>,
+    ) => ({ ...a, ...b })) as unknown as FieldFunctionOptions['mergeObjects'],
+    cache: {} as unknown as FieldFunctionOptions['cache'],
+    storage: {} as unknown as FieldFunctionOptions['storage'],
+  } as unknown as FieldMergeFunctionOptions<
+    Record<string, unknown>,
+    Record<string, unknown>
+  >;
 }
 
 export const generateIncoming = (
   items: TItem[],
-  meta?: Partial<{ totalCount: number; pageInfo: any }>
+  meta?: Partial<{ totalCount: number; pageInfo: Record<string, unknown> }>,
 ) => ({
   results: items,
   ...(meta?.totalCount !== undefined ? { totalCount: meta.totalCount } : {}),

--- a/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/mergeArrayPayload.ts
+++ b/libs/apollo/src/lib/cachePolicy/merge/mergeFunctions/mergeArrayPayload.ts
@@ -3,7 +3,7 @@ import type { FieldMergeFunctionOptions } from '@apollo/client/cache';
 import type { ResolveMergePagination } from '../types';
 
 export function mergeArrayPayload<TItem = unknown, TVars = unknown>(
-  resolvePagination: ResolveMergePagination<TVars>
+  resolvePagination: ResolveMergePagination<TVars>,
 ): FieldMergeFunction<
   readonly TItem[] | undefined,
   readonly TItem[] | undefined,
@@ -11,7 +11,8 @@ export function mergeArrayPayload<TItem = unknown, TVars = unknown>(
 > {
   return (existing, incoming, options) => {
     const { offset = 0 } =
-      resolvePagination(options.args as TVars) || ({} as any);
+      resolvePagination(options.args as TVars) ||
+      ({} as Record<string, unknown>);
 
     const prev = (existing as readonly TItem[] | undefined) ?? [];
     const next = (incoming as readonly TItem[] | undefined) ?? [];

--- a/libs/apollo/src/lib/cachePolicy/queryPolicyConf/getQueryPolicyFactory.test.ts
+++ b/libs/apollo/src/lib/cachePolicy/queryPolicyConf/getQueryPolicyFactory.test.ts
@@ -29,17 +29,32 @@ vi.mock('../generateFieldPolicy', () => ({
 
 // 2) mock getMergeOptions so we can see what paths were passed
 vi.mock('./utils/getMergeOptions', () => ({
-  getMergeOptions: vi.fn((mergeOpts: any, paths: any) => {
-    return {
-      ...mergeOpts,
-      __paths: paths,
-    };
-  }),
+  getMergeOptions: vi.fn(
+    (mergeOpts: Record<string, unknown>, paths: Record<string, unknown>) => {
+      return {
+        ...mergeOpts,
+        __paths: paths,
+      };
+    },
+  ),
 }));
 
 // 3) mock generateQueryPolicyConfig — this is the new piece we actually use
+interface GenerateQueryPolicyConfigInput {
+  itemsPath?: string[];
+  totalCountPath?: string[];
+  paginationMode?: PaginationModeEnum;
+  paginationVariables?: {
+    offsetPath?: string[];
+    limitPath?: string[];
+    pagePath?: string[];
+    perPagePath?: string[];
+    mode?: PaginationModeEnum;
+  };
+}
+
 vi.mock('./utils/generateQueryPolicyConfig', () => ({
-  generateQueryPolicyConfig: vi.fn((input: any) => {
+  generateQueryPolicyConfig: vi.fn((input: GenerateQueryPolicyConfigInput) => {
     // emulate the real function enough for tests
     const {
       itemsPath = [DEFAULT_QUERY_RESULTS_KEY],
@@ -82,7 +97,7 @@ vi.mock('./utils/generateQueryPolicyConfig', () => ({
 
 // 4) mock itemIdPathToKeyFields
 vi.mock('./utils/itemIdPathToKeyFields', () => ({
-  itemIdPathToKeyFields: vi.fn((itemIdPath: any) => {
+  itemIdPathToKeyFields: vi.fn((itemIdPath: string | string[]) => {
     return Array.isArray(itemIdPath) ? itemIdPath : [itemIdPath];
   }),
 }));
@@ -129,7 +144,7 @@ describe('getQueryPolicyFactory', () => {
     expect(generateFieldPolicy).toHaveBeenCalledWith(
       expect.objectContaining({
         keyArgs: ['filters'],
-      })
+      }),
     );
   });
 
@@ -176,7 +191,7 @@ describe('getQueryPolicyFactory', () => {
         itemsPath: ['data', 'items'],
         totalCountPath: ['data', 'total'],
         itemIdPath: ['data', 'items', 'clientId'],
-      }
+      },
     );
 
     // we built the policy config with the provided pagination
@@ -190,7 +205,7 @@ describe('getQueryPolicyFactory', () => {
           pagePath: ['pagination', 'page'],
           perPagePath: ['pagination', 'pageSize'],
         },
-      })
+      }),
     );
 
     // generateFieldPolicy should receive THAT config
@@ -207,7 +222,7 @@ describe('getQueryPolicyFactory', () => {
           mode: MergeModeEnum.Object,
           __paths: expect.any(Object),
         }),
-      })
+      }),
     );
   });
 
@@ -257,7 +272,7 @@ describe('getQueryPolicyFactory', () => {
     conf.buildFn();
 
     expect(warnSpy).toHaveBeenCalledWith(
-      '[getQueryPolicyFactory]: array mode is not yet fully supported.'
+      '[getQueryPolicyFactory]: array mode is not yet fully supported.',
     );
   });
 
@@ -288,7 +303,7 @@ describe('getQueryPolicyFactory', () => {
         itemsPath: [DEFAULT_QUERY_RESULTS_KEY],
         totalCountPath: [DEFAULT_QUERY_TOTAL_COUNT_KEY],
         itemIdPath: [DEFAULT_QUERY_ID_KEY],
-      }
+      },
     );
   });
 

--- a/libs/apollo/src/lib/cachePolicy/queryPolicyConf/utils/assemblePolicyRegistry.ts
+++ b/libs/apollo/src/lib/cachePolicy/queryPolicyConf/utils/assemblePolicyRegistry.ts
@@ -50,12 +50,12 @@
  */
 
 export function assemblePolicyRegistry<
-  const T extends readonly { key: string; buildFn: () => any }[]
+  const T extends readonly { key: string; buildFn: () => unknown }[],
 >(
   opts: T,
   options?: {
     isDevEnv?: boolean;
-  }
+  },
 ) {
   // (Optional) dev-time duplicate-key warning
   if (options?.isDevEnv) {
@@ -65,7 +65,7 @@ export function assemblePolicyRegistry<
       if (seen.has(key)) {
         // eslint-disable-next-line no-console
         console.warn(
-          `[apollo assemblePolicyRegistry] Duplicate key "${key}" – later one will override.`
+          `[apollo assemblePolicyRegistry] Duplicate key "${key}" – later one will override.`,
         );
       }
       seen.add(key);

--- a/libs/apollo/src/lib/cachePolicy/queryPolicyConf/utils/assemblePolicyRegistry.ts
+++ b/libs/apollo/src/lib/cachePolicy/queryPolicyConf/utils/assemblePolicyRegistry.ts
@@ -56,7 +56,7 @@ export function assemblePolicyRegistry<
   options?: {
     isDevEnv?: boolean;
   },
-) {
+): { [K in T[number] as K['key']]: ReturnType<K['buildFn']> } {
   // (Optional) dev-time duplicate-key warning
   if (options?.isDevEnv) {
     const seen = new Set<string>();
@@ -72,5 +72,9 @@ export function assemblePolicyRegistry<
     }
   }
 
-  return Object.fromEntries(opts.map(({ key, buildFn }) => [key, buildFn()]));
+  return Object.fromEntries(
+    opts.map(({ key, buildFn }) => [key, buildFn()]),
+  ) as {
+    [K in T[number] as K['key']]: ReturnType<K['buildFn']>;
+  };
 }

--- a/libs/apollo/src/lib/cachePolicy/queryPolicyConf/utils/generateQueryPolicyConfig.test.ts
+++ b/libs/apollo/src/lib/cachePolicy/queryPolicyConf/utils/generateQueryPolicyConfig.test.ts
@@ -12,22 +12,24 @@ import { generateQueryPolicyConfig } from './generateQueryPolicyConfig';
 // we want to test OUR logic here, not the pagination util’s logic,
 // so we can mock getPaginationVarsPerMode to return predictable shapes
 vi.mock('./getPaginationVarsPerMode', () => ({
-  getPaginationVarsPerMode: vi.fn((mode: any, vars: any) => {
-    // emulate the real behavior enough for tests
-    if (mode === PaginationModeEnum.Offset) {
+  getPaginationVarsPerMode: vi.fn(
+    (mode: PaginationModeEnum, vars: Record<string, unknown>) => {
+      // emulate the real behavior enough for tests
+      if (mode === PaginationModeEnum.Offset) {
+        return {
+          mode,
+          offsetPath: vars?.['offsetPath'] ?? ['pagination', 'offset'],
+          limitPath: vars?.['limitPath'] ?? ['pagination', 'limit'],
+        };
+      }
+
       return {
         mode,
-        offsetPath: vars?.offsetPath ?? ['pagination', 'offset'],
-        limitPath: vars?.limitPath ?? ['pagination', 'limit'],
+        pagePath: vars?.['pagePath'] ?? ['pagination', 'page'],
+        perPagePath: vars?.['perPagePath'] ?? ['pagination', 'perPage'],
       };
-    }
-
-    return {
-      mode,
-      pagePath: vars?.pagePath ?? ['pagination', 'page'],
-      perPagePath: vars?.perPagePath ?? ['pagination', 'perPage'],
-    };
-  }),
+    },
+  ),
 }));
 
 describe('generateQueryPolicyConfig', () => {
@@ -91,7 +93,7 @@ describe('generateQueryPolicyConfig', () => {
 
   it('throws when itemsPath becomes empty after normalization', () => {
     expect(() => generateQueryPolicyConfig({ itemsPath: '' })).toThrow(
-      '[buildQueryPolicyConfig] itemsPath must be a non-empty string or string[]'
+      '[buildQueryPolicyConfig] itemsPath must be a non-empty string or string[]',
     );
   });
 });

--- a/libs/apollo/src/lib/cachePolicy/types/core.ts
+++ b/libs/apollo/src/lib/cachePolicy/types/core.ts
@@ -1,11 +1,16 @@
-import { FieldPolicy, InMemoryCache, TypePolicies } from '@apollo/client';
+import {
+  FieldPolicy,
+  InMemoryCache,
+  TypePolicies,
+  TypePolicy,
+} from '@apollo/client';
 import { TYPE_POLICIES_SYM } from '../constants';
 import { QueryPolicyConfig } from './queryPolicyConfig';
 
 /** Represents a single field policy entry */
 export type TCachePolicyEntry = {
   entityTypename: string;
-  keyFields?: string[] | false;
+  keyFields?: TypePolicy['keyFields'];
   fieldPolicy: FieldPolicy<Record<string, unknown>, Record<string, unknown>>;
   queryPolicyConfig?: QueryPolicyConfig;
 };

--- a/libs/apollo/src/lib/cachePolicy/utils/defaultGetItemId.ts
+++ b/libs/apollo/src/lib/cachePolicy/utils/defaultGetItemId.ts
@@ -7,15 +7,14 @@ import { DEFAULT_QUERY_ID_KEY } from '../constants';
  */
 export function defaultGetItemId<TItem>(
   item: TItem,
-  readField: FieldFunctionOptions['readField']
+  readField: FieldFunctionOptions['readField'],
 ): string | number | null | undefined {
   if (typeof readField !== 'function') {
     return null;
   }
 
-  return readField(DEFAULT_QUERY_ID_KEY, item as any) as
-    | string
-    | number
-    | null
-    | undefined;
+  return readField(
+    DEFAULT_QUERY_ID_KEY,
+    item as NonNullable<Parameters<typeof readField>[1]>,
+  ) as string | number | null | undefined;
 }

--- a/libs/apollo/src/lib/cacheStore/utils/getQueryPolicyConfigFromCache.ts
+++ b/libs/apollo/src/lib/cacheStore/utils/getQueryPolicyConfigFromCache.ts
@@ -4,11 +4,11 @@ import { getTypeFieldPolicyFromCache } from './getTypeFieldPolicyFromCache';
 
 export function getQueryPolicyConfigFromCache(
   cache: ApolloCache,
-  fieldName: string
+  fieldName: string,
 ): QueryPolicyConfig | undefined {
   const fieldPolicy = getTypeFieldPolicyFromCache(cache, 'Query', fieldName);
 
-  return (fieldPolicy as any)?.__queryPolicyConfig as
+  return (fieldPolicy as Record<string, unknown>)?.['__queryPolicyConfig'] as
     | QueryPolicyConfig
     | undefined;
 }

--- a/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/testUtils.ts
+++ b/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/testUtils.ts
@@ -7,8 +7,8 @@ import {
 } from '@apollo/client';
 import { ApolloProvider } from '@apollo/client/react';
 import { renderHook } from '@testing-library/react';
-import { vi } from 'vitest';
 import * as React from 'react';
+import { vi } from 'vitest';
 
 /**
  * Minimal useQuery result shape for mocking in tests.
@@ -46,7 +46,7 @@ export interface MockUseQueryResult<TData, TVars> {
  * `refetch` and `fetchMore` are Promise-based by default.
  */
 export function createUseQueryReturn<TData, TVars>(
-  partial: Partial<MockUseQueryResult<TData, TVars>>
+  partial: Partial<MockUseQueryResult<TData, TVars>>,
 ): MockUseQueryResult<TData, TVars> {
   const refetch =
     partial.refetch ?? vi.fn().mockResolvedValue({ data: partial.data });
@@ -95,7 +95,11 @@ export function createTestApolloClient() {
 export function renderHookWithApollo<T>(callback: () => T) {
   const client = createTestApolloClient();
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(ApolloProvider as any, { client }, children);
+    React.createElement(
+      ApolloProvider as unknown as React.ComponentType<Record<string, unknown>>,
+      { client },
+      children,
+    );
 
   return renderHook(callback, { wrapper: Wrapper });
 }

--- a/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/useInfiniteScrollQuery.test.ts
+++ b/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/useInfiniteScrollQuery.test.ts
@@ -12,7 +12,9 @@ import { useInfiniteScrollQuery } from './useInfiniteScrollQuery';
 
 // Mock useQuery
 vi.mock('@apollo/client/react', async () => {
-  const actual = await vi.importActual<any>('@apollo/client/react');
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '@apollo/client/react',
+  );
   return {
     ...actual,
     useQuery: vi.fn(),
@@ -44,7 +46,7 @@ vi.mock('../../cacheStore/utils/getQueryPolicyConfigFromCache', () => {
       }
 
       throw new Error(
-        `[test] no queryPolicyConfig mock for Query.${fieldName}`
+        `[test] no queryPolicyConfig mock for Query.${fieldName}`,
       );
     },
   };
@@ -83,7 +85,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
           pagination: { offset: 0, limit: 25 },
         },
         networkStatus: NetworkStatus.ready,
-      })
+      }),
     );
 
     renderHookWithApollo(() =>
@@ -95,7 +97,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
           pagination: { offset: 0, limit: 25 },
         },
         pageSize: 25,
-      })
+      }),
     );
 
     expect(useQuery).toHaveBeenCalledWith(
@@ -105,7 +107,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
           filters: { q: 'hello' },
           pagination: { offset: 0, limit: 25 },
         },
-      })
+      }),
     );
   });
 
@@ -120,7 +122,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         variables: { pagination: { offset: 0, limit: 3 } },
         fetchMore,
         networkStatus: NetworkStatus.ready,
-      })
+      }),
     );
 
     const { result } = renderHookWithApollo(() =>
@@ -129,7 +131,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         queryFieldName: 'tasks',
         variables: { pagination: { offset: 0, limit: 3 } },
         pageSize: 3,
-      })
+      }),
     );
 
     await act(async () => {
@@ -147,7 +149,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         data: { tasks: { results: [{ id: 1 }], totalCount: 2 } },
         variables: { pagination: { offset: 0, limit: 1 } },
         networkStatus: NetworkStatus.ready,
-      })
+      }),
     );
 
     const { result } = renderHookWithApollo(() =>
@@ -156,7 +158,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         queryFieldName: 'tasks',
         variables: { pagination: { offset: 0, limit: 1 } },
         pageSize: 1,
-      })
+      }),
     );
 
     expect(result.current.items).toEqual([{ id: 1 }]);
@@ -173,7 +175,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         variables: { pagination: { page: 1, perPage: 2 } },
         fetchMore,
         networkStatus: NetworkStatus.ready,
-      })
+      }),
     );
 
     const { result } = renderHookWithApollo(() =>
@@ -181,7 +183,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         document: RecordsDocument,
         queryFieldName: 'records',
         variables: { pagination: { page: 1, perPage: 2 } },
-      })
+      }),
     );
 
     await act(async () => {
@@ -199,7 +201,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         data: { tasks: { results: [{ id: 1 }], totalCount: 10 } },
         variables: { pagination: { offset: 0, limit: 1 } },
         networkStatus: NetworkStatus.fetchMore,
-      })
+      }),
     );
 
     const { result } = renderHookWithApollo(() =>
@@ -208,7 +210,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
         queryFieldName: 'tasks',
         variables: { pagination: { offset: 0, limit: 1 } },
         pageSize: 1,
-      })
+      }),
     );
 
     expect(result.current.loadingMore).toBe(true);
@@ -223,7 +225,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
           pagination: { offset: 0, limit: 1 },
         },
         networkStatus: NetworkStatus.setVariables,
-      })
+      }),
     );
 
     const { result } = renderHookWithApollo(() =>
@@ -235,7 +237,7 @@ describe('useInfiniteScrollQuery (Apollo v4)', () => {
           pagination: { offset: 0, limit: 1 },
         },
         pageSize: 1,
-      })
+      }),
     );
 
     expect(result.current.loading).toBe(true);

--- a/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/useInfiniteScrollQuery.ts
+++ b/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/useInfiniteScrollQuery.ts
@@ -107,7 +107,7 @@ import { assertValueAtPath } from './utils/assertValueAtPath';
 
 type TProps<
   TData extends Record<string, unknown>,
-  TVars extends OperationVariables
+  TVars extends OperationVariables,
 > = {
   document: TypedDocumentNode<TData, TVars>;
   queryFieldName: Extract<keyof TData, string>;
@@ -120,7 +120,7 @@ type TProps<
 export function useInfiniteScrollQuery<
   TItem,
   TData extends Record<string, unknown>,
-  TVars extends OperationVariables = OperationVariables
+  TVars extends OperationVariables = OperationVariables,
 >(props: TProps<TData, TVars>) {
   const {
     document,
@@ -139,19 +139,19 @@ export function useInfiniteScrollQuery<
 
   // Deep-memoize incoming variables to avoid unnecessary refetches
   const memoizedVariables = useDeepCompareMemoize(
-    (variables ?? {}) as TVars
+    (variables ?? {}) as TVars,
   ) as TVars;
 
   // Retrieve the QueryPolicyConfig from the actual cache
   const queryPolicyConfig = useMemo(() => {
     const cfg = getQueryPolicyConfigFromCache(
       apolloClient.cache,
-      queryFieldName
+      queryFieldName,
     );
 
     if (!cfg) {
       throw new Error(
-        `[useInfiniteScrollQuery] No queryPolicyConfig found for Query.${queryFieldName}. Ensure this field is registered via getQueryPolicyFactory and attached to the cache.`
+        `[useInfiniteScrollQuery] No queryPolicyConfig found for Query.${queryFieldName}. Ensure this field is registered via getQueryPolicyFactory and attached to the cache.`,
       );
     }
 
@@ -186,7 +186,7 @@ export function useInfiniteScrollQuery<
   // Validate structure in DEV env
   if (data) {
     assertValueAtPath({
-      source: (data as any)[queryFieldName],
+      source: (data as Record<string, unknown>)[queryFieldName],
       path: queryPolicyConfig.itemsPath,
       shouldThrow: isDevEnv,
     });

--- a/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/utils/buildInitialVariables.ts
+++ b/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/utils/buildInitialVariables.ts
@@ -20,7 +20,7 @@ type TProps<TVars> = {
 };
 
 export function buildInitialVariables<TVars extends OperationVariables>(
-  args: TProps<TVars>
+  args: TProps<TVars>,
 ): TVars {
   const {
     baseVariables,
@@ -33,7 +33,9 @@ export function buildInitialVariables<TVars extends OperationVariables>(
   } = args;
 
   // clone incoming vars
-  const variables: any = baseVariables ? { ...baseVariables } : {};
+  const variables: Record<string, unknown> = baseVariables
+    ? { ...baseVariables }
+    : {};
 
   // page/perPage shape
   if (paginationMode === PaginationModeEnum.PerPage) {
@@ -54,7 +56,7 @@ export function buildInitialVariables<TVars extends OperationVariables>(
     writeAtPath(variables, paginationPagePath, pageToUse);
     writeAtPath(variables, paginationPerPagePath, perPageToUse);
 
-    return variables;
+    return variables as TVars;
   }
 
   // offset/limit (default)
@@ -75,5 +77,5 @@ export function buildInitialVariables<TVars extends OperationVariables>(
   writeAtPath(variables, paginationOffsetPath, offsetToUse);
   writeAtPath(variables, paginationLimitPath, limitToUse);
 
-  return variables;
+  return variables as TVars;
 }

--- a/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/utils/buildVariablesForPage.ts
+++ b/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/utils/buildVariablesForPage.ts
@@ -23,11 +23,13 @@ type TNextPagePerPage<TVars> = {
 type TNextPageProps<TVars> = TNextPageOffset<TVars> | TNextPagePerPage<TVars>;
 
 export function buildVariablesForPage<TVars extends OperationVariables>(
-  args: TNextPageProps<TVars>
+  args: TNextPageProps<TVars>,
 ): TVars {
   const { previousVariables, paginationMode, incrementBy } = args;
 
-  const nextVars: any = previousVariables ? { ...previousVariables } : {};
+  const nextVars: Record<string, unknown> = previousVariables
+    ? { ...previousVariables }
+    : {};
 
   // offset/limit
   if (paginationMode === PaginationModeEnum.Offset) {

--- a/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/utils/extractItemsAndTotalFromData.ts
+++ b/libs/apollo/src/lib/queryHooks/useInfiniteScrollQuery/utils/extractItemsAndTotalFromData.ts
@@ -21,7 +21,7 @@ export function extractItemsAndTotalFromData<TData, TItem>(args: {
     totalCountPath = [DEFAULT_QUERY_TOTAL_COUNT_KEY],
   } = args;
 
-  const field = (data as any)?.[queryFieldName];
+  const field = (data as Record<string, unknown>)?.[queryFieldName];
 
   if (!field) {
     return { items: undefined, total: 0 };

--- a/libs/apollo/src/lib/utils/deepCloneWeak.ts
+++ b/libs/apollo/src/lib/utils/deepCloneWeak.ts
@@ -70,7 +70,7 @@
 
 export function deepCloneWeak<T extends object>(
   input: T,
-  cloneMap = new WeakMap<object, object>()
+  cloneMap = new WeakMap<object, object>(),
 ): T {
   // Handle primitives and null/undefined
   if (input === null || typeof input !== 'object') {
@@ -93,7 +93,7 @@ export function deepCloneWeak<T extends object>(
   for (const key of Object.keys(input) as (keyof T)[]) {
     const value = input[key];
 
-    (clone as any)[key] =
+    (clone as Record<PropertyKey, unknown>)[key] =
       typeof value === 'object' && value !== null
         ? deepCloneWeak(value as object, cloneMap)
         : value;

--- a/libs/expo/betterangels/src/lib/apollo/cachePolicies/cachePolicyRegistry.ts
+++ b/libs/expo/betterangels/src/lib/apollo/cachePolicies/cachePolicyRegistry.ts
@@ -83,7 +83,7 @@ const policyFactoryList = [
 ] as const;
 
 export function createBaApolloCachePolicyRegistry(
-  isDevEnv: boolean
+  isDevEnv: boolean,
 ): TCachePolicyConfig {
   return assemblePolicyRegistry(policyFactoryList, {
     isDevEnv: isDevEnv,

--- a/libs/react/shelter/src/lib/apollo/cachePolicies/cachePolicyRegistry.ts
+++ b/libs/react/shelter/src/lib/apollo/cachePolicies/cachePolicyRegistry.ts
@@ -25,7 +25,7 @@ const policyFactoryList = [
  * {@code filters} and {@code ordering}.
  */
 export function createShelterApolloCachePolicyRegistry(
-  isDevEnv: boolean
+  isDevEnv: boolean,
 ): TCachePolicyConfig {
   return assemblePolicyRegistry(policyFactoryList, {
     isDevEnv: isDevEnv,


### PR DESCRIPTION
### fix lint warnings in apollo lib
DEV-2472

- fixes mostly `@typescript-eslint/no-explicit-any` warnings in `libs/apollo/`
  - + couple others


## Summary by Sourcery

Tighten TypeScript typings and test utilities across the Apollo cache/query utilities and hooks to resolve lint warnings while preserving existing behaviour.

Enhancements:
- Introduce a shared TMergedPayload type and stricter, typed utilities for merge function tests to replace loose any usage.
- Refine mocked helper implementations and test utilities with explicit, narrow TypeScript types in cache policy and query hook tests.
- Improve generic typing and object casting in cache policy helpers, pagination variable builders, deep cloning, and query policy config accessors to reduce unsafe casts and lint noise.

Tests:
- Adjust Vitest mocks and expectations in Apollo cache policy and useInfiniteScrollQuery tests to comply with stricter typings without changing test intent.