### PR TITLE
fix(accounts): 500 on login-code for deactivated users; reactivate on member re-add (DEV-2516)

### DIFF
--- a/apps/betterangels-backend/accounts/backends.py
+++ b/apps/betterangels-backend/accounts/backends.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import Any, Optional
 
 from common.permissions.config import TemplateConfig
@@ -14,6 +13,7 @@ from rest_framework.request import Request
 
 from .forms import UserCreationForm
 from .models import ExtendedOrganizationInvitation, User
+from .services import get_or_create_user_by_email
 from .utils import demo_email_context
 
 
@@ -26,15 +26,10 @@ class CustomInvitations(InvitationBackend):
     def invite_by_email(
         self, email: str, sender: Optional[User] = None, request: Optional[Request] = None, **kwargs: Any
     ) -> AbstractBaseUser:
+        # Normalizes the email and reactivates previously deactivated accounts
+        # (see accounts.services.get_or_create_user_by_email).
         with transaction.atomic():
-            user, created = self.user_model.objects.get_or_create(
-                email=email,
-                defaults={"username": str(uuid.uuid4()), "is_active": True},
-            )
-            if created:
-                user.set_unusable_password()
-                user.save()
-
+            user, _ = get_or_create_user_by_email(email)
         self.send_invitation(user, sender, **kwargs)
         return user
 

--- a/apps/betterangels-backend/accounts/backends.py
+++ b/apps/betterangels-backend/accounts/backends.py
@@ -13,7 +13,7 @@ from rest_framework.request import Request
 
 from .forms import UserCreationForm
 from .models import ExtendedOrganizationInvitation, User
-from .services import get_or_create_user_by_email
+from .services import get_or_create_user_by_email, reactivate_user
 from .utils import demo_email_context
 
 
@@ -26,10 +26,11 @@ class CustomInvitations(InvitationBackend):
     def invite_by_email(
         self, email: str, sender: Optional[User] = None, request: Optional[Request] = None, **kwargs: Any
     ) -> AbstractBaseUser:
-        # Normalizes the email and reactivates previously deactivated accounts
-        # (see accounts.services.get_or_create_user_by_email).
         with transaction.atomic():
             user, _ = get_or_create_user_by_email(email)
+            # Authorized action: a re-invitation reactivates a deactivated
+            # account.
+            reactivate_user(user)
         self.send_invitation(user, sender, **kwargs)
         return user
 

--- a/apps/betterangels-backend/accounts/headless_views.py
+++ b/apps/betterangels-backend/accounts/headless_views.py
@@ -29,26 +29,27 @@ class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
         if not self.input._user:  # type: ignore[union-attr]
             email = self.input.cleaned_data.get("email")  # type: ignore[union-attr]
             if email:
-                email = email.strip().lower()
+                # get_or_create_user_by_email normalizes (strips + lowercases)
+                # the email before lookup and storage.
                 with transaction.atomic():
                     user, created = get_or_create_user_by_email(email)
                     if created:
                         # Brand-new email: auto-provision so allauth can issue a
-                        # real code.  Reuse any existing EmailAddress row
-                        # (case-insensitive) so mixed-case input can't create a
-                        # duplicate; new rows are primary and unverified.
-                        email_address = EmailAddress.objects.filter(user=user, email__iexact=email).first()
-                        if email_address is None:
-                            EmailAddress.objects.create(
-                                user=user,
-                                email=email,
-                                primary=True,
-                                verified=False,
-                            )
+                        # real code.  The user row is brand-new, so it can't own
+                        # an EmailAddress yet — create a primary, unverified one
+                        # with the normalized address.
+                        assert user.email is not None
+                        EmailAddress.objects.create(
+                            user=user,
+                            email=user.email,
+                            primary=True,
+                            verified=False,
+                        )
                         self.input._user = user  # type: ignore[union-attr]
                     elif user.is_active:
-                        # Defensive: an active account allauth didn't resolve
-                        # still gets a real code.
+                        # Defensive: allauth's form already resolves active
+                        # users case-insensitively, but if it somehow didn't,
+                        # still issue a real code.
                         self.input._user = user  # type: ignore[union-attr]
                     # else: existing-but-inactive — leave ``_user`` unset so
                     # super().post() fakes success without sending anything

--- a/apps/betterangels-backend/accounts/headless_views.py
+++ b/apps/betterangels-backend/accounts/headless_views.py
@@ -17,13 +17,12 @@ class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
     calls ``initiate(user=None, ...)`` which silently fakes success without
     sending a real code.
 
-    We override ``post()`` to provision the account and set ``self.input._user``
-    so the verification process finds it and issues a real code.  Provisioning
-    is delegated to :func:`accounts.services.get_or_create_user_by_email`, which
-    reuses an existing account — reactivating it if it was deactivated — instead
-    of creating a duplicate (which would raise a unique-constraint violation).
-    This follows allauth's subclassing pattern: ``self.input._user`` is the
-    documented protocol variable that ``RequestLoginCodeView.post()`` reads.
+    We override ``post()`` to provision brand-new emails and set
+    ``self.input._user`` so the verification process issues a real code.
+    An email that already belongs to an existing-but-deactivated account is
+    deliberately left untouched — no reactivation, no email — so an anonymous
+    request can't undo an admin's deactivation; ``super().post()`` then fakes
+    success exactly as it does for unknown accounts.
     """
 
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
@@ -32,17 +31,27 @@ class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
             if email:
                 email = email.strip().lower()
                 with transaction.atomic():
-                    user, _ = get_or_create_user_by_email(email)
-                    # Ensure allauth can resolve the address: reuse any existing
-                    # row (case-insensitive) so mixed-case input can't create a
-                    # duplicate; new rows are primary and unverified.
-                    email_address = EmailAddress.objects.filter(user=user, email__iexact=email).first()
-                    if email_address is None:
-                        EmailAddress.objects.create(
-                            user=user,
-                            email=email,
-                            primary=True,
-                            verified=False,
-                        )
-                self.input._user = user  # type: ignore[union-attr]
+                    user, created = get_or_create_user_by_email(email, reactivate=False)
+                    if created:
+                        # Brand-new email: auto-provision so allauth can issue a
+                        # real code.  Reuse any existing EmailAddress row
+                        # (case-insensitive) so mixed-case input can't create a
+                        # duplicate; new rows are primary and unverified.
+                        email_address = EmailAddress.objects.filter(user=user, email__iexact=email).first()
+                        if email_address is None:
+                            EmailAddress.objects.create(
+                                user=user,
+                                email=email,
+                                primary=True,
+                                verified=False,
+                            )
+                        self.input._user = user  # type: ignore[union-attr]
+                    elif user.is_active:
+                        # Defensive: an active account allauth didn't resolve
+                        # still gets a real code.
+                        self.input._user = user  # type: ignore[union-attr]
+                    # else: existing-but-inactive — leave ``_user`` unset so
+                    # super().post() fakes success without sending anything
+                    # (ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS=False) and the account
+                    # stays deactivated.
         return cast(HttpResponse, super().post(request, *args, **kwargs))

--- a/apps/betterangels-backend/accounts/headless_views.py
+++ b/apps/betterangels-backend/accounts/headless_views.py
@@ -2,11 +2,10 @@ from typing import Any, cast
 
 from allauth.account.models import EmailAddress
 from allauth.headless.account.views import RequestLoginCodeView
-from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 
-User = get_user_model()
+from .services import get_or_create_user_by_email
 
 
 class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
@@ -18,9 +17,12 @@ class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
     calls ``initiate(user=None, ...)`` which silently fakes success without
     sending a real code.
 
-    We override ``post()`` to create the user first and set ``self.input._user``
-    so the verification process finds the account and issues a real code.  This
-    follows allauth's subclassing pattern — ``self.input._user`` is the
+    We override ``post()`` to provision the account and set ``self.input._user``
+    so the verification process finds it and issues a real code.  Provisioning
+    is delegated to :func:`accounts.services.get_or_create_user_by_email`, which
+    reuses an existing account — reactivating it if it was deactivated — instead
+    of creating a duplicate (which would raise a unique-constraint violation).
+    This follows allauth's subclassing pattern: ``self.input._user`` is the
     documented protocol variable that ``RequestLoginCodeView.post()`` reads.
     """
 
@@ -28,15 +30,19 @@ class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
         if not self.input._user:  # type: ignore[union-attr]
             email = self.input.cleaned_data.get("email")  # type: ignore[union-attr]
             if email:
+                email = email.strip().lower()
                 with transaction.atomic():
-                    user = User.objects.create_user(email=email, username=email)
-                    user.set_unusable_password()
-                    user.save()
-                    EmailAddress.objects.create(
-                        user=user,
-                        email=email,
-                        primary=True,
-                        verified=False,
-                    )
+                    user, _ = get_or_create_user_by_email(email)
+                    # Ensure allauth can resolve the address: reuse any existing
+                    # row (case-insensitive) so mixed-case input can't create a
+                    # duplicate; new rows are primary and unverified.
+                    email_address = EmailAddress.objects.filter(user=user, email__iexact=email).first()
+                    if email_address is None:
+                        EmailAddress.objects.create(
+                            user=user,
+                            email=email,
+                            primary=True,
+                            verified=False,
+                        )
                 self.input._user = user  # type: ignore[union-attr]
         return cast(HttpResponse, super().post(request, *args, **kwargs))

--- a/apps/betterangels-backend/accounts/headless_views.py
+++ b/apps/betterangels-backend/accounts/headless_views.py
@@ -31,7 +31,7 @@ class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
             if email:
                 email = email.strip().lower()
                 with transaction.atomic():
-                    user, created = get_or_create_user_by_email(email, reactivate=False)
+                    user, created = get_or_create_user_by_email(email)
                     if created:
                         # Brand-new email: auto-provision so allauth can issue a
                         # real code.  Reuse any existing EmailAddress row

--- a/apps/betterangels-backend/accounts/headless_views.py
+++ b/apps/betterangels-backend/accounts/headless_views.py
@@ -20,9 +20,9 @@ class AutoCreateRequestLoginCodeView(RequestLoginCodeView):
     We override ``post()`` to provision brand-new emails and set
     ``self.input._user`` so the verification process issues a real code.
     An email that already belongs to an existing-but-deactivated account is
-    deliberately left untouched — no reactivation, no email — so an anonymous
-    request can't undo an admin's deactivation; ``super().post()`` then fakes
-    success exactly as it does for unknown accounts.
+    deliberately left untouched — no reactivation, no email — anonymous
+    requests can't reactivate a deactivated user; ``super().post()`` then
+    fakes success exactly as it does for unknown accounts.
     """
 
     def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -7,7 +7,7 @@ Reference: https://github.com/HackSoftware/Django-Styleguide#services
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from common.org_types import REGISTRY
 from common.permissions.config import TemplateConfig
@@ -28,6 +28,51 @@ from .role_manager import OrgRoleManager
 
 if TYPE_CHECKING:
     from .models import User
+
+
+# ── User provisioning ────────────────────────────────────────────────
+
+
+def get_or_create_user_by_email(
+    email: str,
+    *,
+    defaults: dict[str, Any] | None = None,
+) -> tuple[UserModel, bool]:
+    """Find or create a user by normalized email, reactivating if needed.
+
+    A single unit of work: callers that perform additional writes alongside
+    this (e.g. ``member_add``) wrap it in their own transaction.
+
+    Emails are stored lowercased by ``User.save()``, so the input is
+    normalized (stripped + lowercased) before lookup — otherwise mixed-case
+    input would miss the existing row and raise a unique-constraint
+    violation.  Existing-but-deactivated accounts (e.g. disabled by a bulk
+    script) are reactivated so login-by-code and re-invitation keep working.
+
+    ``defaults`` (like :meth:`~django.db.models.QuerySet.get_or_create`)
+    seeds field values only when a new user is created.  Brand-new users are
+    created active with an unusable password and a random username (the
+    codebase convention for programmatically created accounts, cf.
+    ``UserManager.create_client``).
+
+    Returns ``(user, created)``.
+    """
+    email = email.strip().lower()
+    user, created = UserModel.objects.get_or_create(
+        email=email,
+        defaults={
+            **(defaults or {}),
+            "username": str(uuid.uuid4()),
+            "is_active": True,
+        },
+    )
+    if created:
+        user.set_unusable_password()
+        user.save()
+    elif not user.is_active:
+        user.is_active = True
+        user.save(update_fields=["is_active"])
+    return user, created
 
 
 # ── Member management ────────────────────────────────────────────────
@@ -51,17 +96,17 @@ def member_add(
     *permission_templates* the user does **not** already hold are
     assigned.  This allows the same user to be added through different
     portals (e.g. outreach and shelter operator) without raising an error.
+    Existing-but-deactivated users are reactivated via
+    :func:`get_or_create_user_by_email`.
     """
-    user, created = UserModel.objects.get_or_create(
-        email=email,
-        defaults={"username": str(uuid.uuid4()), "is_active": True},
+    user, _ = get_or_create_user_by_email(
+        email,
+        defaults={
+            "first_name": first_name,
+            "last_name": last_name,
+            "middle_name": middle_name,
+        },
     )
-    if created:
-        user.first_name = first_name
-        user.last_name = last_name
-        user.middle_name = middle_name
-        user.set_unusable_password()
-        user.save()
 
     is_existing_member = organization.users.filter(pk=user.pk).exists()
 

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -37,20 +37,19 @@ def get_or_create_user_by_email(
     email: str,
     *,
     defaults: dict[str, Any] | None = None,
-    reactivate: bool = True,
 ) -> tuple[UserModel, bool]:
     """Find or create a user by normalized email.
 
-    A single unit of work: callers that perform additional writes alongside
-    this (e.g. ``member_add``) wrap it in their own transaction.
+    A single unit of work with **no side effects on existing users**: an
+    existing-but-deactivated account is returned unchanged.  Callers that are
+    authorized to change account state (e.g. admin-initiated flows such as
+    ``member_add``) call :func:`reactivate_user` explicitly — anonymous flows
+    such as login-code self-signup do not.
 
     Emails are stored lowercased by ``User.save()``, so the input is
     normalized (stripped + lowercased) before lookup — otherwise mixed-case
     input would miss the existing row and raise a unique-constraint
-    violation.  An existing-but-deactivated account is reactivated when
-    ``reactivate`` is true (the default — appropriate for admin-initiated
-    flows such as member re-invitation); pass ``reactivate=False`` for
-    anonymous flows that must not change account state.
+    violation.
 
     ``defaults`` (like :meth:`~django.db.models.QuerySet.get_or_create`)
     seeds field values only when a new user is created.  Brand-new users are
@@ -72,10 +71,19 @@ def get_or_create_user_by_email(
     if created:
         user.set_unusable_password()
         user.save()
-    elif reactivate and not user.is_active:
+    return user, created
+
+
+def reactivate_user(user: UserModel) -> None:
+    """Reactivate a deactivated account (no-op if already active).
+
+    Call only from authorized flows (e.g. an admin re-invites a member via
+    ``member_add``); never from anonymous requests such as login-code
+    self-signup, or a for-cause deactivation would be silently undone.
+    """
+    if not user.is_active:
         user.is_active = True
         user.save(update_fields=["is_active"])
-    return user, created
 
 
 # ── Member management ────────────────────────────────────────────────
@@ -100,7 +108,7 @@ def member_add(
     assigned.  This allows the same user to be added through different
     portals (e.g. outreach and shelter operator) without raising an error.
     Existing-but-deactivated users are reactivated via
-    :func:`get_or_create_user_by_email`.
+    :func:`reactivate_user`.
     """
     user, _ = get_or_create_user_by_email(
         email,
@@ -110,6 +118,8 @@ def member_add(
             "middle_name": middle_name,
         },
     )
+    # Authorized action: re-adding a member reactivates a deactivated account.
+    reactivate_user(user)
 
     is_existing_member = organization.users.filter(pk=user.pk).exists()
 

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -44,7 +44,9 @@ def get_or_create_user_by_email(
     existing-but-deactivated account is returned unchanged.  Callers that are
     authorized to change account state (e.g. admin-initiated flows such as
     ``member_add``) call :func:`reactivate_user` explicitly — anonymous flows
-    such as login-code self-signup do not.
+    such as login-code self-signup do not.  Callers own transaction
+    boundaries: wrap this in ``transaction.atomic()`` when combining it with
+    other writes.
 
     Emails are stored lowercased by ``User.save()``, so the input is
     normalized (stripped + lowercased) before lookup — otherwise mixed-case
@@ -70,7 +72,9 @@ def get_or_create_user_by_email(
     )
     if created:
         user.set_unusable_password()
-        user.save()
+        # All other fields were just written by the INSERT above; only the
+        # password changed.
+        user.save(update_fields=["password"])
     return user, created
 
 

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -57,7 +57,8 @@ def get_or_create_user_by_email(
     seeds field values only when a new user is created.  Brand-new users are
     created active with an unusable password and a random username (the
     codebase convention for programmatically created accounts, cf.
-    ``UserManager.create_client``).
+    ``UserManager.create_client``).  Any ``username``/``is_active`` supplied
+    via ``defaults`` is ignored — the service always enforces these.
 
     Returns ``(user, created)``.
     """

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -37,8 +37,9 @@ def get_or_create_user_by_email(
     email: str,
     *,
     defaults: dict[str, Any] | None = None,
+    reactivate: bool = True,
 ) -> tuple[UserModel, bool]:
-    """Find or create a user by normalized email, reactivating if needed.
+    """Find or create a user by normalized email.
 
     A single unit of work: callers that perform additional writes alongside
     this (e.g. ``member_add``) wrap it in their own transaction.
@@ -46,8 +47,10 @@ def get_or_create_user_by_email(
     Emails are stored lowercased by ``User.save()``, so the input is
     normalized (stripped + lowercased) before lookup — otherwise mixed-case
     input would miss the existing row and raise a unique-constraint
-    violation.  Existing-but-deactivated accounts (e.g. disabled by a bulk
-    script) are reactivated so login-by-code and re-invitation keep working.
+    violation.  An existing-but-deactivated account is reactivated when
+    ``reactivate`` is true (the default — appropriate for admin-initiated
+    flows such as member re-invitation); pass ``reactivate=False`` for
+    anonymous flows that must not change account state.
 
     ``defaults`` (like :meth:`~django.db.models.QuerySet.get_or_create`)
     seeds field values only when a new user is created.  Brand-new users are
@@ -69,7 +72,7 @@ def get_or_create_user_by_email(
     if created:
         user.set_unusable_password()
         user.save()
-    elif not user.is_active:
+    elif reactivate and not user.is_active:
         user.is_active = True
         user.save(update_fields=["is_active"])
     return user, created

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -42,7 +42,7 @@ def get_or_create_user_by_email(
 
     A single unit of work with **no side effects on existing users**: an
     existing-but-deactivated account is returned unchanged.  Callers that are
-    authorized to change account state (e.g. admin-initiated flows such as
+    authorized to change account state (e.g. org-admin-initiated flows such as
     ``member_add``) call :func:`reactivate_user` explicitly — anonymous flows
     such as login-code self-signup do not.  Callers own transaction
     boundaries: wrap this in ``transaction.atomic()`` when combining it with
@@ -81,7 +81,7 @@ def get_or_create_user_by_email(
 def reactivate_user(user: UserModel) -> None:
     """Reactivate a deactivated account (no-op if already active).
 
-    Call only from authorized flows (e.g. an admin re-invites a member via
+    Call only from authorized flows (e.g. an org admin re-invites a member via
     ``member_add``); never from anonymous requests such as login-code
     self-signup, or a for-cause deactivation would be silently undone.
     """

--- a/apps/betterangels-backend/accounts/tests/test_headless_views.py
+++ b/apps/betterangels-backend/accounts/tests/test_headless_views.py
@@ -3,8 +3,9 @@
 Login-by-code self-signup: when ``ACCOUNT_PREVENT_ENUMERATION=True`` the
 headless form only resolves *active* users, so an existing-but-deactivated
 account (e.g. disabled by a bulk script) leaves ``self.input._user = None``.
-The view must reactivate that account (not attempt to create a duplicate,
-which would 500 on the unique email constraint) and still send a real code.
+Brand-new emails are auto-provisioned; existing-but-inactive accounts are left
+untouched (no 500, no duplicate, no email) so anonymous requests can't undo an
+admin's deactivation.
 """
 
 import json
@@ -41,10 +42,10 @@ def _assert_login_code_request_succeeded(response: Any) -> None:
 
 
 @pytest.mark.django_db
-def test_request_login_code_reactivates_existing_inactive_user() -> None:
-    """An existing-but-inactive account is reactivated and sent a real code,
-    without creating a duplicate user row."""
-    User.objects.create_user(
+def test_request_login_code_leaves_inactive_user_untouched() -> None:
+    """An anonymous code request must not reactivate an existing-but-inactive
+    account: no 500, no duplicate, no email, no state change."""
+    user = User.objects.create_user(
         email="sleeper@example.com",
         username="sleeper",
         is_active=False,
@@ -55,17 +56,13 @@ def test_request_login_code_reactivates_existing_inactive_user() -> None:
 
     _assert_login_code_request_succeeded(response)
 
-    # Exactly one user row, and it is active afterward.
+    # Exactly one user row, still inactive.
     assert User.objects.filter(email="sleeper@example.com").count() == 1
-    user = User.objects.get(email="sleeper@example.com")
-    assert user.is_active
+    user.refresh_from_db()
+    assert not user.is_active
 
-    # A real login code was sent (not the enumeration-fake-success mail).
-    mock_send_mail.assert_called_once()
-    template_prefix, recipient, context = mock_send_mail.call_args.args
-    assert template_prefix == "account/email/login_code"
-    assert recipient == "sleeper@example.com"
-    assert context["code"]
+    # Enumeration-safe: no login code and no unknown-account mail is sent.
+    mock_send_mail.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/apps/betterangels-backend/accounts/tests/test_headless_views.py
+++ b/apps/betterangels-backend/accounts/tests/test_headless_views.py
@@ -4,8 +4,8 @@ Login-by-code self-signup: when ``ACCOUNT_PREVENT_ENUMERATION=True`` the
 headless form only resolves *active* users, so an existing-but-deactivated
 account (e.g. disabled by a bulk script) leaves ``self.input._user = None``.
 Brand-new emails are auto-provisioned; existing-but-inactive accounts are left
-untouched (no 500, no duplicate, no email) so anonymous requests can't undo an
-admin's deactivation.
+untouched (no 500, no duplicate, no email) — anonymous requests can't
+reactivate a deactivated user.
 """
 
 import json

--- a/apps/betterangels-backend/accounts/tests/test_headless_views.py
+++ b/apps/betterangels-backend/accounts/tests/test_headless_views.py
@@ -87,3 +87,25 @@ def test_request_login_code_creates_new_user() -> None:
     template_prefix, recipient, _ = mock_send_mail.call_args.args
     assert template_prefix == "account/email/login_code"
     assert recipient == "brandnew@example.com"
+
+
+@pytest.mark.django_db
+def test_request_login_code_creates_new_user_mixed_case() -> None:
+    """A brand-new mixed-case email is normalized end-to-end: the user and
+    EmailAddress rows are stored lowercase."""
+    with patch.object(AccountAdapter, "send_mail") as mock_send_mail:
+        response = _request_login_code("BrandNew@Example.com")
+
+    _assert_login_code_request_succeeded(response)
+
+    user = User.objects.get(email="brandnew@example.com")
+    assert user.is_active
+    assert not user.has_usable_password()
+
+    email_address = EmailAddress.objects.get(user=user, email="brandnew@example.com")
+    assert email_address.primary
+    assert not email_address.verified
+
+    mock_send_mail.assert_called_once()
+    template_prefix, _, _ = mock_send_mail.call_args.args
+    assert template_prefix == "account/email/login_code"

--- a/apps/betterangels-backend/accounts/tests/test_headless_views.py
+++ b/apps/betterangels-backend/accounts/tests/test_headless_views.py
@@ -1,0 +1,92 @@
+"""Tests for ``accounts.headless_views.AutoCreateRequestLoginCodeView``.
+
+Login-by-code self-signup: when ``ACCOUNT_PREVENT_ENUMERATION=True`` the
+headless form only resolves *active* users, so an existing-but-deactivated
+account (e.g. disabled by a bulk script) leaves ``self.input._user = None``.
+The view must reactivate that account (not attempt to create a duplicate,
+which would 500 on the unique email constraint) and still send a real code.
+"""
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from allauth.account.models import EmailAddress
+from django.test import Client
+
+from accounts.adapters import AccountAdapter
+from accounts.models import User
+
+# App client endpoints are CSRF-exempt, so the Django test client can hit them
+# directly with a JSON body.
+LOGIN_CODE_REQUEST_URL = "/_allauth/app/v1/auth/code/request"
+
+
+def _request_login_code(email: str) -> Any:
+    return Client().post(
+        LOGIN_CODE_REQUEST_URL,
+        data=json.dumps({"email": email}),
+        content_type="application/json",
+    )
+
+
+def _assert_login_code_request_succeeded(response: Any) -> None:
+    """Headless returns 401 (unauthenticated) as the normal "code requested"
+    signal; the point is that we don't 500 and no error payload is present."""
+    assert response.status_code == 401
+    payload = json.loads(response.content)
+    assert "errors" not in payload
+    assert payload["meta"]["is_authenticated"] is False
+
+
+@pytest.mark.django_db
+def test_request_login_code_reactivates_existing_inactive_user() -> None:
+    """An existing-but-inactive account is reactivated and sent a real code,
+    without creating a duplicate user row."""
+    User.objects.create_user(
+        email="sleeper@example.com",
+        username="sleeper",
+        is_active=False,
+    )
+
+    with patch.object(AccountAdapter, "send_mail") as mock_send_mail:
+        response = _request_login_code("sleeper@example.com")
+
+    _assert_login_code_request_succeeded(response)
+
+    # Exactly one user row, and it is active afterward.
+    assert User.objects.filter(email="sleeper@example.com").count() == 1
+    user = User.objects.get(email="sleeper@example.com")
+    assert user.is_active
+
+    # A real login code was sent (not the enumeration-fake-success mail).
+    mock_send_mail.assert_called_once()
+    template_prefix, recipient, context = mock_send_mail.call_args.args
+    assert template_prefix == "account/email/login_code"
+    assert recipient == "sleeper@example.com"
+    assert context["code"]
+
+
+@pytest.mark.django_db
+def test_request_login_code_creates_new_user() -> None:
+    """A brand-new email still auto-provisions an active user with an unusable
+    password and an unverified EmailAddress."""
+    with patch.object(AccountAdapter, "send_mail") as mock_send_mail:
+        response = _request_login_code("brandnew@example.com")
+
+    _assert_login_code_request_succeeded(response)
+
+    assert User.objects.filter(email="brandnew@example.com").count() == 1
+    user = User.objects.get(email="brandnew@example.com")
+    assert user.is_active
+    assert not user.has_usable_password()
+
+    email_address = EmailAddress.objects.get(user=user, email="brandnew@example.com")
+    assert email_address.primary
+    assert not email_address.verified
+
+    mock_send_mail.assert_called_once()
+    template_prefix, recipient, _ = mock_send_mail.call_args.args
+    assert template_prefix == "account/email/login_code"
+    assert recipient == "brandnew@example.com"

--- a/apps/betterangels-backend/accounts/tests/test_mutations.py
+++ b/apps/betterangels-backend/accounts/tests/test_mutations.py
@@ -259,6 +259,64 @@ class OrganizationMemberMutationTestCase(GraphQLBaseTestCase, ParametrizedTestCa
         self.assertIsNotNone(response["data"]["addOrganizationMember"]["id"])
         self.assertEqual(initial_org_member_count, OrganizationUser.objects.count())
 
+    def test_add_organization_member_mixed_case_email(self) -> None:
+        """Adding with a mixed-case email finds the existing (lowercased) user
+        instead of creating a duplicate or raising IntegrityError."""
+        existing_member = baker.make(
+            User,
+            first_name="Mixed",
+            last_name="Case",
+            email="mixedcase@example.com",
+            is_active=False,
+        )
+
+        new_member = {
+            "email": "MixedCase@Example.com",
+            "firstName": "Mixed",
+            "middleName": "Ish",
+            "lastName": "Case",
+        }
+
+        mutation = """
+            mutation ($data: OrgInvitationInput!) {
+                addOrganizationMember(data: $data) {
+                    ... on OperationInfo {
+                        messages {
+                            kind
+                            field
+                            message
+                        }
+                    }
+                    ... on OrganizationMemberType {
+                        id
+                        email
+                    }
+                }
+            }
+        """
+
+        variables = {
+            **new_member,
+            "organizationId": self.org.pk,
+            "permissionTemplate": PermissionTemplateEnum.CASEWORKER.name,
+        }
+
+        with patch("accounts.backends.CustomInvitations.send_invitation"):
+            response = self.execute_graphql(mutation, {"data": variables})
+
+        # No IntegrityError / duplicate — the existing user is reused.
+        self.assertNotIn("messages", response["data"]["addOrganizationMember"])
+        self.assertEqual(
+            response["data"]["addOrganizationMember"]["id"],
+            str(existing_member.pk),
+        )
+        self.assertEqual(response["data"]["addOrganizationMember"]["email"], "mixedcase@example.com")
+        self.assertEqual(User.objects.filter(email="mixedcase@example.com").count(), 1)
+
+        # The deactivated user is reactivated by member_add.
+        existing_member.refresh_from_db()
+        self.assertTrue(existing_member.is_active)
+
     def test_remove_organization_member(self) -> None:
 
         removable_member = baker.make(

--- a/apps/betterangels-backend/accounts/tests/test_send_invitation.py
+++ b/apps/betterangels-backend/accounts/tests/test_send_invitation.py
@@ -135,6 +135,23 @@ class SendInvitationTestCase(TestCase):
         self.assertEqual(abstract_user.pk, existing.pk)  # reused
         mock_send.assert_called_once_with(abstract_user, None, domain="localhost:8000")
 
+    @patch("accounts.backends.CustomInvitations.send_invitation")
+    def test_invite_by_email_reactivates_inactive_user(self, mock_send: Mock) -> None:
+        """A deactivated user re-invited with a mixed-case email is reactivated
+        instead of duplicated."""
+        existing = baker.make(User, email=self.email, username="existing", is_active=False)
+
+        abstract_user = self.invitation_backend.invite_by_email(
+            self.email.upper(), domain="localhost:8000"
+        )
+
+        assert isinstance(abstract_user, User)
+        self.assertEqual(abstract_user.pk, existing.pk)  # reused, not duplicated
+        self.assertEqual(User.objects.filter(email=self.email).count(), 1)
+        abstract_user.refresh_from_db()
+        self.assertTrue(abstract_user.is_active)
+        mock_send.assert_called_once_with(abstract_user, None, domain="localhost:8000")
+
     def test_send_invitation_case(self) -> None:
         """Original smoke test — invite_by_email creates an Email record."""
         self.invitation_backend.invite_by_email(self.email, domain={"domain": "localhost:8000"})

--- a/apps/betterangels-backend/accounts/tests/test_send_invitation.py
+++ b/apps/betterangels-backend/accounts/tests/test_send_invitation.py
@@ -141,9 +141,7 @@ class SendInvitationTestCase(TestCase):
         instead of duplicated."""
         existing = baker.make(User, email=self.email, username="existing", is_active=False)
 
-        abstract_user = self.invitation_backend.invite_by_email(
-            self.email.upper(), domain="localhost:8000"
-        )
+        abstract_user = self.invitation_backend.invite_by_email(self.email.upper(), domain="localhost:8000")
 
         assert isinstance(abstract_user, User)
         self.assertEqual(abstract_user.pk, existing.pk)  # reused, not duplicated

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -140,6 +140,20 @@ def test_get_or_create_user_by_email_reactivates_inactive_user() -> None:
     assert User.objects.filter(email="sleepy@example.com").count() == 1
 
 
+@pytest.mark.django_db
+def test_get_or_create_user_by_email_without_reactivate() -> None:
+    """With reactivate=False, an existing-but-deactivated user is returned
+    unchanged (no state change, no duplicate)."""
+    existing = baker.make(User, email="sleepy@example.com", is_active=False)
+
+    user, created = get_or_create_user_by_email("Sleepy@Example.com", reactivate=False)
+
+    assert not created
+    assert user.pk == existing.pk
+    assert not user.is_active  # left as-is
+    assert User.objects.filter(email="sleepy@example.com").count() == 1
+
+
 # ── member_add ─────────────────────────────────────────────────────────
 
 

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -11,6 +11,7 @@ from accounts.services import (
     get_or_create_user_by_email,
     member_add,
     organization_remove_member,
+    reactivate_user,
 )
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
@@ -127,31 +128,34 @@ def test_get_or_create_user_by_email_new_user() -> None:
 
 
 @pytest.mark.django_db
-def test_get_or_create_user_by_email_reactivates_inactive_user() -> None:
-    """An existing-but-deactivated user is reactivated; no duplicate is
-    created."""
+def test_get_or_create_user_by_email_leaves_inactive_user_unchanged() -> None:
+    """The provisioning service has no side effects on existing users: a
+    deactivated account is returned unchanged (reactivation is an explicit,
+    authorized step via reactivate_user)."""
     existing = baker.make(User, email="sleepy@example.com", is_active=False)
 
     user, created = get_or_create_user_by_email("Sleepy@Example.com")
 
     assert not created
     assert user.pk == existing.pk
-    assert user.is_active
+    assert not user.is_active  # left as-is
     assert User.objects.filter(email="sleepy@example.com").count() == 1
 
 
 @pytest.mark.django_db
-def test_get_or_create_user_by_email_without_reactivate() -> None:
-    """With reactivate=False, an existing-but-deactivated user is returned
-    unchanged (no state change, no duplicate)."""
-    existing = baker.make(User, email="sleepy@example.com", is_active=False)
+def test_reactivate_user() -> None:
+    """reactivate_user reactivates a deactivated account and is a no-op for
+    an active one."""
+    inactive = baker.make(User, email="sleepy@example.com", is_active=False)
+    active = baker.make(User, email="awake@example.com", is_active=True)
 
-    user, created = get_or_create_user_by_email("Sleepy@Example.com", reactivate=False)
+    reactivate_user(inactive)
+    reactivate_user(active)
 
-    assert not created
-    assert user.pk == existing.pk
-    assert not user.is_active  # left as-is
-    assert User.objects.filter(email="sleepy@example.com").count() == 1
+    inactive.refresh_from_db()
+    active.refresh_from_db()
+    assert inactive.is_active
+    assert active.is_active
 
 
 # ── member_add ─────────────────────────────────────────────────────────

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -8,6 +8,7 @@ from accounts.models import OrganizationProfile, PermissionGroupTemplate, User
 from accounts.selectors import permission_group_for_user
 from accounts.services import (
     create_organization_with_presets,
+    get_or_create_user_by_email,
     member_add,
     organization_remove_member,
 )
@@ -109,6 +110,36 @@ def test_create_org_atomic() -> None:
     assert not OrgModel.objects.filter(name="Atomic Org").exists()
 
 
+# ── get_or_create_user_by_email ───────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_get_or_create_user_by_email_new_user() -> None:
+    """Brand-new email yields an active user with an unusable password and a
+    normalized (lowercased, stripped) email."""
+    user, created = get_or_create_user_by_email(" NewUser@Example.com ")
+
+    assert created
+    assert user.email == "newuser@example.com"
+    assert user.is_active
+    assert not user.has_usable_password()
+    assert User.objects.filter(email="newuser@example.com").count() == 1
+
+
+@pytest.mark.django_db
+def test_get_or_create_user_by_email_reactivates_inactive_user() -> None:
+    """An existing-but-deactivated user is reactivated; no duplicate is
+    created."""
+    existing = baker.make(User, email="sleepy@example.com", is_active=False)
+
+    user, created = get_or_create_user_by_email("Sleepy@Example.com")
+
+    assert not created
+    assert user.pk == existing.pk
+    assert user.is_active
+    assert User.objects.filter(email="sleepy@example.com").count() == 1
+
+
 # ── member_add ─────────────────────────────────────────────────────────
 
 
@@ -174,6 +205,48 @@ def test_member_add_existing_user_different_org() -> None:
     assert User.objects.filter(email=user.email).count() == 1
     cw_org2 = Group.objects.get(permissiongroup__organization=org_2, permissiongroup__template__name=CASEWORKER.name)
     assert cw_org2 in user.groups.all()
+
+
+@pytest.mark.django_db
+def test_member_add_reactivates_inactive_user() -> None:
+    """Re-adding an existing-but-deactivated user reactivates them without
+    creating a duplicate row."""
+    org = create_organization_with_presets("Reactivate Org", ["outreach"], owner=baker.make(User))
+    existing = baker.make(User, email="revive@example.com", is_active=False)
+
+    user = member_add(
+        email="revive@example.com",
+        first_name="Revive",
+        last_name="User",
+        middle_name=None,
+        organization=org,
+        permission_templates=(CASEWORKER,),
+    )
+
+    assert user.pk == existing.pk
+    assert User.objects.filter(email="revive@example.com").count() == 1
+    user.refresh_from_db()
+    assert user.is_active
+
+
+@pytest.mark.django_db
+def test_member_add_mixed_case_email_finds_existing_user() -> None:
+    """Mixed-case email input finds the existing (lowercased) user instead of
+    creating a duplicate or raising IntegrityError."""
+    org = create_organization_with_presets("Mixed Case Org", ["outreach"], owner=baker.make(User))
+    existing = baker.make(User, email="mixedcase@example.com")
+
+    user = member_add(
+        email="MixedCase@Example.com",
+        first_name="Mixed",
+        last_name="Case",
+        middle_name=None,
+        organization=org,
+        permission_templates=(CASEWORKER,),
+    )
+
+    assert user.pk == existing.pk
+    assert User.objects.filter(email="mixedcase@example.com").count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Problem

Production incident: an existing user (deactivated by a bulk script) could not log in, and the backend returned HTTP 500.

- Login uses django-allauth headless with `ACCOUNT_PREVENT_ENUMERATION=True` and `LOGIN_BY_CODE_ENABLED=True`.
- With enumeration prevention, allauth's `RequestLoginCodeForm.clean_email` only resolves *active* users, so an existing-but-inactive account yields `self.input._user = None`.

### Bug 1 — `accounts/headless_views.py`
When `self.input._user` was `None`, the view unconditionally called `User.objects.create_user(...)`. For an existing inactive account this raised `UniqueViolation` on `accounts_user_email_key` → 500.

### Bug 2 — `accounts/services.py` (`member_add`)
`get_or_create(email=email, ...)` never reactivated existing users, so someone re-added to an org after bulk deactivation stayed inactive and then hit Bug 1. The lookup was also exact-case while `OrgInvitationInput` doesn't normalize email — mixed-case emails could miss the existing row and 500 on the unique constraint.

## Fix

Centralized user provisioning in `accounts/services.py`:

- `get_or_create_user_by_email(email, *, defaults=None)` — **pure find-or-create with no side effects on existing users**:
  - normalizes email (`strip().lower()`) before lookup
  - creates new users active with an unusable password and a uuid username (codebase convention)
  - accepts `defaults` (mirrors `get_or_create`) so `member_add` seeds names in the single INSERT — no extra save, no query-count change
  - returns existing-but-deactivated accounts **unchanged**
- `reactivate_user(user)` — explicit helper; called **only by authorized flows**.

Call sites:

- `headless_views.AutoCreateRequestLoginCodeView` — auto-creates **brand-new** emails only. An existing-but-inactive account is left untouched: allauth's enumeration-safe path returns the same generic success and sends nothing (`ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS=False`) — no 500, no email, no state change. Anonymous requests cannot undo a deactivation.
- `services.member_add` → called by the `addOrganizationMember` mutation — admin-authorized re-add calls `reactivate_user(user)`.
- `backends.invite_by_email` — same latent bug pattern fixed; re-invitation calls `reactivate_user(user)`.

Making reactivation an explicit step (rather than a `reactivate=True/False` parameter) means new call sites **fail safe**: forgetting to reactivate is harmless, whereas a default-on flag could let a future anonymous flow silently reactivate accounts.

Transaction ownership stays at the call sites (the service is a plain unit of work) to avoid nested savepoints.

## Policy decision

Anonymous login-code requests **do not** reactivate deactivated accounts. Deactivation is strictly a Better Angels (platform) admin action — org admins only manage membership, and removing an org member never deactivates the `User`. Reactivation may come from BA-admin or org-admin flows: users deactivated by bulk scripts can be re-enabled by re-inviting them (`addOrganizationMember` / `invite_by_email`), which now reactivates automatically. `User.is_active` is global (not org-scoped), so there is no cross-org concern — the only rule is that no single org's request deactivates a user.

## Behavior notes

- Auto-created login-code users now get a uuid `username` instead of `username=email` (matches `member_add`/`invite_by_email`/`create_client`; also avoids the 150-char username limit).
- Email normalization (`strip().lower()`) lives only in `get_or_create_user_by_email`; call sites pass input through unchanged.

## Tests

- Login code for an existing inactive account: generic success, **no email sent, no state change, no duplicate row, no 500**.
- Brand-new email: still auto-creates an active user with an unusable password and an unverified `EmailAddress`.
- Brand-new mixed-case email: normalized end-to-end (user and `EmailAddress` rows stored lowercase).
- `member_add` reactivates existing inactive users; mixed-case email finds the existing user (no duplicate).
- `invite_by_email` reactivates a deactivated user re-invited with mixed-case email.
- `add_organization_member` with mixed-case email: no duplicate, no `IntegrityError`, user reactivated.
- Unit tests: provisioning service leaves inactive users unchanged; `reactivate_user` reactivates and no-ops on active users.

## Jira

- [DEV-2516](https://betterangels.atlassian.net/browse/DEV-2516) — this work
- [BACS-103](https://betterangels.atlassian.net/browse/BACS-103) — related customer ticket ("Not receiving one time code")

## Verification

- `pytest accounts/tests/` → **116 passed** (36 warnings)
- `ruff check` + `ruff format --check` → clean
- `mypy` on changed modules → clean




[DEV-2516]: https://betterangels.atlassian.net/browse/DEV-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ