### PR TITLE
feat(shelter-operator): add printable shelter report page [2/3]

### DIFF
--- a/libs/react/shelter-operator/src/lib/OperatorApp.tsx
+++ b/libs/react/shelter-operator/src/lib/OperatorApp.tsx
@@ -20,6 +20,7 @@ import {
 } from './pages';
 import { CreateOrganizationPage } from './pages/createOrganization';
 import { Dashboard } from './pages/dashboard/Dashboard';
+import { ShelterReportPage } from './pages/report/ShelterReportPage';
 import {
   ShelterBasicInfoPage,
   ShelterDetailsPage,
@@ -99,6 +100,10 @@ export function OperatorApp() {
                 element={<ShelterMediaPage />}
               />
             </Route>
+            <Route
+              path={routePath(paths.shelterReport)}
+              element={<ShelterReportPage />}
+            />
             <Route path={routePath(mgmtRouteConfig.root)}>
               <Route
                 index

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.test.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.test.tsx
@@ -1,0 +1,121 @@
+import { MockedProvider } from '@apollo/client/testing/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { GetShelterOperatorOverviewDocument } from '../../components/overview/__generated__/overview.generated';
+import { ShelterReportPage } from './ShelterReportPage';
+
+// The page only orchestrates; the PDF itself is covered in useExportPdf.test.
+vi.mock('./useExportPdf', () => ({
+  useExportPdf: () => ({ exportPdf: vi.fn(), isExporting: false }),
+}));
+
+const SHELTER_ID = '1';
+
+const OVERVIEW = {
+  __typename: 'OperatorShelterType',
+  id: SHELTER_ID,
+  name: 'Downtown Emergency Shelter',
+  organization: {
+    __typename: 'OrganizationType',
+    id: '1',
+    name: 'Test Organization',
+  },
+  location: {
+    __typename: 'ShelterLocationType',
+    place: '1234 S Main St, Los Angeles, CA 90015',
+  },
+  bedCounts: {
+    __typename: 'BedCountType',
+    total: 185,
+    available: 42,
+    occupied: 118,
+    reserved: 13,
+    inTurnaround: 7,
+    outOfService: 5,
+  },
+  roomCounts: {
+    __typename: 'RoomCountType',
+    total: 47,
+    available: 9,
+    occupied: 31,
+    reserved: 4,
+    inTurnaround: 2,
+    outOfService: 1,
+  },
+};
+
+const request = {
+  query: GetShelterOperatorOverviewDocument,
+  variables: { shelterId: SHELTER_ID },
+};
+
+function renderPage(mocks: Parameters<typeof MockedProvider>[0]['mocks']) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={[`/operator/shelter/${SHELTER_ID}/report`]}>
+        <Routes>
+          <Route
+            path="/operator/shelter/:shelterId/report"
+            element={<ShelterReportPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </MockedProvider>
+  );
+}
+
+const exportButton = () => screen.getByRole('button', { name: /export pdf/i });
+
+describe('ShelterReportPage', () => {
+  it('shows a loading message while the query is in flight', () => {
+    renderPage([{ request, result: { data: { operatorShelter: OVERVIEW } } }]);
+
+    expect(screen.getByText('Loading report…')).toBeTruthy();
+  });
+
+  it('disables the export button until the data arrives', async () => {
+    renderPage([{ request, result: { data: { operatorShelter: OVERVIEW } } }]);
+
+    expect(exportButton().hasAttribute('disabled')).toBe(true);
+
+    await waitFor(() =>
+      expect(screen.getByText('Test Organization')).toBeTruthy()
+    );
+
+    expect(exportButton().hasAttribute('disabled')).toBe(false);
+  });
+
+  it('renders the report once the query resolves', async () => {
+    renderPage([{ request, result: { data: { operatorShelter: OVERVIEW } } }]);
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bed Summary' })).toBeTruthy()
+    );
+
+    expect(screen.getByRole('heading', { name: 'Room Summary' })).toBeTruthy();
+    expect(screen.queryByText('Loading report…')).toBeNull();
+  });
+
+  it('reports a failure instead of an empty report when the query errors', async () => {
+    renderPage([{ request, error: new Error('network down') }]);
+
+    await waitFor(() =>
+      expect(screen.getByText('Failed to load the shelter report.')).toBeTruthy()
+    );
+
+    expect(exportButton().hasAttribute('disabled')).toBe(true);
+    expect(screen.queryByRole('heading', { name: 'Bed Summary' })).toBeNull();
+  });
+
+  it('explains an empty result rather than rendering a blank report', async () => {
+    renderPage([{ request, result: { data: { operatorShelter: null } } }]);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No shelter data available for this report.')
+      ).toBeTruthy()
+    );
+
+    expect(exportButton().hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
@@ -1,0 +1,61 @@
+import { useQuery } from '@apollo/client/react';
+import { Download } from 'lucide-react';
+import { useRef } from 'react';
+import { useParams } from 'react-router-dom';
+import { Button } from '../../components/base-ui/buttons/buttons';
+import { Text } from '../../components/base-ui/text/text';
+import { GetShelterOperatorOverviewDocument } from '../../components/overview/__generated__/overview.generated';
+import { ShelterReportPrint } from './ShelterReportPrint';
+import { useExportPdf } from './useExportPdf';
+
+export function ShelterReportPage() {
+  const { shelterId } = useParams<{ shelterId: string }>();
+  const targetRef = useRef<HTMLDivElement>(null);
+  const { exportPdf, isExporting } = useExportPdf(
+    targetRef,
+    `shelter-report-${shelterId ?? 'unknown'}.pdf`
+  );
+
+  const { data, loading, error } = useQuery(GetShelterOperatorOverviewDocument, {
+    variables: { shelterId: shelterId ?? '' },
+    skip: !shelterId,
+  });
+
+  const report = data?.operatorShelter;
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <div className="flex justify-end">
+        <Button
+          variant="primary"
+          color="blue"
+          leftIcon={<Download size={20} />}
+          onClick={exportPdf}
+          disabled={isExporting || !report}
+        >
+          {isExporting ? 'Exporting…' : 'Export PDF'}
+        </Button>
+      </div>
+
+      {loading && (
+        <Text variant="body" textColor="text-[#6B7280]">
+          Loading report…
+        </Text>
+      )}
+
+      {error && (
+        <Text variant="body" textColor="text-red-500">
+          Failed to load the shelter report.
+        </Text>
+      )}
+
+      {!loading && !error && !report && (
+        <Text variant="body" textColor="text-[#6B7280]">
+          No shelter data available for this report.
+        </Text>
+      )}
+
+      {report && <ShelterReportPrint ref={targetRef} data={report} />}
+    </div>
+  );
+}

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
@@ -37,25 +37,21 @@ export function ShelterReportPage() {
         </Button>
       </div>
 
-      {loading && (
+      {loading ? (
         <Text variant="body" textColor="text-[#6B7280]">
           Loading report…
         </Text>
-      )}
-
-      {error && (
+      ) : error ? (
         <Text variant="body" textColor="text-red-500">
           Failed to load the shelter report.
         </Text>
-      )}
-
-      {!loading && !error && !report && (
+      ) : report ? (
+        <ShelterReportPrint ref={targetRef} data={report} />
+      ) : (
         <Text variant="body" textColor="text-[#6B7280]">
           No shelter data available for this report.
         </Text>
       )}
-
-      {report && <ShelterReportPrint ref={targetRef} data={report} />}
     </div>
   );
 }

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.test.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, within } from '@testing-library/react';
+import { createRef } from 'react';
+import { ShelterReportPrint } from './ShelterReportPrint';
+import type { ShelterReportData } from './types';
+
+function makeReport(
+  overrides: Partial<ShelterReportData> = {}
+): ShelterReportData {
+  return {
+    id: '1',
+    name: 'Downtown Emergency Shelter',
+    organization: { id: '1', name: 'Test Organization' },
+    location: { place: '1234 S Main St, Los Angeles, CA 90015' },
+    bedCounts: {
+      total: 185,
+      available: 42,
+      occupied: 118,
+      reserved: 13,
+      inTurnaround: 7,
+      outOfService: 5,
+    },
+    roomCounts: {
+      total: 47,
+      available: 9,
+      occupied: 31,
+      reserved: 4,
+      inTurnaround: 2,
+      outOfService: 1,
+    },
+    ...overrides,
+  } as ShelterReportData;
+}
+
+/** Reads a section's label/value pairs in render order. */
+function rowsOf(title: string): Array<[string, string]> {
+  const heading = screen.getByRole('heading', { name: title });
+  const section = heading.closest('section');
+  if (!section) throw new Error(`no section for "${title}"`);
+
+  return [...section.querySelectorAll('div.justify-between')].map((row) => {
+    const [label, value] = [...row.querySelectorAll('span')];
+    return [label.textContent ?? '', value.textContent ?? ''];
+  });
+}
+
+describe('ShelterReportPrint', () => {
+  it('titles the report with the shelter name', () => {
+    render(<ShelterReportPrint data={makeReport()} />);
+
+    expect(
+      within(screen.getByRole('banner')).getByText('Downtown Emergency Shelter')
+    ).toBeTruthy();
+  });
+
+  it('renders the shelter summary', () => {
+    render(<ShelterReportPrint data={makeReport()} />);
+
+    expect(rowsOf('Shelter Summary')).toEqual([
+      ['Name', 'Downtown Emergency Shelter'],
+      ['Organization', 'Test Organization'],
+      ['Address', '1234 S Main St, Los Angeles, CA 90015'],
+    ]);
+  });
+
+  it('renders bed counts in a fixed order', () => {
+    render(<ShelterReportPrint data={makeReport()} />);
+
+    expect(rowsOf('Bed Summary')).toEqual([
+      ['Total', '185'],
+      ['Available', '42'],
+      ['Occupied', '118'],
+      ['Reserved', '13'],
+      ['In Turnaround', '7'],
+      ['Out of Service', '5'],
+    ]);
+  });
+
+  it('renders room counts from the room totals, not the bed totals', () => {
+    render(<ShelterReportPrint data={makeReport()} />);
+
+    expect(rowsOf('Room Summary')).toEqual([
+      ['Total', '47'],
+      ['Available', '9'],
+      ['Occupied', '31'],
+      ['Reserved', '4'],
+      ['In Turnaround', '2'],
+      ['Out of Service', '1'],
+    ]);
+  });
+
+  it('renders zero counts rather than blanks', () => {
+    const zeroed = makeReport({
+      bedCounts: {
+        total: 0,
+        available: 0,
+        occupied: 0,
+        reserved: 0,
+        inTurnaround: 0,
+        outOfService: 0,
+      } as ShelterReportData['bedCounts'],
+    });
+
+    render(<ShelterReportPrint data={zeroed} />);
+
+    expect(rowsOf('Bed Summary').map(([, value]) => value)).toEqual([
+      '0',
+      '0',
+      '0',
+      '0',
+      '0',
+      '0',
+    ]);
+  });
+
+  // organization and location are both nullable on the query.
+  it('falls back to an em dash when the organization is missing', () => {
+    render(<ShelterReportPrint data={makeReport({ organization: null })} />);
+
+    expect(rowsOf('Shelter Summary')).toContainEqual(['Organization', '—']);
+  });
+
+  it('falls back to an em dash when the location is missing', () => {
+    render(<ShelterReportPrint data={makeReport({ location: null })} />);
+
+    expect(rowsOf('Shelter Summary')).toContainEqual(['Address', '—']);
+  });
+
+  // useExportPdf captures whatever this ref points at, so the wiring matters.
+  it('forwards its ref to the printable root', () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(<ShelterReportPrint data={makeReport()} ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current?.classList.contains('shelter-report-print')).toBe(true);
+  });
+});

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.tsx
@@ -1,9 +1,21 @@
-import type { Ref } from 'react';
+import type { ReactNode, Ref } from 'react';
 import { Text } from '../../components/base-ui/text/text';
 import './report.css';
 import { ShelterReportData } from './types';
 
 const cardClassName = 'rounded-xl border border-[#E5E7EB] bg-white p-5';
+
+/** Bed and room counts share a shape, so both render the same rows. */
+const COUNT_ROWS = [
+  { key: 'total', label: 'Total' },
+  { key: 'available', label: 'Available' },
+  { key: 'occupied', label: 'Occupied' },
+  { key: 'reserved', label: 'Reserved' },
+  { key: 'inTurnaround', label: 'In Turnaround' },
+  { key: 'outOfService', label: 'Out of Service' },
+] as const;
+
+type Counts = Record<(typeof COUNT_ROWS)[number]['key'], number>;
 
 function SummaryRow({
   label,
@@ -17,6 +29,31 @@ function SummaryRow({
       <span className="text-[#6B7280]">{label}</span>
       <span className="font-medium text-[#111827]">{value}</span>
     </div>
+  );
+}
+
+function SummarySection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={cardClassName}>
+      <h3 className="text-base font-semibold text-[#111827]">{title}</h3>
+      <div className="mt-3 divide-y divide-[#F3F4F6]">{children}</div>
+    </section>
+  );
+}
+
+function CountsSection({ title, counts }: { title: string; counts: Counts }) {
+  return (
+    <SummarySection title={title}>
+      {COUNT_ROWS.map(({ key, label }) => (
+        <SummaryRow key={key} label={label} value={counts[key]} />
+      ))}
+    </SummarySection>
   );
 }
 
@@ -36,44 +73,14 @@ export function ShelterReportPrint({
           <Text variant="header-md">{name}</Text>
         </header>
 
-        <section className={cardClassName}>
-          <h3 className="text-base font-semibold text-[#111827]">
-            Shelter Summary
-          </h3>
-          <div className="mt-3 divide-y divide-[#F3F4F6]">
-            <SummaryRow label="Name" value={name} />
-            <SummaryRow label="Organization" value={organization?.name ?? '—'} />
-            <SummaryRow label="Address" value={location?.place ?? '—'} />
-          </div>
-        </section>
+        <SummarySection title="Shelter Summary">
+          <SummaryRow label="Name" value={name} />
+          <SummaryRow label="Organization" value={organization?.name ?? '—'} />
+          <SummaryRow label="Address" value={location?.place ?? '—'} />
+        </SummarySection>
 
-        <section className={cardClassName}>
-          <h3 className="text-base font-semibold text-[#111827]">
-            Bed Summary
-          </h3>
-          <div className="mt-3 divide-y divide-[#F3F4F6]">
-            <SummaryRow label="Total" value={bedCounts.total} />
-            <SummaryRow label="Available" value={bedCounts.available} />
-            <SummaryRow label="Occupied" value={bedCounts.occupied} />
-            <SummaryRow label="Reserved" value={bedCounts.reserved} />
-            <SummaryRow label="In Turnaround" value={bedCounts.inTurnaround} />
-            <SummaryRow label="Out of Service" value={bedCounts.outOfService} />
-          </div>
-        </section>
-
-        <section className={cardClassName}>
-          <h3 className="text-base font-semibold text-[#111827]">
-            Room Summary
-          </h3>
-          <div className="mt-3 divide-y divide-[#F3F4F6]">
-            <SummaryRow label="Total" value={roomCounts.total} />
-            <SummaryRow label="Available" value={roomCounts.available} />
-            <SummaryRow label="Occupied" value={roomCounts.occupied} />
-            <SummaryRow label="Reserved" value={roomCounts.reserved} />
-            <SummaryRow label="In Turnaround" value={roomCounts.inTurnaround} />
-            <SummaryRow label="Out of Service" value={roomCounts.outOfService} />
-          </div>
-        </section>
+        <CountsSection title="Bed Summary" counts={bedCounts} />
+        <CountsSection title="Room Summary" counts={roomCounts} />
       </div>
     </div>
   );

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.tsx
@@ -1,0 +1,80 @@
+import type { Ref } from 'react';
+import { Text } from '../../components/base-ui/text/text';
+import './report.css';
+import { ShelterReportData } from './types';
+
+const cardClassName = 'rounded-xl border border-[#E5E7EB] bg-white p-5';
+
+function SummaryRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="flex items-center justify-between py-2 text-sm">
+      <span className="text-[#6B7280]">{label}</span>
+      <span className="font-medium text-[#111827]">{value}</span>
+    </div>
+  );
+}
+
+export function ShelterReportPrint({
+  data,
+  ref,
+}: {
+  data: ShelterReportData;
+  ref?: Ref<HTMLDivElement>;
+}) {
+  const { name, organization, location, bedCounts, roomCounts } = data;
+
+  return (
+    <div ref={ref} className="shelter-report-print">
+      <div className="grid gap-4 p-6">
+        <header>
+          <Text variant="header-md">{name}</Text>
+        </header>
+
+        <section className={cardClassName}>
+          <h3 className="text-base font-semibold text-[#111827]">
+            Shelter Summary
+          </h3>
+          <div className="mt-3 divide-y divide-[#F3F4F6]">
+            <SummaryRow label="Name" value={name} />
+            <SummaryRow label="Organization" value={organization?.name ?? '—'} />
+            <SummaryRow label="Address" value={location?.place ?? '—'} />
+          </div>
+        </section>
+
+        <section className={cardClassName}>
+          <h3 className="text-base font-semibold text-[#111827]">
+            Bed Summary
+          </h3>
+          <div className="mt-3 divide-y divide-[#F3F4F6]">
+            <SummaryRow label="Total" value={bedCounts.total} />
+            <SummaryRow label="Available" value={bedCounts.available} />
+            <SummaryRow label="Occupied" value={bedCounts.occupied} />
+            <SummaryRow label="Reserved" value={bedCounts.reserved} />
+            <SummaryRow label="In Turnaround" value={bedCounts.inTurnaround} />
+            <SummaryRow label="Out of Service" value={bedCounts.outOfService} />
+          </div>
+        </section>
+
+        <section className={cardClassName}>
+          <h3 className="text-base font-semibold text-[#111827]">
+            Room Summary
+          </h3>
+          <div className="mt-3 divide-y divide-[#F3F4F6]">
+            <SummaryRow label="Total" value={roomCounts.total} />
+            <SummaryRow label="Available" value={roomCounts.available} />
+            <SummaryRow label="Occupied" value={roomCounts.occupied} />
+            <SummaryRow label="Reserved" value={roomCounts.reserved} />
+            <SummaryRow label="In Turnaround" value={roomCounts.inTurnaround} />
+            <SummaryRow label="Out of Service" value={roomCounts.outOfService} />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/libs/react/shelter-operator/src/lib/pages/report/report.css
+++ b/libs/react/shelter-operator/src/lib/pages/report/report.css
@@ -1,0 +1,6 @@
+.shelter-report-print {
+  width: 800px;
+  max-width: 800px;
+  margin: 0 auto;
+  background: #fff;
+}

--- a/libs/react/shelter-operator/src/lib/pages/report/types.ts
+++ b/libs/react/shelter-operator/src/lib/pages/report/types.ts
@@ -1,0 +1,8 @@
+import type { GetShelterOperatorOverviewQuery } from '../../components/overview/__generated__/overview.generated';
+
+/**
+ * The shelter data the printed report renders — the `operatorShelter` shape
+ * returned by GetShelterOperatorOverview. Derived from codegen so the report
+ * follows the query rather than drifting from it.
+ */
+export type ShelterReportData = GetShelterOperatorOverviewQuery['operatorShelter'];

--- a/libs/react/shelter-operator/src/lib/routing/routePaths.ts
+++ b/libs/react/shelter-operator/src/lib/routing/routePaths.ts
@@ -19,6 +19,7 @@ export const paths = {
   users: '/operator/users',
   shelter: '/operator/shelter/:shelterId',
   shelterCreate: '/operator/shelter/create',
+  shelterReport: '/operator/shelter/:shelterId/report',
 } as const;
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -122,6 +123,13 @@ export function shelterEditResourceRoute(
     `${shelterMgmtResourceRoute(shelterId, resource)}/${mgmtRouteConfig.actions.edit}`,
     { id: resourceId },
   );
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+/** /operator/shelter/5/report */
+export function shelterReportRoute(shelterId: string): string {
+  return generatePath(paths.shelterReport, { shelterId });
 }
 
 // ── Profile ───────────────────────────────────────────────────────────────────

--- a/libs/react/shelter-operator/vite.config.ts
+++ b/libs/react/shelter-operator/vite.config.ts
@@ -1,5 +1,17 @@
+import path from 'path';
 import { mergeConfig } from 'vitest/config';
-import { baseVitestConfig } from '../../../libs/vite-utils/src/index';
+import {
+  baseVitestConfig,
+  monorepoTsconfigAliases,
+  svgTestResolver,
+} from '../../../libs/vite-utils/src/index';
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../..');
+
 export default mergeConfig(baseVitestConfig, {
+  plugins: process.env.VITEST ? [svgTestResolver()] : [],
+  resolve: {
+    alias: monorepoTsconfigAliases(WORKSPACE_ROOT),
+  },
   test: { environment: 'jsdom' },
 });


### PR DESCRIPTION
﻿**Stack 2 of 3** â€” builds on #2319.

## Problem

Shelter capacity has to be reported outside the app, and there's no document to hand anyone. Operators screenshot the overview or retype counts, so what leaves the building can quietly disagree with what the system says.

## Solution

A printable shelter report at a stable per-shelter URL, backed by the same query as the operator overview â€” printed numbers can't drift from on-screen ones because they come from the same source.

Export stays disabled until data arrives, so the button can't produce a blank or half-populated document, and the loading, error, and empty cases each say what happened instead of rendering an empty report.

Scope: this is the summary-counts report, a point-in-time snapshot of bed and room status. The ticket's broader utilization goal is not addressed here and would need backend aggregation that doesn't exist yet.

## How to test

The query is gated on organization permission and the app sends the active org with each request, so a superuser with no org membership gets a permission error rather than a report.

1. Sign in as a user belonging to an organization that holds the Shelter Operator role on the shelter.
2. Open `/operator/shelter/<id>/report` â€” nothing links here until 3/3.
3. Expect Shelter / Bed / Room summaries matching the operator overview, then click Export PDF.

Give the shelter different bed and room totals when seeding. If Room Summary shows the bed numbers, that's the bug worth catching.

## Summary by Sourcery

Add a dedicated shelter report route and page that renders a printable summary of shelter, bed, and room counts with PDF export support.

New Features:
- Introduce a shelter report route at /operator/shelter/:shelterId/report wired into the operator app routing.
- Add a printable shelter report view that displays shelter, bed, and room summaries based on the existing operator overview query.
- Provide an Export PDF action that captures the rendered report and saves it as a shelter-specific PDF file.

Enhancements:
- Derive the shelter report data type directly from the GetShelterOperatorOverview query to keep the report schema in sync with the overview.
- Apply focused layout and styling for the printable report so it matches operator UI cards while constraining page width for PDF export.

## Summary by Sourcery

Add a printable shelter report route that exports point-in-time shelter capacity summaries from the operator overview data.

New Features:
- Add a dedicated per-shelter report page that presents shelter, bed, and room summary counts and supports PDF export.

Bug Fixes:
- Prevent incomplete or blank reports from being exported by handling loading, error, and empty data states explicitly.

Enhancements:
- Reuse the operator overview data shape and query so printed report values remain consistent with the operator overview.
- Provide a focused printable layout for shelter reports.

Tests:
- Add coverage for report rendering, count accuracy, nullable fields, export-button state, and loading, error, and empty states.