### PR TITLE
fix(teams): org-scoped team id resolution

### DIFF
--- a/apps/betterangels-backend/teams/services.py
+++ b/apps/betterangels-backend/teams/services.py
@@ -30,6 +30,27 @@ def team_create(
     )
 
 
+def resolve_team_id_for_org(
+    *,
+    team_id: int | None,
+    organization_id: int | None,
+) -> int | None:
+    """Validate *team_id* belongs to *organization_id*.
+
+    Raises :class:`~django.core.exceptions.ValidationError` for unknown or
+    cross-org team ids (never silently links another organization's team).
+    Returns ``None`` when no team is requested.
+    """
+    if team_id is None:
+        return None
+    if organization_id is None:
+        raise ValidationError(f"Team with id {team_id} does not exist: task has no organization.") from None
+    try:
+        return Team.objects.get(pk=team_id, organization_id=organization_id).pk
+    except Team.DoesNotExist:
+        raise ValidationError(f"Team with id {team_id} does not exist in organization {organization_id}.") from None
+
+
 @transaction.atomic
 def team_update(
     *,

--- a/apps/betterangels-backend/teams/tests/test_services.py
+++ b/apps/betterangels-backend/teams/tests/test_services.py
@@ -1,0 +1,34 @@
+"""Tests for team services."""
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from organizations.models import Organization
+from teams.models import Team
+from teams.services import resolve_team_id_for_org
+
+
+class ResolveTeamIdForOrgTestCase(TestCase):
+    """Org-scoped team resolution — cross-org ids must be rejected."""
+
+    def setUp(self) -> None:
+        self.org_1 = Organization.objects.create(name="resolve_org_1")
+        self.org_2 = Organization.objects.create(name="resolve_org_2")
+        self.org_1_team = Team.objects.create(slug="wdi_on_site", name="WDI On-site", organization=self.org_1)
+        self.org_2_team = Team.objects.create(slug="wdi_on_site", name="WDI On-site", organization=self.org_2)
+
+    def test_team_id_belongs_to_org(self) -> None:
+        self.assertEqual(
+            resolve_team_id_for_org(team_id=self.org_1_team.pk, organization_id=self.org_1.pk),
+            self.org_1_team.pk,
+        )
+
+    def test_team_id_from_other_org_raises(self) -> None:
+        with self.assertRaises(ValidationError):
+            resolve_team_id_for_org(team_id=self.org_2_team.pk, organization_id=self.org_1.pk)
+
+    def test_team_id_missing_raises(self) -> None:
+        with self.assertRaises(ValidationError):
+            resolve_team_id_for_org(team_id=999_999, organization_id=self.org_1.pk)
+
+    def test_no_team_id_returns_none(self) -> None:
+        self.assertIsNone(resolve_team_id_for_org(team_id=None, organization_id=self.org_1.pk))


### PR DESCRIPTION
## What

- `resolve_team_id_for_org()` validates that a `teamId` belongs to the acting organization — cross-org team ids now raise `ValidationError` instead of silently linking another org's team.

## Tests

`teams/tests/test_services.py`: cross-org id rejection, missing id, same-slug-different-org resolution.

## Not in this PR

Teams are **not** auto-seeded — orgs create their own teams via the admin UI. Legacy-data backfill is a separate migration in the next layer.

## Stack

Layer 1 of a 5-layer stack; each PR builds on the previous.