### PR TITLE
feat(shelter-operator): link the printable report from the Reports tab [3/3]

### DIFF
--- a/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.test.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useParams,
+} from 'react-router-dom';
+import { ReportsPage } from './ReportsPage';
+
+// The charts and their metrics query are this tab's existing content, not what
+// this page adds — stub them out so the nav wiring is what's under test.
+vi.mock('../../components/reports/ReportsView', () => ({
+  ReportsView: ({ shelterId }: { shelterId?: string }) => (
+    <div data-testid="reports-view">reports for {shelterId}</div>
+  ),
+}));
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  const { shelterId } = useParams();
+
+  return <div data-testid="location">{`${pathname} (shelter ${shelterId})`}</div>;
+}
+
+function renderReportsTab(shelterId = '5') {
+  return render(
+    <MemoryRouter
+      initialEntries={[`/operator/shelter/${shelterId}/manage/reports`]}
+    >
+      <Routes>
+        <Route
+          path="/operator/shelter/:shelterId/manage/reports"
+          element={<ReportsPage />}
+        />
+        <Route
+          path="/operator/shelter/:shelterId/report"
+          element={<LocationProbe />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ReportsPage', () => {
+  it('renders the existing reports view for the current shelter', () => {
+    renderReportsTab('5');
+
+    expect(screen.getByTestId('reports-view').textContent).toBe(
+      'reports for 5'
+    );
+  });
+
+  it('navigates to the printable report for the current shelter', () => {
+    renderReportsTab('5');
+
+    fireEvent.click(screen.getByRole('button', { name: /printable report/i }));
+
+    expect(screen.getByTestId('location').textContent).toBe(
+      '/operator/shelter/5/report (shelter 5)'
+    );
+  });
+
+  it('carries the shelter id through rather than hardcoding one', () => {
+    renderReportsTab('42');
+
+    fireEvent.click(screen.getByRole('button', { name: /printable report/i }));
+
+    expect(screen.getByTestId('location').textContent).toBe(
+      '/operator/shelter/42/report (shelter 42)'
+    );
+  });
+
+  it('renders the report link as a button, not a nested anchor', () => {
+    renderReportsTab();
+
+    const button = screen.getByRole('button', { name: /printable report/i });
+
+    expect(button.closest('a')).toBeNull();
+    expect(screen.queryByRole('link', { name: /printable report/i })).toBeNull();
+  });
+});

--- a/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.tsx
@@ -1,5 +1,8 @@
-import { useParams } from 'react-router-dom';
+import { FileText } from 'lucide-react';
+import { Link, useParams } from 'react-router-dom';
 import { ReportsView } from '../../components/reports/ReportsView';
+import { Button } from '../../components/base-ui/buttons/buttons';
+import { shelterReportRoute } from '../../routing';
 
 export function ReportsPage() {
   const { shelterId } = useParams<{ shelterId: string }>();
@@ -8,5 +11,21 @@ export function ReportsPage() {
     throw new Error('Something went wrong. Please try again.');
   }
 
-  return <ReportsView shelterId={shelterId} />;
+  return (
+    <>
+      <div className="flex justify-end px-6 pt-6">
+        <Link to={shelterReportRoute(shelterId)}>
+          <Button
+            variant="primary"
+            color="blue"
+            leftIcon={<FileText size={20} />}
+          >
+            Printable Report
+          </Button>
+        </Link>
+      </div>
+
+      <ReportsView shelterId={shelterId} />
+    </>
+  );
 }

--- a/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.tsx
@@ -1,11 +1,12 @@
 import { FileText } from 'lucide-react';
-import { Link, useParams } from 'react-router-dom';
-import { ReportsView } from '../../components/reports/ReportsView';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '../../components/base-ui/buttons/buttons';
+import { ReportsView } from '../../components/reports/ReportsView';
 import { shelterReportRoute } from '../../routing';
 
 export function ReportsPage() {
   const { shelterId } = useParams<{ shelterId: string }>();
+  const navigate = useNavigate();
 
   if (!shelterId) {
     throw new Error('Something went wrong. Please try again.');
@@ -14,15 +15,14 @@ export function ReportsPage() {
   return (
     <>
       <div className="flex justify-end px-6 pt-6">
-        <Link to={shelterReportRoute(shelterId)}>
-          <Button
-            variant="primary"
-            color="blue"
-            leftIcon={<FileText size={20} />}
-          >
-            Printable Report
-          </Button>
-        </Link>
+        <Button
+          variant="primary"
+          color="blue"
+          leftIcon={<FileText size={20} />}
+          onClick={() => navigate(shelterReportRoute(shelterId))}
+        >
+          Printable Report
+        </Button>
       </div>
 
       <ReportsView shelterId={shelterId} />

--- a/libs/react/shelter-operator/src/lib/routing/routePaths.test.ts
+++ b/libs/react/shelter-operator/src/lib/routing/routePaths.test.ts
@@ -1,0 +1,16 @@
+import { paths, shelterReportRoute } from './routePaths';
+
+describe('shelterReportRoute', () => {
+  it('builds the printable report path for a shelter', () => {
+    expect(shelterReportRoute('5')).toBe('/operator/shelter/5/report');
+  });
+
+  it('substitutes the id rather than returning the pattern', () => {
+    expect(shelterReportRoute('42')).toBe('/operator/shelter/42/report');
+    expect(shelterReportRoute('42')).not.toContain(':shelterId');
+  });
+
+  it('stays in step with the route the app registers', () => {
+    expect(paths.shelterReport).toBe('/operator/shelter/:shelterId/report');
+  });
+});


### PR DESCRIPTION
﻿**Stack 3 of 3** â€” builds on #2320.

## Problem

The printable report exists but nothing links to it, so it's reachable only by typing a URL. For operators, that means it doesn't exist.

## Solution

An entry point on the Reports tab, which is the live reporting surface today.

The original plan put this on the shelter dashboard, but that page is no longer routed on `main` â€” the manage root redirects to beds and nothing renders it. If reviving it is intended work, this PR deliberately leaves it alone.

## How to test

Open a shelter â†’ Manage â†’ Reports â†’ **Printable Report**, and confirm it lands on that shelter's report.

## Summary by Sourcery

Link the shelter Reports tab to its printable report for the current shelter.

New Features:
- Add a Printable Report entry point to the shelter Reports tab.

Tests:
- Add coverage for printable report navigation, shelter ID propagation, and button semantics.
- Add coverage ensuring printable report route generation stays aligned with the registered route.
