### PR TITLE
fix: sync auth.Group permissions for non-registry templates like Global Shelter Operator

### DIFF
--- a/apps/betterangels-backend/accounts/migrations/0003_consolidate_shelter_operator.py
+++ b/apps/betterangels-backend/accounts/migrations/0003_consolidate_shelter_operator.py
@@ -23,6 +23,14 @@ def migrate_to_global_shelter_operator(apps, schema_editor):
     PermissionGroup = apps.get_model("accounts", "PermissionGroup")
     PermissionGroupTemplate = apps.get_model("accounts", "PermissionGroupTemplate")
 
+    # Always ensure the template exists — needed even on fresh installs
+    # (seed_permission_templates fills its permissions on post_migrate).
+    new_template, created = PermissionGroupTemplate.objects.get_or_create(
+        name="Global Shelter Operator",
+    )
+    if created:
+        logger.info("Created PermissionGroupTemplate: Global Shelter Operator")
+
     old_groups = Group.objects.filter(name__in=OLD_GROUP_NAMES)
     if not old_groups.exists():
         return
@@ -35,12 +43,6 @@ def migrate_to_global_shelter_operator(apps, schema_editor):
     if not users_in_old:
         old_groups.delete()
         return
-
-    new_template, created = PermissionGroupTemplate.objects.get_or_create(
-        name="Global Shelter Operator",
-    )
-    if created:
-        logger.info("Created PermissionGroupTemplate: Global Shelter Operator")
 
     # Collect unique users across both old groups to avoid double-processing
     # users who belong to both "Shelter Data Entry" and "Shelter Administration".

--- a/apps/betterangels-backend/accounts/seed.py
+++ b/apps/betterangels-backend/accounts/seed.py
@@ -25,63 +25,70 @@ logger = getLogger(__name__)
 ALL_TEMPLATES = (CASEWORKER, ORG_ADMIN, ORG_SUPERUSER, GLOBAL_SHELTER_OPERATOR, SHELTER_OPERATOR)
 
 
-def _resolve_permissions(
-    permission_strings: list[str],
-) -> list[Permission]:
-    """Resolve ``'app_label.codename'`` strings to Permission objects.
+def _resolve_permissions(permission_strings: list[str]) -> list[int]:
+    """Resolve ``'app_label.codename'`` strings to Permission primary keys.
 
-    Creates missing Permission / ContentType rows in the process, so this
-    works both with and without ``--no-migrations``.
+    Uses ``ignore_conflicts=True`` so that existing rows are a no-op.
+    Returns IDs in the same order as *permission_strings* so callers
+    can compare against existing sets.  No Permission objects are
+    instantiated — pure ID-based.
     """
-    resolved: list[Permission] = []
-    for perm_str in permission_strings:
-        app_label, codename = perm_str.split(".", 1)
-        # Infer model name from codename: "view_shelter" → "shelter"
-        model_name = codename.rsplit("_", 1)[-1]
-        ct, _ = ContentType.objects.get_or_create(
-            app_label=app_label,
-            model=model_name,
-        )
-        perm, _ = Permission.objects.get_or_create(
-            codename=codename,
-            content_type=ct,
-            defaults={"name": codename.replace("_", " ").title()},
-        )
-        resolved.append(perm)
-    return resolved
+    parsed = [(ps.split(".", 1)[0], ps.split(".", 1)[1]) for ps in permission_strings]
+    app_labels = {a for a, _ in parsed}
+    codenames = {c for _, c in parsed}
+    model_of: dict[tuple[str, str], str] = {(a, c): c.rsplit("_", 1)[-1] for a, c in parsed}
+
+    ContentType.objects.bulk_create(
+        [ContentType(app_label=a, model=m) for a, m in {(a, model_of[(a, c)]) for a, c in parsed}],
+        ignore_conflicts=True,
+    )
+
+    ct_lookup = {
+        (ct.app_label, ct.model): ct
+        for ct in ContentType.objects.filter(app_label__in=app_labels, model__in=set(model_of.values()))
+    }
+
+    Permission.objects.bulk_create(
+        [
+            Permission(codename=c, content_type=ct_lookup[(a, model_of[(a, c)])], name=c.replace("_", " ").title())
+            for a, c in parsed
+        ],
+        ignore_conflicts=True,
+    )
+
+    id_lookup: dict[tuple[str, str], int] = {
+        (a, c): pk
+        for a, c, pk in Permission.objects.filter(
+            content_type__app_label__in=app_labels, codename__in=codenames
+        ).values_list("content_type__app_label", "codename", "pk")
+    }
+    return [id_lookup[(a, c)] for a, c in parsed]
 
 
 def _seed_template(template_config: TemplateConfig) -> None:
     """Create or update a PermissionGroupTemplate with its configured permissions."""
     name = template_config.name
-    permissions = template_config.permissions
 
     template, created = PermissionGroupTemplate.objects.get_or_create(name=name)
     if created:
         logger.info("Created PermissionGroupTemplate: %s", name)
 
-    perm_objects = _resolve_permissions(permissions)
-    existing = set(template.permissions.values_list("id", flat=True))
-    wanted = {p.pk for p in perm_objects}
-    if existing != wanted:
-        template.permissions.set(perm_objects)
-        logger.info(
-            "Updated PermissionGroupTemplate permissions: %s (%d perms)",
-            name,
-            len(perm_objects),
-        )
+    wanted_ids = _resolve_permissions(template_config.permissions)
+    existing_ids = set(template.permissions.values_list("id", flat=True))
+    if set(wanted_ids) != existing_ids:
+        template.permissions.set(wanted_ids)
+        logger.info("Updated PermissionGroupTemplate permissions: %s (%d perms)", name, len(wanted_ids))
 
 
 def seed_permission_templates() -> None:
     """Ensure all PermissionGroupTemplates exist with correct permissions.
 
     Idempotent — safe to call on every ``migrate`` / test session start.
+    Always iterates through every template so that permissions are
+    re-synced when a data migration creates a template without
+    permissions (e.g. the consolidation migration that moves users
+    into ``Global Shelter Operator``).  ``_seed_template`` is itself
+    idempotent and only issues writes when the permission set differs.
     """
-    # Skip if already seeded — avoids individual permission resolution queries.
-    expected_names = {t.name for t in ALL_TEMPLATES}
-    existing_names = set(PermissionGroupTemplate.objects.filter(name__in=expected_names).values_list("name", flat=True))
-    if existing_names == expected_names:
-        return
-
     for template_config in ALL_TEMPLATES:
         _seed_template(template_config)

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -137,28 +137,70 @@ def sync_all_org_permission_groups(sender: object, **kwargs: object) -> None:
 
 
 def _sync_template_permissions() -> None:
-    """Sync Django Group.permissions for all registered templates."""
+    """Sync Django Group.permissions for every PermissionGroupTemplate.
+
+    Templates registered in the ``REGISTRY`` are refreshed from their
+    ``TemplateConfig.permissions`` definition.  Non-registry templates
+    (e.g. ``Global Shelter Operator``) are refreshed from the
+    ``ALL_TEMPLATES`` list in ``accounts.seed`` — so that permission
+    changes to ANY template are picked up on the next ``post_migrate``.
+    """
     from common.org_types import REGISTRY
     from django.contrib.auth.models import Permission
-    from django.db.models import Q
 
-    template_names = REGISTRY.template_names()
+    from accounts.seed import ALL_TEMPLATES
+
+    configs: dict[str, list[tuple[str, str]]] = {}
+    app_labels: set[str] = set()
+    codenames: set[str] = set()
+
+    def _add(name: str, perms: list[str]) -> None:
+        parsed = [(ps.split(".", 1)[0], ps.split(".", 1)[1]) for ps in perms]
+        configs[name] = parsed
+        for a, c in parsed:
+            app_labels.add(a)
+            codenames.add(c)
+
+    for name in REGISTRY.template_names():
+        if cfg := REGISTRY.template(name):
+            _add(name, cfg.permissions or [])
+    for tc in ALL_TEMPLATES:
+        if tc.name not in configs:
+            _add(tc.name, tc.permissions or [])
+
+    if not app_labels:
+        return
+
+    # ── Resolve all permissions in one query (no object instantiation) ──
+    all_perm_ids: dict[tuple[str, str], int] = {
+        (a, c): pk
+        for a, c, pk in Permission.objects.filter(
+            content_type__app_label__in=app_labels, codename__in=codenames
+        ).values_list("content_type__app_label", "codename", "pk")
+    }
+
+    # ── Pre-compute wanted IDs per template ──
+    wanted_by_template: dict[str, set[int]] = {
+        name: {all_perm_ids[k] for k in perms if k in all_perm_ids} for name, perms in configs.items()
+    }
+
     with transaction.atomic():
-        templates = PermissionGroupTemplate.objects.filter(name__in=template_names).prefetch_related(
-            "permissions", "permissiongroup_set__group"
+        # Prefetch permissions so .all() calls hit the cache, not the DB.
+        templates = PermissionGroupTemplate.objects.prefetch_related(
+            "permissions", "permissiongroup_set__group__permissions"
         )
 
         for template_db in templates:
-            # Sync template permissions from REGISTRY definition → DB.
-            template_config = REGISTRY.template(template_db.name)
-            if template_config and template_config.permissions:
-                perm_filters = Q()
-                for perm_str in template_config.permissions:
-                    app_label, codename = perm_str.split(".", 1)
-                    perm_filters |= Q(codename=codename, content_type__app_label=app_label)
-                template_db.permissions.set(Permission.objects.filter(perm_filters))
+            # Compute existing IDs once (uses prefetch).
+            existing_ids = {p.pk for p in template_db.permissions.all()}
 
-            # Sync group permissions from template → groups.
-            perms = list(template_db.permissions.all())
+            # Sync template perms from config.
+            if (wanted := wanted_by_template.get(template_db.name)) is not None and wanted != existing_ids:
+                template_db.permissions.set(wanted)
+                existing_ids = wanted
+
+            # Sync group perms from template.  All prefetched — no queries.
             for pgt in template_db.permissiongroup_set.all():
-                pgt.group.permissions.set(perms)
+                group_ids = {p.pk for p in pgt.group.permissions.all()}
+                if existing_ids != group_ids:
+                    pgt.group.permissions.set(existing_ids)

--- a/apps/betterangels-backend/shelters/tests/test_group_permissions.py
+++ b/apps/betterangels-backend/shelters/tests/test_group_permissions.py
@@ -1,7 +1,11 @@
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 
-from accounts.models import PermissionGroupTemplate
+from accounts.models import PermissionGroup, PermissionGroupTemplate, User
+from accounts.seed import seed_permission_templates
+from accounts.signals import _sync_template_permissions
+from model_bakery import baker
+from organizations.models import Organization
 
 
 class ShelterGroupPermissionsTestCase(TestCase):
@@ -50,4 +54,138 @@ class ShelterGroupPermissionsTestCase(TestCase):
                 content_type__app_label="shelters",
                 codename="view_private_shelter",
             ).exists()
+        )
+
+    def test_global_shelter_operator_group_gets_permissions(self) -> None:
+        """
+        A PermissionGroup using the Global Shelter Operator template must
+        result in an auth.Group with the correct permissions — even when the
+        template is NOT registered in the REGISTRY.
+
+        This simulates the real-world migration scenario:
+        1. Consolidation migration creates the template (empty perms).
+        2. Migration creates PermissionGroups → auth.Groups get empty perms.
+        3. post_migrate: seed_permission_templates fills template perms.
+        4. post_migrate: _sync_template_permissions syncs auth.Group perms.
+        """
+        org = Organization.objects.create(name="Test Shelter Org")
+        template = PermissionGroupTemplate.objects.get(name="Global Shelter Operator")
+
+        # ── Step 1 & 2: Simulate post-migration state ──
+        # Template permissions are empty (migration created it without perms).
+        template.permissions.clear()
+        self.assertEqual(template.permissions.count(), 0)
+
+        # Create a PermissionGroup — PermissionGroup.save() copies the
+        # (empty) template permissions into a new auth.Group.
+        pg = PermissionGroup.objects.create(
+            organization=org,
+            template=template,
+            name=template.name,
+        )
+        auth_group = pg.group
+        self.assertEqual(auth_group.permissions.count(), 0)
+
+        # ── Step 3: Seed template permissions ──
+        seed_permission_templates()
+        template.refresh_from_db()
+        self.assertGreater(
+            template.permissions.count(),
+            0,
+            "Template must have permissions after seeding.",
+        )
+
+        # ── Step 4: Sync auth.Group permissions ──
+        _sync_template_permissions()
+        auth_group.refresh_from_db()
+
+        # The group must now have shelter permissions.
+        self.assertTrue(
+            auth_group.permissions.filter(
+                content_type__app_label="shelters",
+                codename="view_shelter",
+            ).exists(),
+            "auth.Group must have view_shelter after sync.",
+        )
+        self.assertTrue(
+            auth_group.permissions.filter(
+                content_type__app_label="shelters",
+                codename="change_shelter",
+            ).exists(),
+            "auth.Group must have change_shelter after sync.",
+        )
+
+        # ── Step 5: Verify idempotency ──
+        permissions_count_before = auth_group.permissions.count()
+        _sync_template_permissions()
+        auth_group.refresh_from_db()
+        self.assertEqual(
+            auth_group.permissions.count(),
+            permissions_count_before,
+            "Syncing template permissions must be idempotent — a second sync should not change the permission count.",
+        )
+        self.assertTrue(
+            auth_group.permissions.filter(
+                content_type__app_label="shelters",
+                codename="view_shelter",
+            ).exists(),
+            "auth.Group must still have view_shelter after a second sync.",
+        )
+        self.assertTrue(
+            auth_group.permissions.filter(
+                content_type__app_label="shelters",
+                codename="change_shelter",
+            ).exists(),
+            "auth.Group must still have change_shelter after a second sync.",
+        )
+
+    def test_global_shelter_operator_admin_module_permission(self) -> None:
+        """
+        A user assigned to a Global Shelter Operator PermissionGroup must
+        be able to see the Shelters admin module (has_module_permission).
+
+        This simulates the real-world scenario where:
+        1. Migration creates template + PermissionGroup (empty perms).
+        2. post_migrate seeds template perms and syncs group perms.
+        3. User should then see the Shelters tab in Django Admin.
+        """
+        org = Organization.objects.create(name="GSO Admin Org")
+        user = baker.make(User, email="khady@example.com", is_staff=True)
+
+        # Simulate migration: template exists but perms are empty.
+        template = PermissionGroupTemplate.objects.get(name="Global Shelter Operator")
+        template.permissions.clear()
+
+        # Create PermissionGroup with empty template (migration does this).
+        pg = PermissionGroup.objects.create(
+            organization=org,
+            template=template,
+            name=template.name,
+        )
+        pg.group.user_set.add(user)
+
+        # User should NOT have shelter perms yet (simulates broken state).
+        user_perms = user.get_all_permissions()
+        self.assertNotIn("shelters.view_shelter", user_perms)
+
+        # Now run the fix: seed + sync.
+        seed_permission_templates()
+        _sync_template_permissions()
+
+        # Re-fetch user to bypass Django's cached permission set
+        # (get_all_permissions caches in _perm_cache).
+        user = User.objects.get(pk=user.pk)
+        user_perms = user.get_all_permissions()
+        self.assertIn("shelters.view_shelter", user_perms)
+        self.assertIn("shelters.change_shelter", user_perms)
+
+        # Verify Django admin module permission via the standard
+        # user.has_module_perms() / user.has_perm() API.
+        self.assertTrue(
+            user.has_module_perms("shelters"),
+            "User with Global Shelter Operator must have module permission for Shelters admin.",
+        )
+        self.assertTrue(
+            user.has_perm("shelters.view_shelter"),
+            "User with Global Shelter Operator must have view_shelter permission.",
         )


### PR DESCRIPTION
The consolidation migration (0003_consolidate_shelter_operator.py) creates the Global Shelter Operator PermissionGroupTemplate without permissions, and then creates PermissionGroups whose auth.Groups inherit those empty permissions.  After post_migrate, seed_permission_templates fills the template permissions, but _sync_template_permissions only synced auth.Group permissions for templates registered in the REGISTRY — which excluded Global Shelter Operator.

Two fixes:
1. seed_permission_templates: remove the early-return short-circuit so that it always re-syncs template permissions (not just when templates are missing).  Individual _seed_template calls are idempotent.
2. _sync_template_permissions: query ALL PermissionGroupTemplates (not just registry ones) so that non-registry templates like Global Shelter Operator get their auth.Group permissions synced.

Tests added:
- Seeds permissions for existing template (post-migration simulation)
- Group gets permissions after seed+sync cycle
- User has admin module permission after seed+sync cycle

## Summary by Sourcery

Ensure permission templates and auth groups stay in sync for registry and non-registry templates, including Global Shelter Operator, and add regression coverage.

Bug Fixes:
- Fix missing permissions on auth.Groups created from non-registry PermissionGroupTemplates such as Global Shelter Operator by syncing all templates, not only those in the registry.
- Ensure seeding permission templates always re-syncs permissions so templates created by data migrations receive the correct permission sets.

Tests:
- Add tests simulating post-migration scenarios to verify Global Shelter Operator groups receive shelter permissions after seed and sync.
- Add tests to confirm users in Global Shelter Operator groups gain the expected shelter and admin module permissions after the seed+sync cycle.