### PR TITLE
Fix shelter sidebar scroll to not cut off bottom if expanded

### DIFF
--- a/libs/react/components/src/lib/Sidebar/Sidebar.tsx
+++ b/libs/react/components/src/lib/Sidebar/Sidebar.tsx
@@ -56,7 +56,7 @@ export function Sidebar(props: TProps) {
   const collapsedWidth = variant === 'basic' ? 'w-[0px]' : 'w-[40px]';
 
   const parentCss = [
-    'h-screen',
+    'h-full',
     'border-r',
     'border-neutral-90',
     'bg-neutral-99',

--- a/libs/react/components/src/lib/Sidebar/SidebarContent.tsx
+++ b/libs/react/components/src/lib/Sidebar/SidebarContent.tsx
@@ -10,7 +10,6 @@ export function SidebarContent(props: TProps) {
   const { className, children } = props;
 
   const parentCss = [
-    'h-full',
     'flex',
     'flex-col',
     'gap-2',


### PR DESCRIPTION
<img width="412" height="856" alt="image" src="https://github.com/user-attachments/assets/d51e2a98-e4c7-4fb5-beff-df42ad4ea810" />

Before, if the Shelter Profile dropdown was open along with Shelter Management, the reports tab at the bottom would get cut off even when scrolling all the way to the bottom. This PR makes the container large enough to scroll all the way down.

## Summary by Sourcery

Bug Fixes:
- Fix shelter sidebar scrolling so bottom items remain accessible when dropdown sections are expanded.