### PR TITLE
fix eslint warnings in expo lib (DEV-2472)

### DIFF
--- a/apps/betterangels/src/app/(private-screens)/welcome.tsx
+++ b/apps/betterangels/src/app/(private-screens)/welcome.tsx
@@ -14,6 +14,7 @@ export default function Welcome() {
   const { signOut } = useSignOut();
   return (
     <View style={styles.container}>
+      {/* eslint-disable-next-line react/style-prop-object -- Expo StatusBar style accepts string */}
       <StatusBar style="dark" />
       <View
         style={{ flex: 1, justifyContent: 'space-between', paddingBottom: 60 }}

--- a/apps/betterangels/src/app/auth.tsx
+++ b/apps/betterangels/src/app/auth.tsx
@@ -29,7 +29,7 @@ export default function Auth() {
   useEffect(() => {
     setUser(undefined);
     CookieManager.clearAll();
-  }, []);
+  }, [setUser]);
 
   return (
     <AuthContainer header={<Logo width={216} height={33} />}>

--- a/libs/expo/shared/ui-components/src/lib/Accordion/Accordion.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeftIcon } from '@monorepo/expo/shared/icons';
 import { Colors, Spacings } from '@monorepo/expo/shared/static';
-import { ReactNode, RefObject, useEffect, useState } from 'react';
+import { ReactNode, RefObject, useCallback, useEffect, useState } from 'react';
 import {
   Keyboard,
   Pressable,
@@ -54,7 +54,7 @@ export function Accordion(props: IAccordionProps) {
   } = props;
   const [place, setPlace] = useState<null | number>(null);
 
-  const scrollToElement = () => {
+  const scrollToElement = useCallback(() => {
     if (!place || !scrollRef) return;
 
     scrollRef.current?.scrollTo({
@@ -62,12 +62,12 @@ export function Accordion(props: IAccordionProps) {
       y: place,
       animated: true,
     });
-  };
+  }, [place, scrollRef]);
 
   useEffect(() => {
     if (!place) return;
     scrollToElement();
-  }, [place]);
+  }, [place, scrollToElement]);
 
   return (
     <View

--- a/libs/expo/shared/ui-components/src/lib/BottomSheet/hooks/useBottomSheetKeyboardIntegration.ts
+++ b/libs/expo/shared/ui-components/src/lib/BottomSheet/hooks/useBottomSheetKeyboardIntegration.ts
@@ -23,7 +23,7 @@ type FocusEvent = {
 };
 
 export function useBottomSheetKeyboardIntegration<T extends TNativeHandle>(
-  ref: RefObject<T>
+  ref: RefObject<T>,
 ) {
   const { animatedKeyboardState, textInputNodesRef } = useBottomSheetInternal();
 
@@ -36,7 +36,7 @@ export function useBottomSheetKeyboardIntegration<T extends TNativeHandle>(
         };
       });
     },
-    [animatedKeyboardState]
+    [animatedKeyboardState],
   );
 
   const handleOnBlur = useCallback(() => {
@@ -76,8 +76,10 @@ export function useBottomSheetKeyboardIntegration<T extends TNativeHandle>(
 
     textInputNodesRef.current.add(nodeHandle);
 
+    const nodesRef = textInputNodesRef.current;
+
     return () => {
-      textInputNodesRef.current.delete(nodeHandle);
+      nodesRef.delete(nodeHandle);
     };
   }, [ref, textInputNodesRef]);
 

--- a/libs/expo/shared/ui-components/src/lib/Date/parseToDate.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Date/parseToDate.tsx
@@ -16,13 +16,13 @@ export function parseToDate(props: TProps): Date | null {
     const parsed = parse(date, inputFormat, new Date());
 
     if (!isValid(parsed)) {
-      throw '';
+      throw new Error('Invalid date');
     }
 
     return parsed;
   } catch {
     console.error(
-      `[parseToDate]: failed to parse date: [${date}] with inputFormat [${inputFormat}]`
+      `[parseToDate]: failed to parse date: [${date}] with inputFormat [${inputFormat}]`,
     );
 
     return null;

--- a/libs/expo/shared/ui-components/src/lib/FieldCard/FieldCard.tsx
+++ b/libs/expo/shared/ui-components/src/lib/FieldCard/FieldCard.tsx
@@ -1,5 +1,5 @@
 import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
-import { ReactNode, RefObject, useEffect, useState } from 'react';
+import { ReactNode, RefObject, useCallback, useEffect, useState } from 'react';
 import {
   DimensionValue,
   Pressable,
@@ -54,7 +54,7 @@ export function FieldCard(props: IFieldCardProps) {
   } = props;
   const [place, setPlace] = useState<null | number>(null);
 
-  const scrollToElement = () => {
+  const scrollToElement = useCallback(() => {
     if (!place || !scrollRef) return;
 
     scrollRef.current?.scrollTo({
@@ -62,12 +62,12 @@ export function FieldCard(props: IFieldCardProps) {
       y: place,
       animated: true,
     });
-  };
+  }, [place, scrollRef]);
 
   useEffect(() => {
     if (!place) return;
     scrollToElement();
-  }, [place]);
+  }, [place, scrollToElement]);
 
   return (
     <Pressable

--- a/libs/expo/shared/ui-components/src/lib/InfiniteList/types.ts
+++ b/libs/expo/shared/ui-components/src/lib/InfiniteList/types.ts
@@ -30,11 +30,11 @@ type InfiniteListBaseProps<T> = {
   renderResultsHeader?: TRenderListResultsHeader | null;
   loadingViewOptions?: TLoadingListView;
   showScrollIndicator?: boolean;
-  ItemSeparatorComponent?: ComponentType<any> | null;
+  ItemSeparatorComponent?: ComponentType<unknown> | null;
   error?: boolean; // determines whether to show ErrorView
   errorTitle?: string;
   errorMessage?: string;
-  ErrorViewComponent?: ComponentType<any> | ReactElement | null;
+  ErrorViewComponent?: ComponentType<unknown> | ReactElement | null;
 };
 
 export type TInfiniteListProps<T> = InfiniteListBaseProps<T> &

--- a/libs/expo/shared/ui-components/src/lib/LengthInput/LengthInput.tsx
+++ b/libs/expo/shared/ui-components/src/lib/LengthInput/LengthInput.tsx
@@ -24,7 +24,9 @@ export function LengthInput(props: LengthInputProps) {
   const [internalValue, setInternalValue] =
     useState<TFeetInchesValue>(EMPTY_VALUE);
 
-  const currentValue = isControlled ? value! : internalValue;
+  const currentValue = isControlled
+    ? (value as TFeetInchesValue)
+    : internalValue;
 
   function normalizeInches(next: TFeetInchesValue): TFeetInchesValue {
     const inchesText = next.inches.trim();

--- a/libs/expo/shared/ui-components/src/lib/Map/clusters/hooks/useClusters.ts
+++ b/libs/expo/shared/ui-components/src/lib/Map/clusters/hooks/useClusters.ts
@@ -71,10 +71,13 @@ export function useClusters<P extends IClusterGeoJson>(props: TProps<P>) {
 
       updateClusters();
     },
-    [updateClusters]
+    [updateClusters],
   );
 
   // Load features whenever pointFeaturesHash changes
+  // pointFeaturesHash captures meaningful content changes;
+  // pointFeatures itself is intentionally omitted to avoid
+  // re-running on reference-only changes.
   useEffect(() => {
     if (!pointFeatures.length) {
       return;
@@ -84,12 +87,13 @@ export function useClusters<P extends IClusterGeoJson>(props: TProps<P>) {
 
     // refresh clusters on map
     updateClusters();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pointFeaturesHash, clusterManager, updateClusters]);
 
   const zoomToCluster = useCallback(
     (c: TClusterPoint, mapRef: RefObject<TMapView | null>) =>
       clusterManager.fitToCluster(c.properties.cluster_id, mapRef),
-    [clusterManager]
+    [clusterManager],
   );
 
   // cleanup

--- a/libs/expo/shared/ui-components/src/lib/Map/clusters/hooks/useMapClusterManager.ts
+++ b/libs/expo/shared/ui-components/src/lib/Map/clusters/hooks/useMapClusterManager.ts
@@ -3,7 +3,7 @@ import { IMapClusterManager, MapClusterManager } from '../MapClusterManager';
 import { IClusterGeoJson } from '../types';
 
 export function useMapClusterManager<P extends IClusterGeoJson>(
-  options: IMapClusterManager = {}
+  options: IMapClusterManager = {},
 ) {
   // Unpack primitive fields so the dependency list tracks individual values
   // and not the `options` object reference. So the manager is rebuilt only when
@@ -11,10 +11,13 @@ export function useMapClusterManager<P extends IClusterGeoJson>(
   const { radius, maxZoom, extent, nodeSize, edgePadding, map, reduce } =
     options;
 
-  const memoizedEdgePadding = useMemo(
-    () => edgePadding,
-    [edgePadding ? JSON.stringify(edgePadding) : undefined]
-  );
+  // Use JSON.stringify as a stable comparison key for edgePadding,
+  // so the cluster manager is rebuilt only when the padding values actually
+  // change — not on every reference change of the options object.
+  const edgePaddingKey = edgePadding ? JSON.stringify(edgePadding) : undefined;
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const memoizedEdgePadding = useMemo(() => edgePadding, [edgePaddingKey]);
 
   return useMemo(
     () =>
@@ -27,6 +30,6 @@ export function useMapClusterManager<P extends IClusterGeoJson>(
         map,
         reduce,
       }),
-    [radius, maxZoom, extent, nodeSize, memoizedEdgePadding, map, reduce]
+    [radius, maxZoom, extent, nodeSize, memoizedEdgePadding, map, reduce],
   );
 }

--- a/libs/expo/shared/ui-components/src/lib/MultiSelect/components/MultiSelectInfinite.tsx
+++ b/libs/expo/shared/ui-components/src/lib/MultiSelect/components/MultiSelectInfinite.tsx
@@ -84,7 +84,6 @@ export function MultiSelectInfinite<T>(props: MultiSelectInfiniteProps<T>) {
   });
 
   const renderRow = useRenderRow<T>({
-    isLocalSearch: hasLocalFilter,
     isSelectAllOption,
     allAreSelected,
     isSelected,

--- a/libs/expo/shared/ui-components/src/lib/MultiSelect/components/MultiSelectInfinite.tsx
+++ b/libs/expo/shared/ui-components/src/lib/MultiSelect/components/MultiSelectInfinite.tsx
@@ -53,7 +53,7 @@ export function MultiSelectInfinite<T>(props: MultiSelectInfiniteProps<T>) {
   // Base list: local filter layered over current options when enabled
   const baseOptions = useMemo(
     () => (withLocalFilter ? filtered : options),
-    [withLocalFilter, filtered, options]
+    [withLocalFilter, filtered, options],
   );
 
   const visibleOptions = useWithSelectAllOption<T>({
@@ -100,9 +100,9 @@ export function MultiSelectInfinite<T>(props: MultiSelectInfiniteProps<T>) {
       }
 
       // default
-      return String(item[valueKey!]);
+      return String(item[valueKey as keyof T]);
     },
-    [keyExtractor, valueKey]
+    [keyExtractor, valueKey],
   );
 
   return (
@@ -127,7 +127,7 @@ export function MultiSelectInfinite<T>(props: MultiSelectInfiniteProps<T>) {
       {hasServerSearch && (
         <SearchBar
           value={''} // UI-only; not controlling from here
-          onChange={onSearch!}
+          onChange={onSearch as NonNullable<typeof onSearch>}
           placeholder={searchPlaceholder}
           debounceMs={searchDebounceMs}
           style={{ marginBottom: DEFAULT_MARGIN_BOTTOM }}

--- a/libs/expo/shared/ui-components/src/lib/MultiSelect/components/MultiSelectStatic.tsx
+++ b/libs/expo/shared/ui-components/src/lib/MultiSelect/components/MultiSelectStatic.tsx
@@ -45,7 +45,7 @@ export function MultiSelectStatic<T>(props: MultiSelectStaticProps<T>) {
   // Base list: local filtered or options
   const baseList = useMemo(
     () => (withLocalFilter ? filtered : options),
-    [withLocalFilter, filtered, options]
+    [withLocalFilter, filtered, options],
   );
 
   const visibleOptions = useWithSelectAllOption<T>({
@@ -76,7 +76,6 @@ export function MultiSelectStatic<T>(props: MultiSelectStaticProps<T>) {
   });
 
   const renderRow = useRenderRow<T>({
-    isLocalSearch: !!withLocalFilter,
     isSelectAllOption,
     allAreSelected,
     isSelected,

--- a/libs/expo/shared/ui-components/src/lib/MultiSelect/utils/getVisibleOptions.test.ts
+++ b/libs/expo/shared/ui-components/src/lib/MultiSelect/utils/getVisibleOptions.test.ts
@@ -17,7 +17,7 @@ const baseOptions: TOption[] = [
 type TTestCase = {
   title: string;
   inputs: TGetVisibleOptions<TOption>;
-  result: any;
+  result: unknown;
 };
 
 const baseOptionsTestParams: TGetVisibleOptions<TOption> = {
@@ -103,7 +103,9 @@ describe('getVisibleOptions for MultiSelect', () => {
     it(`should handle ${testCase.title}`, () => {
       const result = getVisibleOptions(testCase.inputs);
 
-      expect(result).toEqual(expect.arrayContaining(testCase.result));
+      expect(result).toEqual(
+        expect.arrayContaining(testCase.result as readonly unknown[]),
+      );
     });
   });
 });

--- a/libs/expo/shared/ui-components/src/lib/MultiSelect/utils/useRenderRow.tsx
+++ b/libs/expo/shared/ui-components/src/lib/MultiSelect/utils/useRenderRow.tsx
@@ -14,13 +14,12 @@ type TProps<T> = {
   renderOption?: (
     item: T,
     props: TMultiSelectItem,
-    index: number
+    index: number,
   ) => React.ReactElement;
 };
 
 export function useRenderRow<T>(args: TProps<T>) {
   const {
-    isLocalSearch,
     isSelectAllOption,
     allAreSelected,
     isSelected,
@@ -55,13 +54,12 @@ export function useRenderRow<T>(args: TProps<T>) {
       );
     },
     [
-      isLocalSearch,
       isSelectAllOption,
       allAreSelected,
       isSelected,
       getLabel,
       toggleSelected,
       renderOption,
-    ]
+    ],
   );
 }

--- a/libs/expo/shared/ui-components/src/lib/MultiSelect/utils/useRenderRow.tsx
+++ b/libs/expo/shared/ui-components/src/lib/MultiSelect/utils/useRenderRow.tsx
@@ -5,7 +5,6 @@ import {
 } from '../components/MultiSelectItem';
 
 type TProps<T> = {
-  isLocalSearch: boolean;
   isSelectAllOption: (item: T) => boolean;
   allAreSelected: () => boolean;
   isSelected: (item: T) => boolean;

--- a/libs/expo/shared/ui-components/src/lib/PhoneNumberInput/PhoneNumberInputBase.tsx
+++ b/libs/expo/shared/ui-components/src/lib/PhoneNumberInput/PhoneNumberInputBase.tsx
@@ -39,7 +39,7 @@ export function PhoneNumberInputBase(props: TPhoneNumberInputBaseProps) {
     if (prevHasValue && !newHasValue) {
       onClear?.();
     }
-  }, [localPhone, localExt]);
+  }, [localPhone, localExt, onChangeParts, onClear]);
 
   return (
     <View style={[style]}>

--- a/libs/expo/shared/ui-components/src/lib/SearchListBar/SearchListBar.tsx
+++ b/libs/expo/shared/ui-components/src/lib/SearchListBar/SearchListBar.tsx
@@ -42,8 +42,12 @@ export function SearchListBar<T>(props: TProps<T>) {
     onChangeRef.current = onChange;
   }, [onChange]);
 
+  // signature captures meaningful changes to filtered;
+  // filtered itself is intentionally omitted to avoid re-running
+  // on reference-only changes.
   useEffect(() => {
     onChangeRef.current(filtered);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signature]);
 
   return (

--- a/libs/expo/shared/ui-components/src/lib/Textarea/Textarea.tsx
+++ b/libs/expo/shared/ui-components/src/lib/Textarea/Textarea.tsx
@@ -19,7 +19,7 @@ import {
 } from 'react-native';
 
 type TValidateFn = (
-  data: unknown
+  data: unknown,
 ) => boolean | string | Promise<boolean | string>;
 
 type TRules = {
@@ -38,7 +38,7 @@ type TRules = {
 type TSpacing = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 interface ITextareaProps extends TextInputProps {
   label?: string;
-  control: Control<any>;
+  control: Control;
   name: string;
   required?: boolean;
   disabled?: boolean;


### PR DESCRIPTION
### fix lint warnings in expo lib
DEV-2472

- fix `eslint` warnings in:
  - apps/betterangels
  - lib/expo/shared

## Summary by Sourcery

Address lint warnings across Expo shared UI components and BetterAngels app screens by tightening TypeScript typings, stabilizing React hook dependencies, and adding targeted ESLint suppressions where necessary.

Enhancements:
- Stabilize memoization and effect dependencies in map clustering, accordion, field card, bottom sheet keyboard integration, search list bar, and phone input hooks/components to satisfy React hook lint rules and avoid unnecessary re-renders.
- Improve TypeScript typing across multi-select utilities, infinite list components, length input, textarea, and tests for safer and clearer usage.
- Harden date parsing by throwing a proper Error on invalid input before logging and returning null.
- Clarify cleanup logic in bottom sheet keyboard integration by capturing node references at registration time.
- Add an inline comment and ESLint suppression for the Expo StatusBar style prop in the BetterAngels welcome screen.