### PR TITLE
[BP] - create json exporter for report

### DIFF
--- a/apps/betterangels-backend/reports/export_to_json.py
+++ b/apps/betterangels-backend/reports/export_to_json.py
@@ -1,0 +1,70 @@
+"""JSON exporter for shelter reporting metrics."""
+
+import json
+
+from shelters.types.reporting import ShelterOccupancyMetricsType
+
+from .export_options import MetricsExportOptions
+
+
+def metrics_to_json(metrics: ShelterOccupancyMetricsType, options: list[MetricsExportOptions]) -> tuple[str, str]:
+    """Serialize selected shelter metrics into one date-keyed report file."""
+    selected_options = set(options)
+    invalid_options = selected_options - set(MetricsExportOptions)
+    if invalid_options:
+        raise ValueError(f"Unknown metric export options: {', '.join(sorted(map(str, invalid_options)))}")
+    if not selected_options:
+        raise ValueError("At least one metric export option must be selected")
+
+    shelter_id = str(metrics.shelter_id)
+    start_date = metrics.start_date
+    end_date = metrics.end_date
+    date_range = f"{start_date.isoformat()}_{end_date.isoformat()}"
+    report: dict[str, object] = {}
+
+    if MetricsExportOptions.DAILY_OCCUPANCY_METRICS in selected_options:
+        report[MetricsExportOptions.DAILY_OCCUPANCY_METRICS] = {
+            metric.date.isoformat(): {
+                "shelter_id": shelter_id,
+                "occupied_count": metric.occupied_count,
+                "total_beds": metric.total_beds,
+                "occupancy_pct": metric.occupancy_pct,
+            }
+            for metric in metrics.daily_occupancy
+        }
+
+    if MetricsExportOptions.DAILY_BED_STATUS_METRICS in selected_options:
+        report[MetricsExportOptions.DAILY_BED_STATUS_METRICS] = {
+            metric.date.isoformat(): {
+                "shelter_id": shelter_id,
+                "available": metric.available,
+                "occupied": metric.occupied,
+                "reserved": metric.reserved,
+                "out_of_service": metric.out_of_service,
+                "in_turnaround": metric.in_turnaround,
+            }
+            for metric in metrics.daily_bed_status
+        }
+
+    if MetricsExportOptions.RESERVATION_METRICS in selected_options:
+        reservation_metrics = metrics.reservation_metrics
+        report[MetricsExportOptions.RESERVATION_METRICS] = {
+            date_range: {
+                "shelter_id": shelter_id,
+                "check_in_overdue": reservation_metrics.check_in_overdue,
+                "cancelled": reservation_metrics.cancelled,
+                "checked_in": reservation_metrics.checked_in,
+                "check_in_overdue_to_checked_in": reservation_metrics.check_in_overdue_to_checked_in,
+            }
+        }
+
+    if MetricsExportOptions.AVG_DAYS_TO_OCCUPANCY in selected_options:
+        report[MetricsExportOptions.AVG_DAYS_TO_OCCUPANCY] = {
+            date_range: {
+                "shelter_id": shelter_id,
+                "avg_days_to_occupancy": metrics.avg_days_to_occupancy,
+            }
+        }
+
+    filename = f"{start_date.strftime('%Y%m%d')}_{end_date.strftime('%Y%m%d')}_shelter_report.json"
+    return filename, json.dumps({"report": report}, indent=2)

--- a/apps/betterangels-backend/reports/export_to_json.py
+++ b/apps/betterangels-backend/reports/export_to_json.py
@@ -20,7 +20,7 @@ def metrics_to_json(metrics: ShelterOccupancyMetricsType, options: list[MetricsE
     start_date = metrics.start_date
     end_date = metrics.end_date
     date_range = f"{start_date.isoformat()}_{end_date.isoformat()}"
-    report: dict[str, object] = {}
+    report: dict[str, object] = {"shelter_id": shelter_id}
 
     if MetricsExportOptions.DAILY_OCCUPANCY_METRICS in selected_options:
         report[MetricsExportOptions.DAILY_OCCUPANCY_METRICS] = {
@@ -63,4 +63,4 @@ def metrics_to_json(metrics: ShelterOccupancyMetricsType, options: list[MetricsE
         }
 
     filename = f"{start_date.strftime('%Y%m%d')}_{end_date.strftime('%Y%m%d')}_shelter_report.json"
-    return filename, json.dumps({f"{shelter_id}_report": report}, indent=2)
+    return filename, json.dumps({"report": report}, indent=2)

--- a/apps/betterangels-backend/reports/export_to_json.py
+++ b/apps/betterangels-backend/reports/export_to_json.py
@@ -25,7 +25,6 @@ def metrics_to_json(metrics: ShelterOccupancyMetricsType, options: list[MetricsE
     if MetricsExportOptions.DAILY_OCCUPANCY_METRICS in selected_options:
         report[MetricsExportOptions.DAILY_OCCUPANCY_METRICS] = {
             metric.date.isoformat(): {
-                "shelter_id": shelter_id,
                 "occupied_count": metric.occupied_count,
                 "total_beds": metric.total_beds,
                 "occupancy_pct": metric.occupancy_pct,
@@ -36,7 +35,6 @@ def metrics_to_json(metrics: ShelterOccupancyMetricsType, options: list[MetricsE
     if MetricsExportOptions.DAILY_BED_STATUS_METRICS in selected_options:
         report[MetricsExportOptions.DAILY_BED_STATUS_METRICS] = {
             metric.date.isoformat(): {
-                "shelter_id": shelter_id,
                 "available": metric.available,
                 "occupied": metric.occupied,
                 "reserved": metric.reserved,
@@ -50,7 +48,6 @@ def metrics_to_json(metrics: ShelterOccupancyMetricsType, options: list[MetricsE
         reservation_metrics = metrics.reservation_metrics
         report[MetricsExportOptions.RESERVATION_METRICS] = {
             date_range: {
-                "shelter_id": shelter_id,
                 "check_in_overdue": reservation_metrics.check_in_overdue,
                 "cancelled": reservation_metrics.cancelled,
                 "checked_in": reservation_metrics.checked_in,
@@ -61,10 +58,9 @@ def metrics_to_json(metrics: ShelterOccupancyMetricsType, options: list[MetricsE
     if MetricsExportOptions.AVG_DAYS_TO_OCCUPANCY in selected_options:
         report[MetricsExportOptions.AVG_DAYS_TO_OCCUPANCY] = {
             date_range: {
-                "shelter_id": shelter_id,
                 "avg_days_to_occupancy": metrics.avg_days_to_occupancy,
             }
         }
 
     filename = f"{start_date.strftime('%Y%m%d')}_{end_date.strftime('%Y%m%d')}_shelter_report.json"
-    return filename, json.dumps({"report": report}, indent=2)
+    return filename, json.dumps({f"{shelter_id}_report": report}, indent=2)

--- a/apps/betterangels-backend/reports/tests/test_exporters.py
+++ b/apps/betterangels-backend/reports/tests/test_exporters.py
@@ -1,6 +1,7 @@
 """Tests for report data export."""
 
 import csv
+import json
 import zipfile
 from datetime import date
 from io import BytesIO, StringIO
@@ -29,6 +30,7 @@ from reports.export_to_csv import (
     reservation_metrics_to_csv,
     rows_to_csv,
 )
+from reports.export_to_json import metrics_to_json
 from reports.export_to_xlsx import metrics_to_xlsx
 
 
@@ -388,6 +390,73 @@ class TestShelterMetricsExport:
     def test_metrics_to_xlsx_rejects_unknown_options(self) -> None:
         with pytest.raises(ValueError, match="unknown_metric"):
             metrics_to_xlsx(
+                _shelter_occupancy_metrics(),
+                [MetricsExportOptions.DAILY_OCCUPANCY_METRICS, cast(MetricsExportOptions, "unknown_metric")],
+            )
+
+    def test_metrics_to_json_exports_selected_metrics_as_date_keyed_report(self) -> None:
+        filename, json_content = metrics_to_json(
+            _shelter_occupancy_metrics(),
+            _all_metric_export_options(),
+        )
+
+        assert filename == "20260601_20260630_shelter_report.json"
+        assert json.loads(json_content) == {
+            "report": {
+                "daily_occupancy_metrics": {
+                    "2026-06-01": {
+                        "shelter_id": "shelter-1",
+                        "occupied_count": 8,
+                        "total_beds": 10,
+                        "occupancy_pct": 80.0,
+                    }
+                },
+                "daily_bed_status_metrics": {
+                    "2026-06-01": {
+                        "shelter_id": "shelter-1",
+                        "available": 2,
+                        "occupied": 8,
+                        "reserved": 1,
+                        "out_of_service": 0,
+                        "in_turnaround": 0,
+                    }
+                },
+                "reservation_metrics": {
+                    "2026-06-01_2026-06-30": {
+                        "shelter_id": "shelter-1",
+                        "check_in_overdue": 3,
+                        "cancelled": 2,
+                        "checked_in": 11,
+                        "check_in_overdue_to_checked_in": 1,
+                    }
+                },
+                "avg_days_to_occupancy": {
+                    "2026-06-01_2026-06-30": {
+                        "shelter_id": "shelter-1",
+                        "avg_days_to_occupancy": 4.5,
+                    }
+                },
+            }
+        }
+
+    def test_metrics_to_json_exports_only_selected_metrics(self) -> None:
+        _, json_content = metrics_to_json(
+            _shelter_occupancy_metrics(),
+            [MetricsExportOptions.DAILY_OCCUPANCY_METRICS, MetricsExportOptions.RESERVATION_METRICS],
+        )
+
+        assert json.loads(json_content)["report"].keys() == {
+            "daily_occupancy_metrics",
+            "reservation_metrics",
+        }
+
+    def test_metrics_to_json_rejects_empty_options(self) -> None:
+        with pytest.raises(ValueError, match="At least one"):
+            metrics_to_json(_shelter_occupancy_metrics(), [])
+
+    def test_metrics_to_json_rejects_unknown_options(self) -> None:
+        with pytest.raises(ValueError, match="unknown_metric"):
+            metrics_to_json(
                 _shelter_occupancy_metrics(),
                 [MetricsExportOptions.DAILY_OCCUPANCY_METRICS, cast(MetricsExportOptions, "unknown_metric")],
             )

--- a/apps/betterangels-backend/reports/tests/test_exporters.py
+++ b/apps/betterangels-backend/reports/tests/test_exporters.py
@@ -402,10 +402,9 @@ class TestShelterMetricsExport:
 
         assert filename == "20260601_20260630_shelter_report.json"
         assert json.loads(json_content) == {
-            "report": {
+            "shelter-1_report": {
                 "daily_occupancy_metrics": {
                     "2026-06-01": {
-                        "shelter_id": "shelter-1",
                         "occupied_count": 8,
                         "total_beds": 10,
                         "occupancy_pct": 80.0,
@@ -413,7 +412,6 @@ class TestShelterMetricsExport:
                 },
                 "daily_bed_status_metrics": {
                     "2026-06-01": {
-                        "shelter_id": "shelter-1",
                         "available": 2,
                         "occupied": 8,
                         "reserved": 1,
@@ -423,7 +421,6 @@ class TestShelterMetricsExport:
                 },
                 "reservation_metrics": {
                     "2026-06-01_2026-06-30": {
-                        "shelter_id": "shelter-1",
                         "check_in_overdue": 3,
                         "cancelled": 2,
                         "checked_in": 11,
@@ -432,7 +429,6 @@ class TestShelterMetricsExport:
                 },
                 "avg_days_to_occupancy": {
                     "2026-06-01_2026-06-30": {
-                        "shelter_id": "shelter-1",
                         "avg_days_to_occupancy": 4.5,
                     }
                 },
@@ -445,7 +441,7 @@ class TestShelterMetricsExport:
             [MetricsExportOptions.DAILY_OCCUPANCY_METRICS, MetricsExportOptions.RESERVATION_METRICS],
         )
 
-        assert json.loads(json_content)["report"].keys() == {
+        assert json.loads(json_content)["shelter-1_report"].keys() == {
             "daily_occupancy_metrics",
             "reservation_metrics",
         }

--- a/apps/betterangels-backend/reports/tests/test_exporters.py
+++ b/apps/betterangels-backend/reports/tests/test_exporters.py
@@ -402,7 +402,8 @@ class TestShelterMetricsExport:
 
         assert filename == "20260601_20260630_shelter_report.json"
         assert json.loads(json_content) == {
-            "shelter-1_report": {
+            "report": {
+                "shelter_id": "shelter-1",
                 "daily_occupancy_metrics": {
                     "2026-06-01": {
                         "occupied_count": 8,
@@ -441,7 +442,10 @@ class TestShelterMetricsExport:
             [MetricsExportOptions.DAILY_OCCUPANCY_METRICS, MetricsExportOptions.RESERVATION_METRICS],
         )
 
-        assert json.loads(json_content)["shelter-1_report"].keys() == {
+        report = json.loads(json_content)["report"]
+        assert report["shelter_id"] == "shelter-1"
+        assert report.keys() == {
+            "shelter_id",
             "daily_occupancy_metrics",
             "reservation_metrics",
         }


### PR DESCRIPTION
## Summary by Sourcery

Add JSON export support for shelter occupancy reporting metrics and corresponding validation tests.

New Features:
- Introduce a JSON exporter that serializes selected shelter occupancy metrics into a date-keyed report file.

Tests:
- Add tests covering JSON metric export structure, option filtering, and validation for empty or unknown export options.