### PR TITLE
ci: run the GraphQL Inspector after typecheck and tests

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -174,17 +174,6 @@ jobs:
           fi
           EOF
 
-      - name: 🕵🏻‍♂️ GraphQL Inspector
-        uses: kamilkisiela/graphql-inspector@master
-        # Warning: This now skips schema breaking checks in forked repositories.
-        # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          schema: main:apps/betterangels-backend/schema.graphql
-          fail-on-breaking: true
-          approve-label: graphql-inspector:approved-breaking-change
-
       - name: 🔬 Typecheck
         run: |
           docker compose run better-angels bash <<'EOF'
@@ -197,6 +186,17 @@ jobs:
           # Exclude Betterangels Frontend Given its CI is not setup yet
           yarn nx affected -t test
           EOF
+
+      - name: 🕵🏻‍♂️ GraphQL Inspector
+        uses: kamilkisiela/graphql-inspector@master
+        # Warning: This now skips schema breaking checks in forked repositories.
+        # Resolve in: https://betterangels.atlassian.net/browse/DEV-690
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          schema: main:apps/betterangels-backend/schema.graphql
+          fail-on-breaking: true
+          approve-label: graphql-inspector:approved-breaking-change
 
       - name: 🛠️ Build and Push Artifacts
         run: |


### PR DESCRIPTION
## What

Moves the `🕵🏻‍♂️ GraphQL Inspector` step to run **after** `🔬 Typecheck` and `🧪 Test`, instead of before them. Same step, same inputs, same job — only the position changes.

## Why

The Inspector fails the job on any breaking schema change until someone applies the `graphql-inspector:approved-breaking-change` label. Because steps short-circuit, that failure prevented Typecheck and Test from running at all.

The practical effect: a PR with an intentional breaking change reports a red `BuildTestDeploy` with **no test signal whatsoever**, and nothing in the log indicating what actually broke. Hit this on the org-scoped teams stack (#2310, #2317) — two full CI cycles produced ~5-minute runs that looked like failures but contained no test results, because the pipeline aborted before the tests.

With the reorder, a breaking-change PR still tells you whether its code works, and the Inspector failure stands alone as the one item needing a human decision.

## Note

This does not change what the Inspector checks or when it fails — a breaking change still blocks the job until the label is applied. It only stops that block from hiding the test results.

## Summary by Sourcery

Run typecheck and tests before GraphQL Inspector validation to preserve actionable CI results for breaking schema changes.

Enhancements:
- Run GraphQL schema compatibility checks after typechecking and tests so breaking schema changes no longer suppress code-quality and test results.

CI:
- Reorder the GraphQL Inspector workflow step to execute after Typecheck and Test while preserving its existing validation and failure behavior.