### PR TITLE
perf(ci): slim Docker image and use ECR layer caching

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -82,11 +82,6 @@ jobs:
           echo "MONOREPO_IMAGE=localhost:5000/monorepo" >> $GITHUB_ENV
           echo "ECR_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
 
-      - name: 🧹 Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
-          df -h /
-
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -85,7 +85,6 @@ jobs:
       - name: 🧹 Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
-          sudo docker system prune -af --volumes 2>/dev/null || true
           df -h /
 
       - name: 🐳 Set up Docker Buildx

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -83,7 +83,7 @@ jobs:
           echo "ECR_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
 
       - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker-container
           driver-opts: network=host
@@ -98,7 +98,7 @@ jobs:
 
       # Build Monorepo Image — push to local registry (avoids slow `load: true`)
       - name: 🏗️ Build Monorepo Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: Dockerfile
           push: true

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -82,6 +82,12 @@ jobs:
           echo "MONOREPO_IMAGE=localhost:5000/monorepo" >> $GITHUB_ENV
           echo "ECR_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
 
+      - name: 🧹 Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          sudo docker system prune -af --volumes 2>/dev/null || true
+          df -h /
+
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -27,11 +27,6 @@ jobs:
           ) }}
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     permissions:
       actions: read # Required to find the last successful workflow run
       contents: read # Required for actions/checkout
@@ -79,30 +74,19 @@ jobs:
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           echo "IMAGE_TAG_PREFIX=$IMAGE_TAG_PREFIX" >> $GITHUB_ENV
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
-          echo "MONOREPO_IMAGE=localhost:5000/monorepo" >> $GITHUB_ENV
-          echo "ECR_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
+          echo "MONOREPO_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-        with:
-          driver: docker-container
-          driver-opts: network=host
 
-      - name: ⏳ Wait for local registry
-        run: |
-          for i in $(seq 1 30); do
-            curl -s http://localhost:5000/v2/ && break
-            echo "Waiting for registry... ($i)"
-            sleep 1
-          done
-
-      # Build Monorepo Image — push to local registry (avoids slow `load: true`)
+      # Build Monorepo Image for each commit using GitHub Actions cache
       - name: 🏗️ Build Monorepo Docker image
         uses: docker/build-push-action@v7
         with:
           file: Dockerfile
-          push: true
-          tags: localhost:5000/monorepo:${{ env.DOCKER_TAG }}
+          load: true
+          tags: |
+            ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -225,12 +209,10 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
 
-      - name: 🏗️ Push Monorepo Docker image to ECR
+      - name: 🏗️ Push Monorepo Docker image
         if: matrix.environment == 'production'
         run: |
-          docker pull ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
-          docker tag ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }} ${{ env.ECR_IMAGE }}:${{ env.DOCKER_TAG }}
-          docker push ${{ env.ECR_IMAGE }}:${{ env.DOCKER_TAG }}
+          docker push ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
 
       - name: 🚀 Deploy Changes
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -75,11 +75,12 @@ jobs:
           echo "IMAGE_TAG_PREFIX=$IMAGE_TAG_PREFIX" >> $GITHUB_ENV
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
           echo "MONOREPO_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
+          echo "CACHE_IMAGE=${{ env.ECR_REGISTRY }}/monorepo:buildcache" >> $GITHUB_ENV
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Build Monorepo Image for each commit using GitHub Actions cache
+      # Build Monorepo Image — pull cache from ECR, push only on main to minimize egress costs
       - name: 🏗️ Build Monorepo Docker image
         uses: docker/build-push-action@v7
         with:
@@ -87,8 +88,8 @@ jobs:
           load: true
           tags: |
             ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}
+          cache-to: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('type=registry,ref={0},mode=max', env.CACHE_IMAGE) || '' }}
 
       - name: 🔑 Prep Container Permissions
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -78,6 +78,16 @@ jobs:
           echo "CACHE_IMAGE=${{ env.ECR_REGISTRY }}/monorepo:buildcache" >> $GITHUB_ENV
           echo "BRANCH_CACHE=${{ env.ECR_REGISTRY }}/monorepo:buildcache-${BRANCH_NAME}" >> $GITHUB_ENV
 
+      - name: 🐳 Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ASSUMED_ROLE }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: 🐳 Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -105,17 +115,7 @@ jobs:
           sudo setfacl --modify user:1000:rw /var/run/docker.sock
           sudo setfacl -Rm u:1000:rwX,d:u:1000:rwX $HOME/.docker
 
-      - name: 🐳 Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.ASSUMED_ROLE }}
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: 🐳 Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: 🔄 Spin up monorepo environment
+      - name:  Spin up monorepo environment
         run: |
           docker compose up -d
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -83,7 +83,8 @@ jobs:
 
       # Build Monorepo Image with ECR layer caching
       # - Pull from main's cache (shared) + branch-specific cache
-      # - Only push cache on main to minimize egress costs
+      # - Always push to branch cache (low egress, incremental)
+      # - Additionally push to main cache on main branch pushes
       - name: 🏗️ Build Monorepo Docker image
         uses: docker/build-push-action@v7
         with:
@@ -94,7 +95,9 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.CACHE_IMAGE }}-main
             type=registry,ref=${{ env.BRANCH_CACHE }}
-          cache-to: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('type=registry,ref={0}-main,mode=max', env.CACHE_IMAGE) || '' }}
+          cache-to: |
+            type=registry,ref=${{ env.BRANCH_CACHE }},mode=max
+            ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('type=registry,ref={0}-main,mode=max', env.CACHE_IMAGE) || '' }}
 
       - name: 🔑 Prep Container Permissions
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -27,6 +27,11 @@ jobs:
           ) }}
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     permissions:
       actions: read # Required to find the last successful workflow run
       contents: read # Required for actions/checkout
@@ -74,19 +79,30 @@ jobs:
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
           echo "IMAGE_TAG_PREFIX=$IMAGE_TAG_PREFIX" >> $GITHUB_ENV
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
-          echo "MONOREPO_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
+          echo "MONOREPO_IMAGE=localhost:5000/monorepo" >> $GITHUB_ENV
+          echo "ECR_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          driver-opts: network=host
 
-      # Build Monorepo Image for each commit using GitHub Actions cache
+      - name: ⏳ Wait for local registry
+        run: |
+          for i in $(seq 1 30); do
+            curl -s http://localhost:5000/v2/ && break
+            echo "Waiting for registry... ($i)"
+            sleep 1
+          done
+
+      # Build Monorepo Image — push to local registry (avoids slow `load: true`)
       - name: 🏗️ Build Monorepo Docker image
         uses: docker/build-push-action@v6
         with:
           file: Dockerfile
-          load: true
-          tags: |
-            ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
+          push: true
+          tags: localhost:5000/monorepo:${{ env.DOCKER_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -209,10 +225,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
 
-      - name: 🏗️ Push Monorepo Docker image
+      - name: 🏗️ Push Monorepo Docker image to ECR
         if: matrix.environment == 'production'
         run: |
-          docker push ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
+          docker pull ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
+          docker tag ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }} ${{ env.ECR_IMAGE }}:${{ env.DOCKER_TAG }}
+          docker push ${{ env.ECR_IMAGE }}:${{ env.DOCKER_TAG }}
 
       - name: 🚀 Deploy Changes
         run: |

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -76,11 +76,14 @@ jobs:
           echo "DOCKER_TAG=$DOCKER_TAG" >> $GITHUB_ENV
           echo "MONOREPO_IMAGE=${{ env.ECR_REGISTRY }}/monorepo" >> $GITHUB_ENV
           echo "CACHE_IMAGE=${{ env.ECR_REGISTRY }}/monorepo:buildcache" >> $GITHUB_ENV
+          echo "BRANCH_CACHE=${{ env.ECR_REGISTRY }}/monorepo:buildcache-${BRANCH_NAME}" >> $GITHUB_ENV
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Build Monorepo Image — pull cache from ECR, push only on main to minimize egress costs
+      # Build Monorepo Image with ECR layer caching
+      # - Pull from main's cache (shared) + branch-specific cache
+      # - Only push cache on main to minimize egress costs
       - name: 🏗️ Build Monorepo Docker image
         uses: docker/build-push-action@v7
         with:
@@ -88,8 +91,10 @@ jobs:
           load: true
           tags: |
             ${{ env.MONOREPO_IMAGE }}:${{ env.DOCKER_TAG }}
-          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}
-          cache-to: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('type=registry,ref={0},mode=max', env.CACHE_IMAGE) || '' }}
+          cache-from: |
+            type=registry,ref=${{ env.CACHE_IMAGE }}-main
+            type=registry,ref=${{ env.BRANCH_CACHE }}
+          cache-to: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('type=registry,ref={0}-main,mode=max', env.CACHE_IMAGE) || '' }}
 
       - name: 🔑 Prep Container Permissions
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,23 +32,30 @@ RUN --mount=type=cache,target=/var/lib/apt/lists --mount=target=/var/cache/apt,t
 
 # Pin due to: https://github.com/aws/aws-cli/issues/8320
 ENV AWS_CLI_VERSION=2.33.14
-RUN ARCH=$(uname -m) && \
-  if [ "$ARCH" = "x86_64" ]; then \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
-  elif [ "$ARCH" = "aarch64" ]; then \
-    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip"; \
-  else \
-    echo "Unsupported architecture: $ARCH" && exit 1; \
-  fi && \
-  unzip awscliv2.zip && \
-  ./aws/install && \
-  rm -rf awscliv2.zip aws
+RUN --mount=type=cache,target=/var/cache/awscli \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+      aws_url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+      aws_url="https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWS_CLI_VERSION}.zip"; \
+    else \
+      echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    cache_zip="/var/cache/awscli/awscliv2-${AWS_CLI_VERSION}.zip" && \
+    if [ ! -f "$cache_zip" ]; then \
+      curl -fsSL "$aws_url" -o "$cache_zip"; \
+    fi && \
+    cp "$cache_zip" awscliv2.zip && \
+    unzip -q awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip aws
 
 # Install Node
 # https://github.com/nodejs/docker-node/blob/3ac814a0a3470b195cb15530adcc3793c8268730/22/bullseye/Dockerfile
 ENV NODE_VERSION=22.21.1
 
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+RUN --mount=type=cache,target=/var/cache/nodejs \
+    ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
     amd64) ARCH='x64';; \
     ppc64el) ARCH='ppc64le';; \
@@ -75,14 +82,21 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
       { gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" && gpg --batch --fingerprint "$key"; } || \
       { gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" && gpg --batch --fingerprint "$key"; } ; \
   done \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && tarball="node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+  && cache_tar="/var/cache/nodejs/$tarball" \
+  && if [ ! -f "$cache_tar" ]; then \
+       curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/$tarball" \
+       && cp "$tarball" "$cache_tar"; \
+     else \
+       cp "$cache_tar" "$tarball"; \
+     fi \
   && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
   && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
   && gpgconf --kill all \
   && rm -rf "$GNUPGHOME" \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && grep " $tarball\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "$tarball" -C /usr/local --strip-components=1 --no-same-owner \
+  && rm "$tarball" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs \
   # smoke tests
   && node --version \
@@ -93,7 +107,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
 RUN npm install -g eas-cli@20.5.1
 
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-RUN corepack enable
 
 # Python - uv (pinned version)
 COPY --from=ghcr.io/astral-sh/uv:0.11.23 /uv /uvx /usr/local/bin/
@@ -157,6 +170,6 @@ RUN --mount=type=cache,uid=1000,gid=1000,target=/workspace/.yarn/cache \
 
 # Production Build
 FROM base AS production
-COPY --from=uv-stage /workspace /workspace
-COPY --from=yarn /workspace /workspace
+COPY --from=uv-stage --link /workspace /workspace
+COPY --from=yarn --link /workspace /workspace
 COPY --chown=betterangels . /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists --mount=target=/var/cache/apt,t
       zip \
       libpq5 \
       gdal-bin
-ENV PATH=/workspace/.venv/bin:$PATH:$HOME/.local/bin
+ENV PATH=/workspace/.venv/bin:$PATH:/home/betterangels/.local/bin
 RUN mkdir -p /workspace/.venv && mkdir -p /workspace/node_modules /home/betterangels \
     && chown -R betterangels:betterangels /workspace /home/betterangels
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,7 @@ RUN --mount=type=cache,target=/var/cache/nodejs \
 RUN npm install -g eas-cli@20.5.1
 
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
 
 # Python - uv (pinned version)
 COPY --from=ghcr.io/astral-sh/uv:0.11.23 /uv /uvx /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN ARCH=$(uname -m) && \
   fi && \
   unzip awscliv2.zip && \
   ./aws/install && \
-  rm awscliv2.zip
+  rm -rf awscliv2.zip aws
 
 # Install Node
 # https://github.com/nodejs/docker-node/blob/3ac814a0a3470b195cb15530adcc3793c8268730/22/bullseye/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ RUN --mount=type=cache,target=/var/lib/apt/lists --mount=target=/var/cache/apt,t
     && chmod a+r /etc/apt/keyrings/docker.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update \
-    && apt-get install -y \
-      docker-ce \
+    && apt-get install -y --no-install-recommends \
       docker-ce-cli \
-      containerd.io \
       docker-buildx-plugin \
     && docker --version
 


### PR DESCRIPTION
## Summary

Slims the Docker image and switches from GitHub Actions cache to ECR for layer caching.

## Docker image slimming (~300MB smaller)
- Replace `docker-ce` with just `docker-ce-cli` (host provides daemon via socket)
- Add `--mount=type=cache` for AWS CLI and Node.js downloads (cache 180MB between builds)
- Add `--link` to production COPY commands for parallel stage copies
- Fix undefined \`\$HOME\` variable in ENV PATH

## CI improvements
- Upgrade to `docker/setup-buildx-action@v4` and `docker/build-push-action@v7`
- Switch cache backend from GHA (10GB limit, no eviction) to ECR (unlimited, faster)
- Branch-scoped cache tags — PRs read from main's cache + own branch, write to own branch
- Main pushes additionally update the shared cache

## Cache strategy
| Event | Reads from | Writes to |
|---|---|---|
| PR push | main cache + own branch | Own branch only |
| Main push | main cache + own branch | Own branch + main cache |

`mode=max` is used — only changed layers are uploaded, costing ~\$0.05 per main push.