### PR TITLE
feat(teams): per-org legacy team backfill migration

### DIFF
--- a/apps/betterangels-backend/common/tests/utils.py
+++ b/apps/betterangels-backend/common/tests/utils.py
@@ -196,17 +196,32 @@ class GraphQLBaseTestCase(
         from notes.groups import CASEWORKER
         from teams.models import Team
 
-        from common.enums import SelahTeamEnum
-
         self.org_1 = organization_recipe.make(name="org_1")
         self.org_2 = organization_recipe.make(name="org_2")
 
-        # Create Team objects matching SelahTeamEnum values for backward
-        # compatibility with the deprecated ``team`` GraphQL field.
-        for org in (self.org_1, self.org_2):
-            for team_value in SelahTeamEnum.values:
+        # Create Team objects matching the legacy enum slugs so tests can
+        # exercise org-scoped team assignment.  Test-local list — product
+        # teams are created by org admins via the admin UI.
+        for slug in (
+            "bowtie_riverside_outreach",
+            "echo_park_on_site",
+            "echo_park_outreach",
+            "hollywood_on_site",
+            "hollywood_outreach",
+            "la_river_outreach",
+            "los_feliz_outreach",
+            "northeast_hollywood_outreach",
+            "selah_staff",
+            "silver_lake_outreach",
+            "slcc_on_site",
+            "sunday_social_atwater_on_site",
+            "sunday_social_atwater_outreach",
+            "wdi_on_site",
+            "wdi_outreach",
+        ):
+            for org in (self.org_1, self.org_2):
                 Team.objects.get_or_create(
-                    slug=team_value,
+                    slug=slug,
                     organization=org,
                 )
 

--- a/apps/betterangels-backend/teams/migrations/0002_backfill_org_teams.py
+++ b/apps/betterangels-backend/teams/migrations/0002_backfill_org_teams.py
@@ -1,0 +1,83 @@
+"""Backfill org-scoped Team rows from the deprecated SelahTeamEnum.
+
+For every organization whose notes/tasks still carry a legacy
+``old_team`` value without a ``team`` FK:
+
+1. Create the missing ``Team`` row scoped to that organization.
+2. Point the notes/tasks at it.
+
+Idempotent — re-running is a no-op.  Safe to reverse (reverse is a no-op;
+the generated Team rows are left in place).
+
+REMOVE this migration when ``old_team`` is dropped (deprecation cleanup).
+"""
+
+from django.db import migrations
+
+# Slug → human-readable name for the deprecated ``SelahTeamEnum`` values.
+# Hardcoded so the migration is self-contained (no app imports at runtime).
+LEGACY_TEAM_LABELS = {
+    "bowtie_riverside_outreach": "Bowtie & Riverside Outreach",
+    "echo_park_on_site": "Echo Park On-site",
+    "echo_park_outreach": "Echo Park Outreach",
+    "hollywood_on_site": "Hollywood On-site",
+    "hollywood_outreach": "Hollywood Outreach",
+    "la_river_outreach": "LA River Outreach",
+    "los_feliz_outreach": "Los Feliz Outreach",
+    "northeast_hollywood_outreach": "Northeast Hollywood Outreach",
+    "selah_staff": "SELAH Staff",
+    "silver_lake_outreach": "Silver Lake Outreach",
+    "slcc_on_site": "SLCC On-site",
+    "sunday_social_atwater_on_site": "Sunday Social / Atwater On-site",
+    "sunday_social_atwater_outreach": "Sunday Social / Atwater Outreach",
+    "wdi_on_site": "WDI On-site",
+    "wdi_outreach": "WDI Outreach",
+}
+
+
+def backfill_org_teams(apps, schema_editor):  # type: ignore[no-untyped-def]
+    Team = apps.get_model("teams", "Team")
+    Note = apps.get_model("notes", "Note")
+    Task = apps.get_model("tasks", "Task")
+
+    def ensure_team(org_id: int, slug: str):
+        return Team.objects.get_or_create(
+            slug=slug,
+            organization_id=org_id,
+            defaults={"name": LEGACY_TEAM_LABELS.get(slug, slug.replace("_", " ").title())},
+        )[0]
+
+    # Rows needing backfill: legacy team set, FK still empty.
+    note_rows = list(
+        Note.objects.filter(team__isnull=True, old_team__isnull=False)
+        .values_list("organization_id", "old_team")
+        .distinct()
+    )
+    task_rows = list(
+        Task.objects.filter(organization__isnull=False, team__isnull=True, old_team__isnull=False)
+        .values_list("organization_id", "old_team")
+        .distinct()
+    )
+
+    for org_id, slug in set(note_rows + task_rows):
+        ensure_team(org_id, slug)
+
+    for org_id, slug in note_rows:
+        team = ensure_team(org_id, slug)
+        Note.objects.filter(organization_id=org_id, old_team=slug, team__isnull=True).update(team_id=team.pk)
+
+    for org_id, slug in task_rows:
+        team = ensure_team(org_id, slug)
+        Task.objects.filter(organization_id=org_id, old_team=slug, team__isnull=True).update(team_id=team.pk)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("teams", "0001_initial"),
+        ("notes", "0002_initial"),
+        ("tasks", "0002_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_org_teams, migrations.RunPython.noop),
+    ]

--- a/docs/teams_org_scoping.md
+++ b/docs/teams_org_scoping.md
@@ -1,0 +1,64 @@
+# Teams Org-Scoping — Deployment Runbook & Follow-ups
+
+Deployment checklist for the per-org teams work (team FK validation,
+org-scoped mutations, legacy-team backfill, permission sync).
+
+## Deploy steps
+
+1. **Pre-deploy audit** (against production DB, before migrating):
+
+   ```bash
+   manage.py audit_team_org_scoping
+   ```
+
+   Confirms current cross-org team references and legacy-team backfill status.
+   Expected on a pre-migration DB: zero teams per non-SELAH orgs, notes/tasks
+   possibly carrying legacy `old_team` values.
+
+2. **Migrate** — applies `teams.0002_backfill_org_teams` (creates per-org
+   `Team` rows from legacy values and backfills note/task FKs) and the
+   `old_team` removals (`notes.0003`, `tasks.0003`). Idempotent.
+
+3. **Sync permission groups** — ensures every org's groups carry current
+   template permissions (including `teams.*` for Org Admin):
+
+   ```bash
+   manage.py sync_org_permission_groups          # write
+   manage.py sync_org_permission_groups --check  # verify-only
+   ```
+
+4. **Post-deploy audit** — re-run `audit_team_org_scoping`; must exit `OK:
+   no cross-org team references.`
+
+5. **Teams are org-admin created.** New orgs start with no teams; org
+   admins create them through the admin UI (Teams page / `createTeam`).
+   The legacy-team backfill migration only creates teams for orgs that
+   already have notes/tasks carrying legacy `old_team` values. Test
+   fixtures (`load_report_test_data`) remain available for local data.
+
+## Permission model (post-deploy)
+
+- **Org-owned**: teams, members, reports, shelter operations, and
+  note/task **writes** (header-driven via `HasOrgPerm`).
+- **Platform-shared by design**: client profiles, note/task **reads**
+  (orgs coordinate on shared clients and see cross-org interactions).
+
+## Follow-up decisions (product)
+
+1. Can org B edit/delete org A's client profiles? (Today: yes, via global
+   perms. Suggested: edits shared, deletes admin-only.)
+2. Can org B complete/reassign a task on a shared client? (Today: no —
+   object-level perms are org-owned.)
+3. Are client documents shared-read or org-owned? (Today: shared read via
+   global `Attachment.VIEW`.)
+
+## Known leftovers
+
+- `resolve_permission_group` first-match still used in
+  `clients.create_client_document`, `referrals`, `hmis`, and the `teams`
+  query fallback (mobile pre-org-header). Migrate to header-driven org.
+- GraphQL `teamId` cannot be set to explicit `null` (strawberry
+  `Maybe[ID]` rejects it) — teams can't be cleared via the API. Use
+  `Maybe[ID | None]` if clearing is ever required.
+- `scripts/archived/backfill_attachment_perms.py` is a retired one-off
+  (hardcoded SELAH org) — kept for reference only.


### PR DESCRIPTION
## What

- `teams.0002_backfill_org_teams`: idempotent data migration that creates per-org `Team` rows from legacy `old_team` values on notes/tasks and backfills the FKs. Data-driven only — no default teams are seeded for new orgs.
- `docs/teams_org_scoping.md`: deploy runbook (audit → migrate → sync perms → audit) + permission model + follow-ups.

## Deploy notes

- Run `manage.py audit_team_org_scoping` before/after deploying (command ships in a later layer).
- Migration is safe to re-run and reverses to a no-op.
- New orgs start with zero teams; admins create them in the UI (Teams page). `load_report_test_data` still seeds SELAH teams for local fixtures.

## Stack

Layer 2 of 5.