### PR TITLE
Turn off expo dev client tools button via config (DEV-2430)

### DIFF
--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -105,7 +105,7 @@ export default {
           toolsButton: false,
           skipOnboarding: true,
           showMenuAtLaunch: false,
-          // Seee: https://github.com/expo/expo/blob/main/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+          // See: https://github.com/expo/expo/blob/main/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
         },
       ],
       [

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -102,6 +102,10 @@ export default {
         'expo-dev-client',
         {
           launchMode: 'launcher',
+          toolsButton: false,
+          skipOnboarding: true,
+          showMenuAtLaunch: false,
+          // Seee: https://github.com/expo/expo/blob/main/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
         },
       ],
       [

--- a/apps/betterangels/app.config.js
+++ b/apps/betterangels/app.config.js
@@ -21,7 +21,7 @@ export default {
     name: IS_PRODUCTION ? 'BetterAngels' : 'BetterAngels (Dev)',
     slug: 'betterangels',
     scheme: IS_PRODUCTION ? 'betterangels' : 'betterangels-dev',
-    version: '1.2.6',
+    version: '1.2.7',
     orientation: 'portrait',
     icon: IS_PRODUCTION
       ? './src/app/assets/images/icon.png'
@@ -34,7 +34,7 @@ export default {
     ios: {
       supportsTablet: true,
       bundleIdentifier: BUNDLE_IDENTIFIER,
-      buildNumber: '1.2.6',
+      buildNumber: '1.2.7',
       associatedDomains: [`applinks:${HOSTNAME}`],
       config: {
         usesNonExemptEncryption: false,
@@ -70,7 +70,7 @@ export default {
         },
       ],
       config: {},
-      versionCode: 80,
+      versionCode: 81,
     },
     web: {
       favicon: './src/app/assets/images/favicon.png',


### PR DESCRIPTION
### Turn off expo dev client tools button via config
DEV-2430

add following settings for `expo-dev-client`:
- toolsButton: false,
-  skipOnboarding: true,
-   showMenuAtLaunch: false,

https://github.com/expo/expo/blob/main/packages/expo-dev-launcher/plugin/src/pluginConfig.ts

## Summary by Sourcery

Update BetterAngels Expo app configuration to adjust dev client behavior and bump app version metadata.

New Features:
- Configure expo-dev-client to hide the tools button, skip onboarding, and not show the menu at launch.

Enhancements:
- Increment app version, iOS build number, and Android version code for the BetterAngels app configuration.