### PR TITLE
fix: re-apply Catalyst weak-link WidgetKit/ActivityKit flags

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.2.5',
+    version: '1.2.6',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,18 +34,13 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.2.5',
+      buildNumber: '1.2.6',
       associatedDomains: [`applinks:${HOSTNAME}`],
       config: {
         usesNonExemptEncryption: false,
       },
       infoPlist: {
         UIDesignRequiresCompatibility: true,
-        // Prevent install on macOS < 14.2 via Catalyst ("Designed for iPad").
-        // The iOSSupport WidgetKit on older macOS lacks activityBackgroundTint,
-        // causing a dyld crash at launch. Bumping LSMinimumSystemVersion avoids
-        // the crash without needing fragile weak-linking flags.
-        LSMinimumSystemVersion: '14.2',
       },
     },
     android: {
@@ -75,7 +70,7 @@ export default {
         },
       ],
       config: {},
-      versionCode: 79,
+      versionCode: 80,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',
@@ -90,6 +85,17 @@ export default {
         {
           ios: {
             deploymentTarget: '16.4',
+            // Weak-link WidgetKit and ActivityKit to prevent dyld crash at launch
+            // on macOS < 14.2 when running as "Designed for iPad" (Catalyst).
+            // The activityBackgroundTint symbol from WidgetKit is pulled in
+            // transitively by Expo native dependencies but doesn't exist in the
+            // iOSSupport WidgetKit on macOS 14.1 and earlier. Weak-linking tells
+            // dyld to treat missing symbols as NULL instead of aborting.
+            // See: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html
+            extraIosProps: {
+              OTHER_LDFLAGS:
+                '$(inherited) -weak_framework WidgetKit -weak_framework ActivityKit',
+            },
           },
         },
       ],


### PR DESCRIPTION
## Summary

Re-applies the `-weak_framework WidgetKit -weak_framework ActivityKit` linker flags that were originally added in #2269 and reverted in #2273.

## Why

On macOS < 14.2, when running the iOS app as "Designed for iPad" (Catalyst), the iOSSupport WidgetKit framework lacks the `activityBackgroundTint` symbol (pulled in transitively by Expo native deps). This causes a dyld crash at launch. Weak-linking tells dyld to treat missing symbols as NULL instead of aborting.

## What happened with #2273

The weak-link flags were incorrectly blamed for an iOS Simulator dyld crash. That crash was a separate local build environment issue — the security fix (#2238) did not change any Expo package versions in `yarn.lock`.

## Changes

| File | Change |
|---|---|
| `apps/betterangels/app.config.js` | Re-apply `extraIosProps` with weak framework flags; remove `LSMinimumSystemVersion` |
| Version | `1.2.5` → `1.2.6` |
| iOS buildNumber | `1.2.5` → `1.2.6` |
| Android versionCode | `79` → `80` |

Reverts the revert in #2273. Restores fix for BACS-97.