### PR TITLE
fix shelter migration index name

### DIFF
--- a/apps/betterangels-backend/shelters/migrations/0002_shelter_schedule_idx.py
+++ b/apps/betterangels-backend/shelters/migrations/0002_shelter_schedule_idx.py
@@ -12,6 +12,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddIndex(
             model_name='schedule',
-            index=models.Index(fields=['shelter', 'schedule_type', 'is_exception'], name='schedule_shelter_type_exception_idx'),
+            index=models.Index(fields=['shelter', 'schedule_type', 'is_exception'], name='sched_shelter_type_except_idx'),
         ),
     ]

--- a/apps/betterangels-backend/shelters/models/schedule.py
+++ b/apps/betterangels-backend/shelters/models/schedule.py
@@ -6,12 +6,12 @@ from django.db import models
 from django.db.models import Case, ExpressionWrapper, F, Q, UniqueConstraint, Value, When
 from django.db.models.functions import Cast, Coalesce, Extract, Mod, NullIf
 from django_choices_field import TextChoicesField
+
 from shelters.constants import DAILY_MINUTES
 from shelters.enums import ConditionChoices, DayOfWeekChoices, ScheduleTypeChoices
 
 from .lookups import Demographic
 from .shelter import Shelter
-
 
 # Helpers -------------------------------------------------------------------
 
@@ -166,7 +166,7 @@ class Schedule(BaseModel):
         indexes = [
             models.Index(
                 fields=["shelter", "schedule_type", "is_exception"],
-                name="schedule_shelter_type_exception_idx",
+                name="sched_shelter_type_except_idx",
             ),
         ]
         constraints = [


### PR DESCRIPTION
index name cannot exceed 30 chars. wasn't tripped when running migrations in test

## Summary by Sourcery

Bug Fixes:
- Rename the schedule index to a shorter identifier that satisfies the database's maximum index name length constraint.