### PR TITLE
fix eslint warnings for expo-betterangels lib (DEV-2472)

### DIFF
--- a/libs/expo/betterangels/src/lib/apollo/cachePolicies/utils/toUrlKeyFieldValue.test.ts
+++ b/libs/expo/betterangels/src/lib/apollo/cachePolicies/utils/toUrlKeyFieldValue.test.ts
@@ -1,4 +1,5 @@
 // toUrlKeyFieldValue.test.ts
+import { StoreValue } from '@apollo/client';
 import { toUrlKeyFieldValue } from './toUrlKeyFieldValue';
 
 type TCase = {
@@ -64,6 +65,6 @@ const cases: ReadonlyArray<TCase> = [
 
 describe('toUrlKeyFieldValue (table-driven)', () => {
   test.each(cases)('$name', ({ input, expected }) => {
-    expect(toUrlKeyFieldValue(input as any)).toBe(expected);
+    expect(toUrlKeyFieldValue(input as StoreValue)).toBe(expected);
   });
 });

--- a/libs/expo/betterangels/src/lib/apollo/graphql/response/utils/hasTypename.ts
+++ b/libs/expo/betterangels/src/lib/apollo/graphql/response/utils/hasTypename.ts
@@ -1,11 +1,11 @@
 export function hasTypename<TName extends string>(
   obj: unknown,
-  typename: TName
+  typename: TName,
 ): obj is { __typename: TName } {
   return (
     !!obj &&
     typeof obj === 'object' &&
     '__typename' in obj &&
-    (obj as any).__typename === typename
+    (obj as { __typename: unknown }).__typename === typename
   );
 }

--- a/libs/expo/betterangels/src/lib/helpers/validateAsEnum.ts
+++ b/libs/expo/betterangels/src/lib/helpers/validateAsEnum.ts
@@ -1,6 +1,6 @@
 export function validateAsEnum<T extends object>(
-  value: any,
-  enumObj: T
+  value: unknown,
+  enumObj: T,
 ): value is T[keyof T] {
   return Object.values(enumObj).includes(value);
 }

--- a/libs/expo/betterangels/src/lib/hooks/interactions/useGetClientInteractionsWithLocation.ts
+++ b/libs/expo/betterangels/src/lib/hooks/interactions/useGetClientInteractionsWithLocation.ts
@@ -6,6 +6,10 @@ import {
   TNotesQueryInteraction,
 } from '../../apollo';
 
+type TInteractionWithLocation = TNotesQueryInteraction & {
+  location: NonNullable<TNotesQueryInteraction['location']>;
+};
+
 const defaultSortOrder: NoteOrder = {
   interactedAt: Ordering.Desc,
   id: Ordering.Desc,
@@ -30,11 +34,12 @@ export function useGetClientInteractionsWithLocation(props: TProps) {
     nextFetchPolicy: 'cache-first',
   });
 
-  let interactions: TNotesQueryInteraction[] | undefined = undefined;
+  let interactions: TInteractionWithLocation[] | undefined = undefined;
 
   if (data) {
-    interactions =
-      data.notes.results.filter((n) => Boolean(n.location?.point)) ?? [];
+    interactions = (data.notes.results.filter((n) =>
+      Boolean(n.location?.point),
+    ) ?? []) as TInteractionWithLocation[];
   }
 
   if (error) {

--- a/libs/expo/betterangels/src/lib/hooks/useInitialLocation.ts
+++ b/libs/expo/betterangels/src/lib/hooks/useInitialLocation.ts
@@ -15,7 +15,7 @@ const INITIAL_LOCATION = {
 export function useInitialLocation(
   editing: boolean | undefined,
   location: LocationDraft | undefined,
-  setValue?: (name: 'location', value: LocationDraft) => void
+  setValue?: (name: 'location', value: LocationDraft) => void,
 ) {
   const places = useGooglePlaces();
   const [userLocation, setUserLocation] = useState<LocationObject | null>(null);
@@ -80,7 +80,7 @@ export function useInitialLocation(
         } else {
           const geocodeResult = await places.reverseGeocode(
             INITIAL_LOCATION.latitude,
-            INITIAL_LOCATION.longitude
+            INITIAL_LOCATION.longitude,
           );
           setValueRef.current?.('location', {
             ...locationRef.current,
@@ -97,7 +97,7 @@ export function useInitialLocation(
     };
 
     void autoSetInitialLocation();
-  }, [places]);
+  }, [places, defaultLocation]);
 
   return [userLocation];
 }

--- a/libs/expo/betterangels/src/lib/providers/blockingScreen/BlockingScreenProvider.tsx
+++ b/libs/expo/betterangels/src/lib/providers/blockingScreen/BlockingScreenProvider.tsx
@@ -16,8 +16,8 @@ export default function BlockingScreenProvider(props: TBlockingScreenProvider) {
   const [visible, setVisible] = useState(false);
   const pendingUnsub = useRef<(() => void) | null>(null);
 
-  const blockScreen = () => setVisible(true);
-  const unblockScreen = () => setVisible(false);
+  const blockScreen = useCallback(() => setVisible(true), []);
+  const unblockScreen = useCallback(() => setVisible(false), []);
 
   const blockScreenUntilNextNavigation = useCallback(() => {
     if (pendingUnsub.current) {
@@ -40,7 +40,7 @@ export default function BlockingScreenProvider(props: TBlockingScreenProvider) {
       pendingUnsub.current?.();
       pendingUnsub.current = null;
     },
-    []
+    [],
   );
 
   return (

--- a/libs/expo/betterangels/src/lib/screenRouting/clientProfileRoutes/constants.ts
+++ b/libs/expo/betterangels/src/lib/screenRouting/clientProfileRoutes/constants.ts
@@ -12,7 +12,7 @@ export enum ClientProfileSectionEnum {
 }
 
 export function isValidClientProfileSectionEnum(
-  value: any
+  value: unknown,
 ): value is ClientProfileSectionEnum {
   return validateAsEnum(value, ClientProfileSectionEnum);
 }

--- a/libs/expo/betterangels/src/lib/screens/Client/ClientProfile/hooks/useDeleteClientProfile.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/ClientProfile/hooks/useDeleteClientProfile.tsx
@@ -1,3 +1,4 @@
+import type { Reference, StoreObject } from '@apollo/client';
 import { useMutation } from '@apollo/client/react';
 import { useRouter } from 'expo-router';
 import { useSnackbar } from '../../../../hooks';
@@ -14,7 +15,7 @@ export function useDeleteClientProfile(props: TProps) {
   const router = useRouter();
   const { showSnackbar } = useSnackbar();
   const [deleteClientProfile, { loading }] = useMutation(
-    DeleteClientProfileDocument
+    DeleteClientProfileDocument,
   );
 
   const deleteProfile = async (id: string) => {
@@ -37,16 +38,18 @@ export function useDeleteClientProfile(props: TProps) {
 
                 const existingResults = existing.results ?? [];
 
-                const nextResults = existingResults.filter((ref: any) => {
-                  const refId = readField('id', ref);
+                const nextResults = existingResults.filter(
+                  (ref: StoreObject | Reference) => {
+                    const refId = readField('id', ref);
 
-                  // remove any dangling refs
-                  if (refId === null || refId === undefined) {
-                    return false;
-                  }
+                    // remove any dangling refs
+                    if (refId === null || refId === undefined) {
+                      return false;
+                    }
 
-                  return refId !== id;
-                });
+                    return refId !== id;
+                  },
+                );
 
                 const nextTotal =
                   typeof existing.totalCount === 'number'
@@ -83,7 +86,7 @@ export function useDeleteClientProfile(props: TProps) {
       }
     } catch (e) {
       console.error(
-        `Error deleting Client Profile Id ${clientProfileId}: ${e}`
+        `Error deleting Client Profile Id ${clientProfileId}: ${e}`,
       );
 
       showSnackbar({

--- a/libs/expo/betterangels/src/lib/screens/Client/Locations/map/hooks/useInteractionPointFeatures.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/Locations/map/hooks/useInteractionPointFeatures.ts
@@ -10,7 +10,7 @@ export function useInteractionPointFeatures(clientProfileId: string) {
     {
       id: clientProfileId,
       ordering: [{ interactedAt: Ordering.Desc }, { id: Ordering.Desc }],
-    }
+    },
   );
 
   const pointFeatures = useMemo<PointFeature<TClusterInteraction>[]>(() => {
@@ -21,12 +21,12 @@ export function useInteractionPointFeatures(clientProfileId: string) {
     return interactions.map((i, index) =>
       toPointFeature({
         id: String(i.id),
-        latitude: i.location!.point[1],
-        longitude: i.location!.point[0],
+        latitude: i.location.point[1],
+        longitude: i.location.point[0],
         interactedAt: new Date(i.interactedAt),
         // mostRecent prop is dependent on interactions NotesQuery sort order
         mostRecent: index === 0,
-      })
+      }),
     );
   }, [interactions]);
 

--- a/libs/expo/betterangels/src/lib/screens/Client/Locations/map/hooks/useInteractionsMapRegion.ts
+++ b/libs/expo/betterangels/src/lib/screens/Client/Locations/map/hooks/useInteractionsMapRegion.ts
@@ -23,6 +23,10 @@ export function useInteractionsMapRegion({ interaction, delta }: TProps) {
     ? `${latitude},${longitude},${latitudeDelta},${longitudeDelta}`
     : null;
 
+  const deltaKey = delta
+    ? `${delta.latitudeDelta},${delta.longitudeDelta}`
+    : null;
+
   return useMemo(() => {
     if (!interaction) {
       return null;
@@ -47,5 +51,8 @@ export function useInteractionsMapRegion({ interaction, delta }: TProps) {
       longitude,
       ...latLngDeltas,
     });
-  }, [regionKey, interaction?.id]);
+    // interaction?.id, regionKey, and deltaKey are stable keys that avoid
+    // recomputation on reference-only changes of the raw objects.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [regionKey, deltaKey, interaction?.id]);
 }

--- a/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Client/Tasks/TasksTab.tsx
@@ -55,7 +55,7 @@ export function TasksTab(props: TProps) {
 
   const [filtersKey, setFiltersKey] = useState(0); // used to trigger remount
   const [currentFilters, setCurrentFilters] = useState<TModelFilters>(
-    getInitialTaskFilters()
+    getInitialTaskFilters(),
   );
 
   function onFilterChange(selectedFilters: TModelFilters) {
@@ -102,21 +102,24 @@ export function TasksTab(props: TProps) {
   };
 
   const currentPath = client
-    ? `/client/${client?.clientProfile.id}?newTab=Tasks`
+    ? `/client/${client.clientProfile.id}?newTab=Tasks`
     : undefined;
 
-  const handleTaskPress = useCallback((task: TaskType) => {
-    router.navigate({
-      pathname: `/task/${task.id}`,
-      params: { arrivedFrom: currentPath },
-    });
-  }, []);
+  const handleTaskPress = useCallback(
+    (task: TaskType) => {
+      router.navigate({
+        pathname: `/task/${task.id}`,
+        params: { arrivedFrom: currentPath },
+      });
+    },
+    [currentPath],
+  );
 
   const renderTaskItem = useCallback(
     (task: TaskType) => (
       <TaskCard task={task} onPress={handleTaskPress} variant="withoutClient" />
     ),
-    [handleTaskPress]
+    [handleTaskPress],
   );
 
   function renderListHeaderText(visible: number, total: number | undefined) {

--- a/libs/expo/betterangels/src/lib/screens/ClientEditHmis/basicForms/DemographicInfo/DemographicInfoFormHmis.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientEditHmis/basicForms/DemographicInfo/DemographicInfoFormHmis.tsx
@@ -43,6 +43,7 @@ export function DemographicInfoFormHmis() {
   return (
     <Form>
       <Form.Field title="Gender">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <MultiSelect_V2
           options={Object.entries(enumGenderHmis).map(([key, value]) => ({
             id: key as HmisGenderEnum,
@@ -95,6 +96,7 @@ export function DemographicInfoFormHmis() {
       </Form.Field>
 
       <Form.Field title="Race and Ethnicity">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <MultiSelect_V2
           options={Object.entries(enumRaceHmis).map(([key, value]) => ({
             id: key as HmisRaceEnum,
@@ -123,7 +125,7 @@ export function DemographicInfoFormHmis() {
           onDelete={() => {
             setValue(
               'additionalRaceEthnicityDetail',
-              emptyState.additionalRaceEthnicityDetail
+              emptyState.additionalRaceEthnicityDetail,
             );
           }}
           errorMessage={errors.additionalRaceEthnicityDetail?.message}
@@ -141,7 +143,7 @@ export function DemographicInfoFormHmis() {
               placeholder="Select pronouns"
               maxRadioItems={0}
               items={Object.entries(enumDisplayPronoun).map(
-                ([val, displayValue]) => ({ value: val, displayValue })
+                ([val, displayValue]) => ({ value: val, displayValue }),
               )}
               selectedValue={value}
               onChange={(value) => onChange(value || '')}
@@ -188,7 +190,7 @@ export function DemographicInfoFormHmis() {
               disabled={isSubmitting}
               placeholder="Select eye color"
               items={Object.entries(enumDisplayEyeColor).map(
-                ([val, displayValue]) => ({ value: val, displayValue })
+                ([val, displayValue]) => ({ value: val, displayValue }),
               )}
               selectedValue={value}
               onChange={(value) =>
@@ -210,7 +212,7 @@ export function DemographicInfoFormHmis() {
               disabled={isSubmitting}
               placeholder="Select hair color"
               items={Object.entries(enumDisplayHairColor).map(
-                ([val, displayValue]) => ({ value: val, displayValue })
+                ([val, displayValue]) => ({ value: val, displayValue }),
               )}
               selectedValue={value}
               onChange={(value) =>
@@ -232,7 +234,7 @@ export function DemographicInfoFormHmis() {
               disabled={isSubmitting}
               placeholder="Select marital status"
               items={Object.entries(enumDisplayMaritalStatus).map(
-                ([val, displayValue]) => ({ value: val, displayValue })
+                ([val, displayValue]) => ({ value: val, displayValue }),
               )}
               selectedValue={value}
               onChange={(value) =>
@@ -253,7 +255,7 @@ export function DemographicInfoFormHmis() {
           onDelete={() =>
             setValue(
               'physicalDescription',
-              demographicInfoFormEmptyState.physicalDescription
+              demographicInfoFormEmptyState.physicalDescription,
             )
           }
           error={!!errors.physicalDescription}
@@ -262,12 +264,13 @@ export function DemographicInfoFormHmis() {
       </Form.Field>
 
       <Form.Field title="ADA Accommodation">
+        {/* eslint-disable-next-line react/jsx-pascal-case */}
         <MultiSelect_V2
           options={Object.entries(enumDisplayAdaAccommodationEnum).map(
             ([key, value]) => ({
               id: key as AdaAccommodationEnum,
               label: value,
-            })
+            }),
           )}
           selected={adaAccommodationValues.map((val) => ({
             id: val,

--- a/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientInteractionsViewHmis/ClientInteractionsViewHmis.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientInteractionsViewHmis/ClientInteractionsViewHmis.tsx
@@ -16,20 +16,22 @@ type TProps = { client?: HmisClientProfileType };
 export function ClientInteractionsViewHmis(props: TProps) {
   const { client } = props;
 
+  const clientId = client?.id;
+
   const renderItemFn = useCallback(
     (item: HmisNoteType) => (
       <NoteCardHmis
         onPress={() => {
           router.navigate({
             pathname: `/notes-hmis/${item.id}`,
-            params: { clientId: client?.id },
+            params: { clientId },
           });
         }}
         variant="clientProfile"
         hmisNote={item}
       />
     ),
-    []
+    [clientId],
   );
 
   const renderHeader = useCallback(
@@ -55,7 +57,7 @@ export function ClientInteractionsViewHmis(props: TProps) {
             accessibilityLabel="create an interaction"
             accessibilityHint="create new interaction"
             onPress={() => {
-              router.navigate(`/notes-hmis/create?clientId=${client!.id}`);
+              router.navigate(`/notes-hmis/create?clientId=${clientId}`);
             }}
           >
             <PlusIcon />
@@ -63,7 +65,7 @@ export function ClientInteractionsViewHmis(props: TProps) {
         </View>
       );
     },
-    [client!.id]
+    [clientId],
   );
 
   if (!client) {

--- a/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientLocationsViewHmis/map/hooks/useInteractionPointFeatures.ts
+++ b/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientLocationsViewHmis/map/hooks/useInteractionPointFeatures.ts
@@ -21,12 +21,15 @@ export function useInteractionPointFeatures(clientProfileId: string) {
     return interactions.map((i, index) =>
       toPointFeature({
         id: String(i.id),
+        // useGetClientInteractionsWithLocationHmis filters for location.point
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         latitude: i.location!.point[1],
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         longitude: i.location!.point[0],
         interactedAt: new Date(i.date),
         // mostRecent prop is dependent on interactions NotesQuery sort order
         mostRecent: index === 0,
-      })
+      }),
     );
   }, [interactions]);
 

--- a/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientLocationsViewHmis/map/hooks/useInteractionsMapRegion.ts
+++ b/libs/expo/betterangels/src/lib/screens/ClientHmis/tabs/ClientLocationsViewHmis/map/hooks/useInteractionsMapRegion.ts
@@ -23,6 +23,10 @@ export function useInteractionsMapRegion({ interaction, delta }: TProps) {
     ? `${latitude},${longitude},${latitudeDelta},${longitudeDelta}`
     : null;
 
+  const deltaKey = delta
+    ? `${delta.latitudeDelta},${delta.longitudeDelta}`
+    : null;
+
   return useMemo(() => {
     if (!interaction) {
       return null;
@@ -47,5 +51,8 @@ export function useInteractionsMapRegion({ interaction, delta }: TProps) {
       longitude,
       ...latLngDeltas,
     });
-  }, [regionKey, interaction?.id]);
+    // regionKey, interaction?.id, and deltaKey are stable keys that avoid
+    // recomputation on reference-only changes of the raw objects.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [regionKey, interaction?.id, deltaKey]);
 }

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms/ClientProfileForm/ClientProfileForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms/ClientProfileForm/ClientProfileForm.tsx
@@ -32,7 +32,7 @@ export default function ClientProfileForm(props: IClientProfileForms) {
   });
 
   const [updateClientProfile, { loading: isUpdating }] = useMutation(
-    UpdateClientProfileDocument
+    UpdateClientProfileDocument,
   );
 
   const methods = useForm<FormValues>({
@@ -68,7 +68,7 @@ export default function ClientProfileForm(props: IClientProfileForms) {
       const inputs = toUpdateClienProfileInputs(
         id,
         values,
-        methods.formState.dirtyFields
+        methods.formState.dirtyFields,
       );
 
       if (!inputs) {
@@ -131,11 +131,11 @@ export default function ClientProfileForm(props: IClientProfileForms) {
 
     const formData = extractClientFormData(
       validComponentName,
-      fetchProfileData.clientProfile
+      fetchProfileData.clientProfile,
     );
 
     methods.reset(formData);
-  }, [fetchProfileData, id]);
+  }, [fetchProfileData, id, methods, validComponentName]);
 
   if (isFetchingProfile) {
     return <LoadingView />;
@@ -173,7 +173,7 @@ function toDateOnlyString(date: Date): string {
 function toUpdateClienProfileInputs(
   id: string,
   values: FormValues,
-  dirtyFields?: Partial<Record<keyof FormValues, boolean>>
+  dirtyFields?: Partial<Record<keyof FormValues, boolean>>,
 ): UpdateClientProfileInput | null {
   if (!values || !id) {
     return null;
@@ -198,7 +198,7 @@ function toUpdateClienProfileInputs(
   ) {
     if (values.unhousedStartDate instanceof Date) {
       updatedInputs.unhousedStartDate = toDateOnlyString(
-        values.unhousedStartDate
+        values.unhousedStartDate,
       );
     } else if (values.unhousedStartDate === null) {
       updatedInputs.unhousedStartDate = null;

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/ClientProfileRelatedModelForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/ClientProfileRelatedModelForm.tsx
@@ -49,7 +49,7 @@ export function ClientProfileRelatedModelForm(props: TProps) {
       : `Edit ${titleSingular}`;
 
     navigation.setOptions({ title: navTitle });
-  }, [navigation, clientProfile, section]);
+  }, [navigation, clientProfile, section, createMode, titleSingular]);
 
   if (loading) {
     return <LoadingView />;

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/ClientProfileRelatedModelList.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/ClientProfileRelatedModelList.tsx
@@ -45,7 +45,7 @@ export function ClientProfileRelatedModelList(props: TProps) {
 
   useLayoutEffect(() => {
     navigation.setOptions({ title: `${titlePlural}` });
-  }, [navigation, clientProfile]);
+  }, [navigation, clientProfile, titlePlural]);
 
   if (loading) {
     return <LoadingView />;

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/forms/ClientContactsForm/useClientContactForm.ts
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/forms/ClientContactsForm/useClientContactForm.ts
@@ -55,7 +55,7 @@ export function useClientContactForm(props: TProps) {
     setValue('phoneNumber', phoneNumber);
     setValue('mailingAddress', mailingAddress);
     setValue('relationshipToClient', relationshipToClient);
-  }, [clientProfile, relationId, setValue, toFormState]);
+  }, [clientProfile, relationId, setValue]);
 
   const [email, phoneNumber, mailingAddress, relationshipToClient] = useWatch({
     control,
@@ -108,7 +108,7 @@ export function useClientContactForm(props: TProps) {
       const errorsApplied = applyValidationErrors(
         response,
         mutationKey,
-        setError
+        setError,
       );
 
       if (errorsApplied) {
@@ -125,7 +125,7 @@ export function useClientContactForm(props: TProps) {
         getViewClientProfileRoute({
           id: clientProfileId,
           openCard: ClientProfileSectionEnum.RelevantContacts,
-        })
+        }),
       );
 
       return true;
@@ -161,7 +161,7 @@ export function useClientContactForm(props: TProps) {
 function isSuccessMutationResponse(
   response: ApolloClient.MutateResult<
     UpdateClientContactMutation | CreateClientContactMutation
-  >
+  >,
 ): boolean {
   const responseData = response.data;
 
@@ -195,7 +195,7 @@ function applyValidationErrors(
     CreateClientContactMutation | UpdateClientContactMutation
   >,
   key: 'updateClientContact' | 'createClientContact',
-  setError: UseFormSetError<TClientContactFormState>
+  setError: UseFormSetError<TClientContactFormState>,
 ): boolean {
   let hasErrors = false;
 

--- a/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/forms/HmisProfileForm/HmisProfileForm.tsx
+++ b/libs/expo/betterangels/src/lib/screens/ClientProfileForms/relatedClientProfileModel/forms/HmisProfileForm/HmisProfileForm.tsx
@@ -75,9 +75,7 @@ export function HmisProfileForm(props: TProps) {
 
   const isEditMode = !!relationId;
 
-  const onSubmit: SubmitHandler<THmisProfileFormState> = async (
-    formState: any
-  ) => {
+  const onSubmit: SubmitHandler<THmisProfileFormState> = async (formState) => {
     if (!formIsValid) {
       return;
     }
@@ -196,7 +194,7 @@ export function HmisProfileForm(props: TProps) {
                 label="Type of HMIS ID"
                 placeholder="Select type of HMIS ID"
                 items={Object.entries(enumDisplayHmisAgency).map(
-                  ([value, displayValue]) => ({ value, displayValue })
+                  ([value, displayValue]) => ({ value, displayValue }),
                 )}
                 selectedValue={field.value}
                 onChange={(value) => field.onChange(value)}
@@ -237,7 +235,7 @@ export function HmisProfileForm(props: TProps) {
 }
 
 function isSuccessMutationResponse(
-  responseData: UpdateHmisProfileMutation | CreateHmisProfileMutation
+  responseData: UpdateHmisProfileMutation | CreateHmisProfileMutation,
 ): boolean {
   const modelTypename = 'HmisProfileType';
 
@@ -264,7 +262,7 @@ function hasUniquenessError(
   response: ApolloLink.Result<
     UpdateHmisProfileMutation | CreateHmisProfileMutation
   >,
-  key: 'updateHmisProfile' | 'createHmisProfile'
+  key: 'updateHmisProfile' | 'createHmisProfile',
 ): string | null {
   const operationInfo = extractOperationInfo(response, key);
 
@@ -278,7 +276,7 @@ function hasUniquenessError(
     'Constraint “unique_hmis_id_agency” is violated.';
 
   const uniquenessError = operationMessages.find(
-    (m) => m.message === uniquenessServerErrorMessage
+    (m) => m.message === uniquenessServerErrorMessage,
   );
 
   if (uniquenessError) {

--- a/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/Clients/index.tsx
@@ -23,7 +23,7 @@ type TClientProfileHmis =
 
 export default function Clients({ Logo }: { Logo: ElementType }) {
   const [currentClient, setCurrentClient] = useState<TClientProfile | null>(
-    null
+    null,
   );
   const [search, setSearch] = useState('');
   const { user } = useUser();
@@ -36,7 +36,7 @@ export default function Clients({ Logo }: { Logo: ElementType }) {
         onMenuPress={setCurrentClient}
       />
     ),
-    [setCurrentClient]
+    [setCurrentClient],
   );
 
   const handleClientPress = useCallback((id: string) => {
@@ -46,17 +46,20 @@ export default function Clients({ Logo }: { Logo: ElementType }) {
     });
   }, []);
 
-  const renderClientItemHmis = useCallback((client: TClientProfileHmis) => {
-    const { id } = client;
+  const renderClientItemHmis = useCallback(
+    (client: TClientProfileHmis) => {
+      const { id } = client;
 
-    if (!id) {
-      return null;
-    }
+      if (!id) {
+        return null;
+      }
 
-    return (
-      <ClientCardHmis onPress={() => handleClientPress(id)} client={client} />
-    );
-  }, []);
+      return (
+        <ClientCardHmis onPress={() => handleClientPress(id)} client={client} />
+      );
+    },
+    [handleClientPress],
+  );
 
   return (
     <View style={styles.container} testID="clients-screen">

--- a/libs/expo/betterangels/src/lib/screens/NoteForm/Location.tsx
+++ b/libs/expo/betterangels/src/lib/screens/NoteForm/Location.tsx
@@ -161,7 +161,7 @@ export default function LocationComponent(props: ILocationProps) {
           ? {
               formattedAddress: geocodeResult.formattedAddress,
               addressComponents: JSON.stringify(
-                geocodeResult.addressComponents ?? []
+                geocodeResult.addressComponents ?? [],
               ),
             }
           : undefined,
@@ -185,12 +185,12 @@ export default function LocationComponent(props: ILocationProps) {
         ) {
           await geocodeAndSave(
             defaultLocation.latitude,
-            defaultLocation.longitude
+            defaultLocation.longitude,
           );
         } else {
           await geocodeAndSave(
             coords?.latitude ?? INITIAL_LOCATION.latitude,
-            coords?.longitude ?? INITIAL_LOCATION.longitude
+            coords?.longitude ?? INITIAL_LOCATION.longitude,
           );
         }
       } catch (err) {
@@ -199,7 +199,7 @@ export default function LocationComponent(props: ILocationProps) {
     };
 
     void autoSetInitialLocation();
-  }, [point, address, places, onLocationChange, location]);
+  }, [point, address, places, onLocationChange, location, defaultLocation]);
 
   return (
     <FieldCard

--- a/libs/expo/betterangels/src/lib/screens/NoteForm/NoteEditorScreen.tsx
+++ b/libs/expo/betterangels/src/lib/screens/NoteForm/NoteEditorScreen.tsx
@@ -3,7 +3,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Colors } from '@monorepo/expo/shared/static';
 import { DiscardModal, TextButton } from '@monorepo/expo/shared/ui-components';
 import { useNavigation, useRouter } from 'expo-router';
-import { useEffect, useLayoutEffect } from 'react';
+import { useCallback, useEffect, useLayoutEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import {
   DeleteNoteDocument,
@@ -31,7 +31,13 @@ type NoteEditorScreenProps = {
 };
 
 export default function NoteEditorScreen(props: NoteEditorScreenProps) {
-  const { mode, noteId, arrivedFrom, clientProfileId, teamId: routeTeamId } = props;
+  const {
+    mode,
+    noteId,
+    arrivedFrom,
+    clientProfileId,
+    teamId: routeTeamId,
+  } = props;
   const [teamPreference] = useUserTeamPreference();
   const teamId = routeTeamId || teamPreference || undefined;
 
@@ -84,13 +90,13 @@ export default function NoteEditorScreen(props: NoteEditorScreenProps) {
     ? `/client/${resolvedClientProfileId}`
     : '/';
 
-  const goBack = () => {
+  const goBack = useCallback(() => {
     if (isCreateMode) {
       arrivedFrom ? router.replace(arrivedFrom) : router.back();
     } else {
       router.back();
     }
-  };
+  }, [isCreateMode, arrivedFrom, router]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -116,7 +122,7 @@ export default function NoteEditorScreen(props: NoteEditorScreenProps) {
         />
       ),
     });
-  }, [arrivedFrom, isCreateMode, navigation, router]);
+  }, [arrivedFrom, isCreateMode, navigation, router, goBack]);
 
   async function saveNote(isSubmitted?: boolean) {
     const dirty = isCreateMode ? undefined : formState.dirtyFields;

--- a/libs/expo/betterangels/src/lib/screens/NotesHmis/NoteCreateHmis/NoteCreateHmis.tsx
+++ b/libs/expo/betterangels/src/lib/screens/NotesHmis/NoteCreateHmis/NoteCreateHmis.tsx
@@ -10,8 +10,8 @@ import {
 } from '../../../apollo';
 import { applyManualFormErrors } from '../../../errors';
 import { useSnackbar } from '../../../hooks';
-import { ClientViewTabEnum } from '../../Client/ClientTabs';
 import { InteractionListHmisDocument } from '../../../ui-components/InteractionListHmis/__generated__/interactionListHmis.generated';
+import { ClientViewTabEnum } from '../../Client/ClientTabs';
 import {
   NoteFormHmis,
   NoteFormSchemaHmis,
@@ -22,7 +22,7 @@ import {
   getNoteFormEmptyStateHmis,
   NoteFormFieldNamesHmis,
 } from '../NoteFormHmis/formSchema';
-import splitBucket from '../utils/splitBucket';
+import splitBucket, { TBucket } from '../utils/splitBucket';
 import { useApplyTasks } from '../utils/useApplyTasks';
 import { CreateNoteHmisDocument } from './__generated__/createClientNoteHmis.generated';
 import {
@@ -52,7 +52,7 @@ export function NoteCreateHmis(props: TProps) {
   async function applyBucket(
     id: string,
     type: ServiceRequestTypeEnum,
-    bucket: any
+    bucket: TBucket | undefined,
   ) {
     const { toCreateStandard, toDeleteStandard, toCreateOther, toDeleteOther } =
       splitBucket(bucket);
@@ -64,7 +64,7 @@ export function NoteCreateHmis(props: TProps) {
           data: {
             hmisNoteId: id,
             serviceRequestType: type,
-            serviceId: s.serviceId!,
+            serviceId: s.serviceId,
           },
         },
       });
@@ -75,7 +75,7 @@ export function NoteCreateHmis(props: TProps) {
       await deleteService({
         variables: {
           data: {
-            serviceRequestId: s.serviceRequestId!,
+            serviceRequestId: s.serviceRequestId,
             hmisNoteId: id,
             serviceRequestType: type,
           },
@@ -90,7 +90,7 @@ export function NoteCreateHmis(props: TProps) {
           data: {
             hmisNoteId: id,
             serviceRequestType: type,
-            serviceOther: o.serviceOther!.trim(),
+            serviceOther: o.serviceOther.trim(),
           },
         },
       });
@@ -101,7 +101,7 @@ export function NoteCreateHmis(props: TProps) {
       await deleteService({
         variables: {
           data: {
-            serviceRequestId: o.serviceRequestId!,
+            serviceRequestId: o.serviceRequestId,
             hmisNoteId: id,
             serviceRequestType: type,
           },
@@ -143,7 +143,7 @@ export function NoteCreateHmis(props: TProps) {
       if (CombinedGraphQLErrors.is(error)) {
         const fieldErrors = extractExtensionFieldErrors(
           error,
-          NoteFormFieldNamesHmis
+          NoteFormFieldNamesHmis,
         );
         if (fieldErrors.length) {
           applyManualFormErrors(fieldErrors, methods.setError);
@@ -188,13 +188,13 @@ export function NoteCreateHmis(props: TProps) {
       await applyBucket(
         hmisNoteId,
         ServiceRequestTypeEnum.Provided,
-        draftServices[ServiceRequestTypeEnum.Provided]
+        draftServices[ServiceRequestTypeEnum.Provided],
       );
 
       await applyBucket(
         hmisNoteId,
         ServiceRequestTypeEnum.Requested,
-        draftServices[ServiceRequestTypeEnum.Requested]
+        draftServices[ServiceRequestTypeEnum.Requested],
       );
 
       await apolloClient.refetchQueries({
@@ -203,7 +203,7 @@ export function NoteCreateHmis(props: TProps) {
 
       // 5. Success - Redirect
       router.replace(
-        `/client/${clientId}?activeTab=${ClientViewTabEnum.Interactions}`
+        `/client/${clientId}?activeTab=${ClientViewTabEnum.Interactions}`,
       );
     } catch (error) {
       console.error('[HmisNoteCreate] error:', error);

--- a/libs/expo/betterangels/src/lib/screens/NotesHmis/NoteEditHmis/NoteEditHmis.tsx
+++ b/libs/expo/betterangels/src/lib/screens/NotesHmis/NoteEditHmis/NoteEditHmis.tsx
@@ -37,7 +37,7 @@ import {
   TNoteFormOutputsHmis,
   noteFormEmptyStateHmis,
 } from '../NoteFormHmis';
-import splitBucket from '../utils/splitBucket';
+import splitBucket, { TBucket } from '../utils/splitBucket';
 import { useApplyTasks } from '../utils/useApplyTasks';
 import { HmisNoteDocument } from './__generated__/getClientNoteHmis.generated';
 import {
@@ -83,7 +83,7 @@ export function NoteEditHmis(props: TProps) {
         },
       });
       router.dismissTo(
-        `/client/${clientId}?activeTab=${ClientViewTabEnum.Interactions}`
+        `/client/${clientId}?activeTab=${ClientViewTabEnum.Interactions}`,
       );
     } catch (err) {
       console.error(err);
@@ -98,7 +98,7 @@ export function NoteEditHmis(props: TProps) {
   async function applyBucket(
     id: string,
     type: ServiceRequestTypeEnum,
-    bucket: any
+    bucket: TBucket | undefined,
   ) {
     const { toCreateStandard, toDeleteStandard, toCreateOther, toDeleteOther } =
       splitBucket(bucket);
@@ -109,7 +109,7 @@ export function NoteEditHmis(props: TProps) {
           data: {
             hmisNoteId: id,
             serviceRequestType: type,
-            serviceId: s.serviceId!,
+            serviceId: s.serviceId,
           },
         },
       });
@@ -120,7 +120,7 @@ export function NoteEditHmis(props: TProps) {
       await deleteService({
         variables: {
           data: {
-            serviceRequestId: s.serviceRequestId!,
+            serviceRequestId: s.serviceRequestId,
             hmisNoteId: id,
             serviceRequestType: type,
           },
@@ -135,7 +135,7 @@ export function NoteEditHmis(props: TProps) {
           data: {
             hmisNoteId: id,
             serviceRequestType: type,
-            serviceOther: o.serviceOther!.trim(),
+            serviceOther: o.serviceOther.trim(),
           },
         },
       });
@@ -146,7 +146,7 @@ export function NoteEditHmis(props: TProps) {
       await deleteService({
         variables: {
           data: {
-            serviceRequestId: o.serviceRequestId!,
+            serviceRequestId: o.serviceRequestId,
             hmisNoteId: id,
             serviceRequestType: type,
           },
@@ -245,7 +245,7 @@ export function NoteEditHmis(props: TProps) {
       if (CombinedGraphQLErrors.is(error)) {
         const fieldErrors = extractExtensionFieldErrors(
           error,
-          NoteFormFieldNamesHmis
+          NoteFormFieldNamesHmis,
         );
 
         if (fieldErrors.length) {
@@ -288,19 +288,19 @@ export function NoteEditHmis(props: TProps) {
       await applyBucket(
         id,
         ServiceRequestTypeEnum.Provided,
-        draftServices[ServiceRequestTypeEnum.Provided]
+        draftServices[ServiceRequestTypeEnum.Provided],
       );
 
       await applyBucket(
         id,
         ServiceRequestTypeEnum.Requested,
-        draftServices[ServiceRequestTypeEnum.Requested]
+        draftServices[ServiceRequestTypeEnum.Requested],
       );
 
       await refetch();
 
       router.replace(
-        `/client/${clientId}?activeTab=${ClientViewTabEnum.Interactions}`
+        `/client/${clientId}?activeTab=${ClientViewTabEnum.Interactions}`,
       );
     } catch (error) {
       console.error('[updateHmisNoteMutation] error:', error);

--- a/libs/expo/betterangels/src/lib/screens/NotesHmis/NoteFormHmis/formSchema.ts
+++ b/libs/expo/betterangels/src/lib/screens/NotesHmis/NoteFormHmis/formSchema.ts
@@ -1,9 +1,6 @@
 import { format } from 'date-fns';
 import { z } from 'zod';
-import {
-  ServiceRequestTypeEnum,
-  TaskStatusEnum,
-} from '../../../apollo';
+import { ServiceRequestTypeEnum, TaskStatusEnum } from '../../../apollo';
 
 // ----------------------------------------------------------------------
 // 1. Local Draft Task Type
@@ -68,7 +65,7 @@ export const NoteFormSchemaHmis = z.object({
     .optional()
     .refine(
       (val) => val instanceof Date && !Number.isNaN(val.getTime()),
-      'Date is required.'
+      'Date is required.',
     ),
   refClientProgram: z.string(),
   note: z.string().min(1, 'Note is required.'),
@@ -109,7 +106,7 @@ export const noteFormEmptyStateHmis: TNoteFormInputsHmis = {
   date: undefined,
   refClientProgram: '',
   note: '',
-  location: undefined as any,
+  location: undefined as unknown as TNoteFormInputsHmis['location'], // TODO: see if can update schema to accept undefined
   tasks: [],
   services: {},
 };
@@ -126,5 +123,5 @@ export const getNoteFormEmptyStateHmis = (): TNoteFormInputsHmis => ({
 type NoteFormFieldNameHmis = keyof typeof NoteFormSchemaHmis.shape;
 
 export const NoteFormFieldNamesHmis = Object.keys(
-  NoteFormSchemaHmis.shape
+  NoteFormSchemaHmis.shape,
 ) as NoteFormFieldNameHmis[];

--- a/libs/expo/betterangels/src/lib/screens/NotesHmis/utils/splitBucket.tsx
+++ b/libs/expo/betterangels/src/lib/screens/NotesHmis/utils/splitBucket.tsx
@@ -1,21 +1,27 @@
-export default function splitBucket(bucket?: {
+export type TBucket = {
   serviceRequests?: {
     id?: string;
     service?: { id: string; label?: string } | null;
     markedForDeletion?: boolean;
     serviceOther?: string | null;
   }[];
-}) {
+};
+
+export default function splitBucket(bucket?: TBucket) {
   const serviceRequests = bucket?.serviceRequests ?? [];
 
   // CREATE standard: brand-new rows (no id), not marked for deletion, with a selected service
   const toCreateStandard = serviceRequests
     .filter((s) => !s.id && !s.markedForDeletion && !!s.service?.id)
+    // safe: filtered above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     .map((s) => ({ serviceId: s.service!.id }));
 
   // DELETE standard: persisted rows (has id) explicitly marked for deletion
   const toDeleteStandard = serviceRequests
     .filter((s) => !!s.id && !!s.markedForDeletion)
+    // safe: filtered above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     .map((s) => ({ serviceRequestId: s.id! }));
 
   // CREATE “other”: brand-new (no serviceRequestId), not marked for deletion, with non-empty text
@@ -25,13 +31,17 @@ export default function splitBucket(bucket?: {
         o.id?.startsWith('tmp-other') &&
         !o.markedForDeletion &&
         !!o.serviceOther &&
-        o.serviceOther.trim().length > 0
+        o.serviceOther.trim().length > 0,
     )
+    // safe: filtered above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     .map((o) => ({ serviceOther: o.serviceOther!.trim() }));
 
   // DELETE “other”: persisted (has serviceRequestId) and marked for deletion
   const toDeleteOther = serviceRequests
     .filter((o) => !!o.id && !!o.markedForDeletion && !!o.serviceOther)
+    // safe: filtered above
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     .map((o) => ({ serviceRequestId: o.id! }));
 
   return { toCreateStandard, toDeleteStandard, toCreateOther, toDeleteOther };

--- a/libs/expo/betterangels/src/lib/screens/NotesHmis/utils/useApplyTasks.ts
+++ b/libs/expo/betterangels/src/lib/screens/NotesHmis/utils/useApplyTasks.ts
@@ -15,7 +15,7 @@ export function useApplyTasks() {
     async (
       tasks: DraftTask[] | undefined,
       hmisNoteId: string,
-      hmisClientProfileId: string
+      hmisClientProfileId: string,
     ) => {
       const { toCreateTask, toUpdateTask, toDeleteTask } = splitTasks(tasks);
 
@@ -44,6 +44,8 @@ export function useApplyTasks() {
         await updateTask({
           variables: {
             data: {
+              // safe: splitTasks guarantees id for update tasks
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               id: s.id!,
               summary: s.summary,
               teamId: s.teamId ?? undefined,
@@ -54,7 +56,7 @@ export function useApplyTasks() {
         });
       }
     },
-    [createTask, deleteTask, updateTask]
+    [createTask, deleteTask, updateTask],
   );
 
   return { applyTasks };

--- a/libs/expo/betterangels/src/lib/ui-components/AuthContainer.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/AuthContainer.tsx
@@ -19,6 +19,7 @@ export default function AuthContainer({
 
   return (
     <>
+      {/* eslint-disable-next-line react/style-prop-object -- Expo StatusBar style accepts string */}
       <StatusBar style="dark" />
       <View style={[styles.container, { paddingBottom: insets.bottom }, style]}>
         <View style={styles.headerContainer}>{header}</View>

--- a/libs/expo/betterangels/src/lib/ui-components/ClientProfileList/ListClientsHmis.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ClientProfileList/ListClientsHmis.tsx
@@ -63,7 +63,7 @@ export function ListClientsHmis(props: TProps) {
     (item: HmisClientProfileType) => {
       return renderItem(item);
     },
-    [renderItem]
+    [renderItem],
   );
 
   if (items.length === 0 && loading) {
@@ -75,7 +75,7 @@ export function ListClientsHmis(props: TProps) {
       <InfiniteList<HmisClientProfileType>
         modelName="client"
         data={items}
-        keyExtractor={(item) => item.id!}
+        keyExtractor={(item) => item.id}
         totalItems={total}
         renderItem={renderItemFn}
         itemGap={itemGap}

--- a/libs/expo/betterangels/src/lib/ui-components/Filters/FilterClients/FilterClientOptions.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/Filters/FilterClients/FilterClientOptions.tsx
@@ -79,6 +79,7 @@ export function FilterClientOptions(props: TProps) {
 
   return (
     <Filters.Screen onDone={handleDone} onClear={() => setLocalSelected([])}>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <MultiSelect_V2<TFilterOption>
         infinite
         options={options}

--- a/libs/expo/betterangels/src/lib/ui-components/Filters/FilterClientsHmis/FilterClientOptionsHmis.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/Filters/FilterClientsHmis/FilterClientOptionsHmis.tsx
@@ -75,6 +75,7 @@ export function FilterClientOptionsHmis(props: TProps) {
 
   return (
     <Filters.Screen onDone={handleDone} onClear={() => setLocalSelected([])}>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <MultiSelect_V2<TFilterOption>
         infinite
         options={options}

--- a/libs/expo/betterangels/src/lib/ui-components/Filters/FilterOrganizations/FilterOrganizationsOptions.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/Filters/FilterOrganizations/FilterOrganizationsOptions.tsx
@@ -78,6 +78,7 @@ export function FilterOrganizationsOptions(props: TProps) {
 
   return (
     <Filters.Screen onDone={handleDone} onClear={() => setLocalSelected([])}>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <MultiSelect_V2<TFilterOption>
         infinite
         options={options}

--- a/libs/expo/betterangels/src/lib/ui-components/Filters/FilterStatic/OptionScreen.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/Filters/FilterStatic/OptionScreen.tsx
@@ -35,6 +35,7 @@ export function OptionScreen({
 
   return (
     <Filters.Screen onDone={handleDone} onClear={() => setLocalSelected([])}>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <MultiSelect_V2<TFilterOption>
         options={options}
         selected={localSelected}

--- a/libs/expo/betterangels/src/lib/ui-components/Filters/FilterTeams/FilterTeamsOptions.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/Filters/FilterTeams/FilterTeamsOptions.tsx
@@ -25,9 +25,9 @@ export function FilterTeamsOptions(props: TProps) {
 
   const options = useMemo<TFilterOption[]>(() => {
     return teams.map((t) => ({
-        id: t.id,
-        label: t.name,
-      }));
+      id: t.id,
+      label: t.name,
+    }));
   }, [teams]);
 
   if (error) {
@@ -41,6 +41,7 @@ export function FilterTeamsOptions(props: TProps) {
 
   return (
     <Filters.Screen onDone={handleDone} onClear={() => setLocalSelected([])}>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <MultiSelect_V2<TFilterOption>
         options={options}
         selected={localSelected}

--- a/libs/expo/betterangels/src/lib/ui-components/Filters/FilterUsers/FilterUserOptions.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/Filters/FilterUsers/FilterUserOptions.tsx
@@ -107,6 +107,7 @@ export function FilterUserOptions(props: TProps) {
 
   return (
     <Filters.Screen onDone={handleDone} onClear={() => setLocalSelected([])}>
+      {/* eslint-disable-next-line react/jsx-pascal-case */}
       <MultiSelect_V2<TFilterOption>
         infinite
         options={options}

--- a/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/ServicesModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/ServicesModal.tsx
@@ -17,8 +17,8 @@ import {
   DeleteServiceRequestDocument,
   ServiceRequestTypeEnum,
 } from '../../apollo';
-import { NoteFormServiceItem } from '../../screens/NoteForm/schema';
 import { useSnackbar } from '../../hooks';
+import { NoteFormServiceItem } from '../../screens/NoteForm/schema';
 
 import MainScrollContainer from '../MainScrollContainer';
 import OtherCategory from './OtherCategory';
@@ -97,14 +97,14 @@ export default function ServicesModal(props: IServicesModalProps) {
     [...arr].sort(
       (a, b) =>
         (a.priority ?? 0) - (b.priority ?? 0) ||
-        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
     );
 
   const sortServices = (arr: ApiService[]) =>
     [...arr].sort(
       (a, b) =>
         (a.priority ?? 0) - (b.priority ?? 0) ||
-        a.label.toLowerCase().localeCompare(b.label.toLowerCase())
+        a.label.toLowerCase().localeCompare(b.label.toLowerCase()),
     );
 
   const toServicesByCategory = useCallback(
@@ -116,12 +116,12 @@ export default function ServicesModal(props: IServicesModalProps) {
             title: cat.name,
             items: pipe(
               sortServices((cat.services ?? []) as ApiService[]),
-              rmap((s: ApiService): TItem => ({ id: s.id, label: s.label }))
+              rmap((s: ApiService): TItem => ({ id: s.id, label: s.label })),
             ),
-          })
-        )
+          }),
+        ),
       ),
-    []
+    [],
   );
 
   const filterServicesByText = useCallback(
@@ -134,30 +134,30 @@ export default function ServicesModal(props: IServicesModalProps) {
           (cat: TCategory): TCategory => ({
             ...cat,
             items: (cat.items || []).filter((i) =>
-              i.label.toLowerCase().includes(q)
+              i.label.toLowerCase().includes(q),
             ),
-          })
+          }),
         ),
-        rfilter((cat: TCategory) => cat.items.length > 0)
+        rfilter((cat: TCategory) => cat.items.length > 0),
       );
     },
-    []
+    [],
   );
 
   // Type predicates so we don’t need non-null assertions
   const hasService = useCallback(
     (
-      it: IServicesModalProps['initialServiceRequests'][number]
+      it: IServicesModalProps['initialServiceRequests'][number],
     ): it is { id: string; service: { id: string; label?: string } } =>
       Boolean(it.service?.id),
-    []
+    [],
   );
 
   const hasOther = useCallback(
     (
-      it: IServicesModalProps['initialServiceRequests'][number]
+      it: IServicesModalProps['initialServiceRequests'][number],
     ): it is { id: string; serviceOther: string } => Boolean(it.serviceOther),
-    []
+    [],
   );
 
   const computeInitial = useCallback(() => {
@@ -166,7 +166,7 @@ export default function ServicesModal(props: IServicesModalProps) {
       const existing: SelectedService[] = initialLocalServices
         .filter((s) => s.serviceId)
         .map((s) => ({
-          serviceId: s.serviceId!,
+          serviceId: s.serviceId as string,
           label: s.label || '',
           markedForDeletion: false,
         }));
@@ -174,7 +174,7 @@ export default function ServicesModal(props: IServicesModalProps) {
       const others = initialLocalServices
         .filter((s) => s.serviceOther)
         .map((s) => ({
-          serviceOther: s.serviceOther!,
+          serviceOther: s.serviceOther as string,
           serviceRequestId: undefined,
           markedForDeletion: false,
         }));
@@ -191,7 +191,7 @@ export default function ServicesModal(props: IServicesModalProps) {
         serviceId: it.service.id,
         label: it.service.label ?? '',
         markedForDeletion: false,
-      }))
+      })),
     );
 
     const others = pipe(
@@ -201,7 +201,7 @@ export default function ServicesModal(props: IServicesModalProps) {
         serviceRequestId: it.id,
         serviceOther: it.serviceOther,
         markedForDeletion: false,
-      }))
+      })),
     );
 
     return { existing, others };
@@ -240,20 +240,26 @@ export default function ServicesModal(props: IServicesModalProps) {
   const categories = useMemo(
     () =>
       toServicesByCategory(
-        (availableCategories?.serviceCategories?.results ?? []) as ApiCategory[]
+        (availableCategories?.serviceCategories?.results ??
+          []) as ApiCategory[],
       ),
-    [availableCategories, toServicesByCategory]
+    [availableCategories, toServicesByCategory],
   );
 
   const filteredServices = useMemo(
     () => filterServicesByText(categories, searchText),
-    [categories, filterServicesByText, searchText]
+    [categories, filterServicesByText, searchText],
   );
 
   const hasResults = filteredServices.some((c) => c.items.length > 0);
 
   // ---------- Submit ----------
   const submitServices = useCallback(async () => {
+    if (!noteId) {
+      console.error('[ServicesModal] submitServices called without noteId');
+      return;
+    }
+
     setIsSubmitLoading(true);
     try {
       if (isLocalMode && onServicesChange) {
@@ -281,17 +287,19 @@ export default function ServicesModal(props: IServicesModalProps) {
 
       // Server mode: create/delete via mutations
       const toCreate = serviceRequests.filter(
-        (s) => !s.serviceRequestId && !s.markedForDeletion
+        (s) => !s.serviceRequestId && !s.markedForDeletion,
       );
       const toDelete = serviceRequests.filter(
-        (s) => Boolean(s.serviceRequestId) && Boolean(s.markedForDeletion)
+        (s) => Boolean(s.serviceRequestId) && Boolean(s.markedForDeletion),
       );
       const toRemoveOtherServices = serviceRequestsOthers.filter(
-        (o) => Boolean(o.serviceRequestId) && Boolean(o.markedForDeletion)
+        (o) => Boolean(o.serviceRequestId) && Boolean(o.markedForDeletion),
       );
       const toCreateOtherServices = serviceRequestsOthers.filter(
         (o) =>
-          Boolean(o.serviceOther) && !o.serviceRequestId && !o.markedForDeletion
+          Boolean(o.serviceOther) &&
+          !o.serviceRequestId &&
+          !o.markedForDeletion,
       );
 
       // Sequential awaits (safer with server constraints)
@@ -300,7 +308,7 @@ export default function ServicesModal(props: IServicesModalProps) {
           variables: {
             data: {
               serviceId: s.serviceId,
-              noteId: noteId!,
+              noteId: noteId,
               serviceRequestType: type,
             },
           },
@@ -318,7 +326,7 @@ export default function ServicesModal(props: IServicesModalProps) {
           variables: {
             data: {
               serviceOther: o.serviceOther,
-              noteId: noteId!,
+              noteId: noteId,
               serviceRequestType: type,
             },
           },
@@ -356,14 +364,14 @@ export default function ServicesModal(props: IServicesModalProps) {
     setServiceRequests(
       pipe(
         existing,
-        rmap((s) => ({ ...s, markedForDeletion: true }))
-      )
+        rmap((s) => ({ ...s, markedForDeletion: true })),
+      ),
     );
     setServiceRequestsOthers(
       pipe(
         others,
-        rmap((o) => ({ ...o, markedForDeletion: true }))
-      )
+        rmap((o) => ({ ...o, markedForDeletion: true })),
+      ),
     );
   }, [computeInitial]);
 
@@ -405,7 +413,7 @@ export default function ServicesModal(props: IServicesModalProps) {
                   {category.items.map((item, idx) => {
                     const entry = rfind(
                       serviceRequests,
-                      (s) => s.serviceId === item.id
+                      (s) => s.serviceId === item.id,
                     );
                     const checked =
                       !!entry &&
@@ -422,7 +430,7 @@ export default function ServicesModal(props: IServicesModalProps) {
                     );
                   })}
                 </View>
-              ) : null
+              ) : null,
             )
           ) : (
             <View style={{ alignItems: 'center' }}>

--- a/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/ServicesModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/ServicesModal.tsx
@@ -255,11 +255,6 @@ export default function ServicesModal(props: IServicesModalProps) {
 
   // ---------- Submit ----------
   const submitServices = useCallback(async () => {
-    if (!noteId) {
-      console.error('[ServicesModal] submitServices called without noteId');
-      return;
-    }
-
     setIsSubmitLoading(true);
     try {
       if (isLocalMode && onServicesChange) {
@@ -283,6 +278,11 @@ export default function ServicesModal(props: IServicesModalProps) {
         onServicesChange(selectedServices);
         close();
         return;
+      }
+
+      // Server mode requires a noteId
+      if (!noteId) {
+        throw new Error('[ServicesModal] submitServices called without noteId');
       }
 
       // Server mode: create/delete via mutations

--- a/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServices/index.tsx
@@ -3,9 +3,9 @@ import { FieldCard, Pill } from '@monorepo/expo/shared/ui-components';
 import { RefObject } from 'react';
 import { ScrollView, View } from 'react-native';
 import { ServiceRequestTypeEnum, ViewNoteQuery } from '../../apollo';
-import { NoteFormServiceItem } from '../../screens/NoteForm/schema';
 import { normalizeService } from '../../helpers';
 import { useModalScreen } from '../../providers';
+import { NoteFormServiceItem } from '../../screens/NoteForm/schema';
 import { enumDisplayServiceType } from '../../static';
 import ServicesModal from './ServicesModal';
 
@@ -22,7 +22,7 @@ interface IRequestedServicesProps {
 }
 
 export default function RequestedProvidedServices(
-  props: IRequestedServicesProps
+  props: IRequestedServicesProps,
 ) {
   const {
     noteId,
@@ -64,9 +64,9 @@ export default function RequestedProvidedServices(
 
   // For ServicesModal in local mode, we need normalized initial service requests
   const normalizedServiceRequests = !isLocalMode
-    ? (initialServices as ViewNoteQuery['note']['providedServices'])?.map(
-        normalizeService
-      ) ?? []
+    ? ((initialServices as ViewNoteQuery['note']['providedServices'])?.map(
+        normalizeService,
+      ) ?? [])
     : [];
 
   return (
@@ -138,6 +138,8 @@ export default function RequestedProvidedServices(
         })
       }
     >
+      {/* FieldCard requires children */}
+      {/* eslint-disable-next-line react/jsx-no-useless-fragment */}
       <></>
     </FieldCard>
   );

--- a/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServicesHmis/ServicesModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServicesHmis/ServicesModal.tsx
@@ -13,7 +13,6 @@ import {
 } from '@monorepo/expo/shared/ui-components';
 
 import { ServiceRequestTypeEnum } from '../../apollo';
-import { useSnackbar } from '../../hooks';
 
 import MainScrollContainer from '../MainScrollContainer';
 import OtherCategory from './OtherCategory';
@@ -57,7 +56,6 @@ export default function ServicesModal(props: IServicesModalProps) {
   const { selectedServices, type, onSelect, close } = props;
 
   const { data: availableCategories } = useQuery(ServiceCategoriesHmisDocument);
-  const { showSnackbar } = useSnackbar();
   const { bottom: bottomInset } = useSafeAreaInsets();
 
   const [rows, setRows] = useState<SelectedService[]>([]);
@@ -71,14 +69,14 @@ export default function ServicesModal(props: IServicesModalProps) {
     [...arr].sort(
       (a, b) =>
         (a.priority ?? 0) - (b.priority ?? 0) ||
-        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
     );
 
   const sortServices = (arr: ApiService[]) =>
     [...arr].sort(
       (a, b) =>
         (a.priority ?? 0) - (b.priority ?? 0) ||
-        a.label.toLowerCase().localeCompare(b.label.toLowerCase())
+        a.label.toLowerCase().localeCompare(b.label.toLowerCase()),
     );
 
   const toServicesByCategory = useCallback(
@@ -90,12 +88,12 @@ export default function ServicesModal(props: IServicesModalProps) {
             title: cat.name,
             items: pipe(
               sortServices((cat.services ?? []) as ApiService[]),
-              rmap((s: ApiService): TItem => ({ id: s.id, label: s.label }))
+              rmap((s: ApiService): TItem => ({ id: s.id, label: s.label })),
             ),
-          })
-        )
+          }),
+        ),
       ),
-    []
+    [],
   );
 
   const filterServicesByText = useCallback(
@@ -108,28 +106,28 @@ export default function ServicesModal(props: IServicesModalProps) {
           (cat: TCategory): TCategory => ({
             ...cat,
             items: (cat.items || []).filter((i) =>
-              i.label.toLowerCase().includes(q)
+              i.label.toLowerCase().includes(q),
             ),
-          })
+          }),
         ),
-        rfilter((cat: TCategory) => cat.items.length > 0)
+        rfilter((cat: TCategory) => cat.items.length > 0),
       );
     },
-    []
+    [],
   );
 
   const hasService = useCallback(
     (
-      it: SelectedService
+      it: SelectedService,
     ): it is SelectedService & { service: { id: string; label?: string } } =>
       !!it.service?.id,
-    []
+    [],
   );
 
   const hasOther = useCallback(
     (it: SelectedService): it is SelectedService & { serviceOther: string } =>
       typeof it.serviceOther === 'string' && it.serviceOther.length > 0,
-    []
+    [],
   );
 
   const computeInitial = useCallback(() => {
@@ -139,9 +137,9 @@ export default function ServicesModal(props: IServicesModalProps) {
       rfilter((it) => !it.serviceOther || it.serviceOther.trim().length === 0),
       rmap((it) => ({
         id: it.id,
-        service: { id: it.service!.id, label: it.service!.label ?? '' },
+        service: { id: it.service.id, label: it.service.label ?? '' },
         markedForDeletion: it.markedForDeletion ?? false,
-      }))
+      })),
     );
 
     const others = pipe(
@@ -151,7 +149,7 @@ export default function ServicesModal(props: IServicesModalProps) {
         id: it.id,
         serviceOther: it.serviceOther,
         markedForDeletion: it.markedForDeletion ?? false,
-      }))
+      })),
     );
 
     return [...std, ...others];
@@ -181,14 +179,15 @@ export default function ServicesModal(props: IServicesModalProps) {
   const categories = useMemo(
     () =>
       toServicesByCategory(
-        (availableCategories?.serviceCategories?.results ?? []) as ApiCategory[]
+        (availableCategories?.serviceCategories?.results ??
+          []) as ApiCategory[],
       ),
-    [availableCategories, toServicesByCategory]
+    [availableCategories, toServicesByCategory],
   );
 
   const filteredServices = useMemo(
     () => filterServicesByText(categories, searchText),
-    [categories, filterServicesByText, searchText]
+    [categories, filterServicesByText, searchText],
   );
 
   const hasResults = filteredServices.some((c) => c.items.length > 0);
@@ -198,11 +197,11 @@ export default function ServicesModal(props: IServicesModalProps) {
       rows
         .filter((r) => r.serviceOther)
         .map((r) => ({
-          serviceOther: r.serviceOther!,
+          serviceOther: r.serviceOther as string,
           serviceRequestId: r.id,
           markedForDeletion: r.markedForDeletion ?? false,
         })),
-    [rows]
+    [rows],
   );
 
   const setOtherCategoryRows = useCallback(
@@ -211,7 +210,7 @@ export default function ServicesModal(props: IServicesModalProps) {
         serviceOther: string | null;
         serviceRequestId?: string;
         markedForDeletion?: boolean;
-      }[]
+      }[],
     ) => {
       setRows((prev) => {
         const nonOther = prev.filter((r) => !r.serviceOther);
@@ -224,7 +223,7 @@ export default function ServicesModal(props: IServicesModalProps) {
               (r) =>
                 !!r.serviceOther &&
                 r.serviceOther === o.serviceOther &&
-                !r.service
+                !r.service,
             );
 
           const isServerId =
@@ -232,8 +231,10 @@ export default function ServicesModal(props: IServicesModalProps) {
             !o.serviceRequestId.startsWith('tmp-other-');
 
           const id = isServerId
-            ? o.serviceRequestId!
-            : existing?.id ?? makeTmpId();
+            ? // safe: guarded by isServerId
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              o.serviceRequestId!
+            : (existing?.id ?? makeTmpId());
 
           return {
             id,
@@ -245,7 +246,7 @@ export default function ServicesModal(props: IServicesModalProps) {
         return [...nonOther, ...merged];
       });
     },
-    [makeTmpId]
+    [makeTmpId],
   );
 
   // ---------- Submit ----------
@@ -255,7 +256,7 @@ export default function ServicesModal(props: IServicesModalProps) {
     });
 
     close();
-  }, [rows, type, close, showSnackbar]);
+  }, [rows, type, close, onSelect]);
 
   // ---------- Close (revert) ----------
   const clearAll = useCallback(() => {
@@ -263,10 +264,10 @@ export default function ServicesModal(props: IServicesModalProps) {
       pipe(
         prev,
         rfilter((r) => Boolean(r.id) || Boolean(r.serviceOther)),
-        rmap((r) => ({ ...r, markedForDeletion: true }))
-      )
+        rmap((r) => ({ ...r, markedForDeletion: true })),
+      ),
     );
-  }, [computeInitial]);
+  }, []);
 
   useEffect(() => {
     setRows(computeInitial());
@@ -315,7 +316,7 @@ export default function ServicesModal(props: IServicesModalProps) {
                     );
                   })}
                 </View>
-              ) : null
+              ) : null,
             )
           ) : (
             <View style={{ alignItems: 'center' }}>

--- a/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServicesHmis/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/RequestedProvidedServicesHmis/index.tsx
@@ -30,7 +30,7 @@ type IRequestedServicesProps =
     };
 
 export default function HmisRequestedProvidedServices(
-  props: IRequestedServicesProps
+  props: IRequestedServicesProps,
 ) {
   const { services: selectedServices, type } = props;
   const { showModalScreen } = useModalScreen();
@@ -82,7 +82,7 @@ export default function HmisRequestedProvidedServices(
                 setValue(
                   'services',
                   { ...current, ...e },
-                  { shouldDirty: true }
+                  { shouldDirty: true },
                 );
               }}
               close={close}
@@ -93,6 +93,8 @@ export default function HmisRequestedProvidedServices(
         })
       }
     >
+      {/* FieldCard requires children */}
+      {/* eslint-disable-next-line react/jsx-no-useless-fragment */}
       <></>
     </FieldCard>
   );

--- a/libs/expo/betterangels/src/lib/ui-components/SignInContainer/index.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/SignInContainer/index.tsx
@@ -37,6 +37,9 @@ export default function SignInContainer({
       refetchFeatureFlags();
       router.replace(user.isOutreachAuthorized ? '/' : '/welcome');
     }
+    // refetchFeatureFlags is called only when user just became truthy (login).
+    // Adding it to deps could cause spurious refetches if not memoized upstream.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
   return (

--- a/libs/expo/betterangels/src/lib/ui-components/TaskStatusBtn/TaskStatusBtn.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/TaskStatusBtn/TaskStatusBtn.tsx
@@ -42,13 +42,16 @@ export function TaskStatusBtn(props: TaskStatusBtnProps) {
   const client = useApolloClient();
 
   const [value, setValue] = useState<TaskStatusEnum>(
-    status || TaskStatusEnum.ToDo
+    status || TaskStatusEnum.ToDo,
   );
 
+  // Sync external status prop to local state.
+  // value intentionally omitted to avoid infinite loop.
   useEffect(() => {
     if (status && status !== value) {
       setValue(status);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, status]);
 
   const onUpdateTask = async (newStatus: TaskStatusEnum) => {


### PR DESCRIPTION
### fix eslint warnings for expo-betterangels lib
DEV-2472

## Summary by Sourcery

Address ESLint warnings and improve type safety and React hook usage across the expo-betterangels library with minor behavioral safeguards added where needed.

Bug Fixes:
- Prevent service submission when noteId is missing in ServicesModal to avoid invalid mutations.
- Ensure HMIS client interactions and locations views use stable clientId in navigation and callbacks, preventing stale or undefined IDs.
- Synchronize TaskStatusBtn internal state with external status prop without causing React effect loops.
- Use safer typing and guards when handling Apollo cache objects, enum validation, and interaction locations to avoid runtime errors.
- Avoid clearing client contact form state from stale profile data by tightening effect dependencies.

Enhancements:
- Tighten TypeScript types and remove non-null assertions in service request handling and note HMIS utilities for safer mutations.
- Introduce a shared TBucket type for HMIS note service bucket utilities to improve reuse and type safety.
- Refine React hook dependencies and memoization across screens and hooks (navigation handlers, map regions, forms) to satisfy lint rules and reduce unnecessary recomputation.
- Clean up unused imports, adjust component usage (e.g., MultiSelect_V2, StatusBar), and add inline ESLint disables where required to conform to lint configuration.
- Improve test typing by using Apollo StoreValue in cache policy tests and stronger enum validation helpers.

Tests:
- Update cache policy utility tests to use properly typed Apollo StoreValue inputs instead of any for stricter test type checking.

Chores:
- Resolve numerous ESLint style and dependency warnings throughout the expo-betterangels library without changing core functionality.