### PR TITLE
fix(permissions): require the user's group to be the group holding the perm

### DIFF
--- a/apps/betterangels-backend/common/permissions/utils.py
+++ b/apps/betterangels-backend/common/permissions/utils.py
@@ -249,15 +249,25 @@ def _org_perm_exists_across_fields(
     codename: str,
     fields: list[str],
 ) -> Q:
-    """Return a ``Q`` checking the user holds a permission on any of the org fields."""
+    """Return a ``Q`` checking the user holds a permission on any of the org fields.
+
+    Both conditions — that *user* is in the group, and that the group carries
+    the permission — MUST stay inside a single ``.filter()`` call.
+    ``Organization.permission_groups`` is multi-valued, so chaining them as two
+    ``.filter()`` calls builds two independent joins and lets them be satisfied
+    by *different* permission groups: "user is in some group of this org, and
+    some group of this org has the permission". Every organization is
+    provisioned with every template, so that reads as "any member holds every
+    permission any template in their org has".
+    """
     return reduce(
         or_,
         (
             Q(
                 Exists(
-                    Organization.objects.filter(pk=OuterRef(f))
-                    .filter(permission_groups__group__user=user)
-                    .filter(_perm_q(app_label, codename))
+                    Organization.objects.filter(pk=OuterRef(f)).filter(
+                        Q(permission_groups__group__user=user) & _perm_q(app_label, codename)
+                    )
                 )
             )
             for f in fields

--- a/apps/betterangels-backend/common/tests/test_org_permissions.py
+++ b/apps/betterangels-backend/common/tests/test_org_permissions.py
@@ -10,11 +10,15 @@ template, effectively "any member holds every permission in their org".
 import uuid
 
 from accounts.groups import ORG_ADMIN
-from accounts.models import User
+from accounts.models import PermissionGroup, User
 from accounts.role_manager import OrgRoleManager
+from accounts.tests.baker_recipes import organization_recipe
+from common.permissions.utils import permissioned_queryset
 from common.tests.utils import GraphQLBaseTestCase
-from django.test import ignore_warnings
+from django.contrib.auth.models import Permission
+from django.test import TestCase, ignore_warnings
 from model_bakery import baker
+from organizations.models import Organization
 from teams.models import Team
 
 CREATE_TEAM = """
@@ -61,3 +65,46 @@ class OrgPermSameGroupTestCase(GraphQLBaseTestCase):
         payload = (response.get("data") or {}).get("createTeam") or {}
         self.assertIsNone(payload.get("id"))
         self.assertEqual(Team.objects.filter(name="Caseworker Team").count(), 0)
+
+
+class PermissionedQuerysetSameGroupTestCase(TestCase):
+    """Direct coverage of the helper, independent of any app's mutations.
+
+    The end-to-end case above goes through ``createTeam``; this pins the same
+    rule at the level the fix lives, so it still holds if that mutation changes.
+    """
+
+    def setUp(self) -> None:
+        self.org = organization_recipe.make(name="perm_same_group_org")
+        self.user = baker.make(User, username=f"member_{uuid.uuid4()}")
+        self.org.add_user(self.user)
+
+        groups = list(PermissionGroup.objects.filter(organization=self.org).select_related("group")[:2])
+        assert len(groups) >= 2, "the org recipe should provision at least two permission groups"
+        self.member_group, self.holder_group = groups[0], groups[1]
+
+        permission = Permission.objects.exclude(pk__in=self.member_group.group.permissions.values("pk")).first()
+        assert permission is not None
+        self.permission = permission
+
+        # The permission lives in one group; the user belongs to the other.
+        self.holder_group.group.permissions.add(self.permission)
+        self.member_group.group.user_set.add(self.user)
+
+    def _matches(self) -> bool:
+        perm = f"{self.permission.content_type.app_label}.{self.permission.codename}"
+        return permissioned_queryset(
+            Organization.objects.all(),
+            user=self.user,
+            organization_id=str(self.org.pk),
+            perms=[perm],
+            organization_field="pk",
+        ).exists()
+
+    def test_membership_in_one_group_does_not_borrow_another_groups_permission(self) -> None:
+        self.assertFalse(self._matches())
+
+    def test_membership_in_the_holding_group_matches(self) -> None:
+        self.holder_group.group.user_set.add(self.user)
+
+        self.assertTrue(self._matches())

--- a/apps/betterangels-backend/common/tests/test_org_permissions.py
+++ b/apps/betterangels-backend/common/tests/test_org_permissions.py
@@ -1,0 +1,63 @@
+"""HasOrgPerm must match the user's group against the permission-holding group.
+
+``Organization.permission_groups`` is multi-valued, so two chained ``.filter()``
+calls on it build independent joins and can be satisfied by different groups.
+That made ``HasOrgPerm(X)`` mean "the user is in some group of this org, and
+some group of this org has X" — and since every org is provisioned with every
+template, effectively "any member holds every permission in their org".
+"""
+
+import uuid
+
+from accounts.groups import ORG_ADMIN
+from accounts.models import User
+from accounts.role_manager import OrgRoleManager
+from common.tests.utils import GraphQLBaseTestCase
+from django.test import ignore_warnings
+from model_bakery import baker
+from teams.models import Team
+
+CREATE_TEAM = """
+    mutation ($data: CreateTeamInput!) {
+        createTeam(data: $data) {
+            ... on OperationInfo { messages { kind field message } }
+            ... on TeamType { id name }
+        }
+    }
+"""
+
+
+@ignore_warnings(category=UserWarning)
+class OrgPermSameGroupTestCase(GraphQLBaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        # Provision the Org Admin template for org_1 so the org holds a group
+        # carrying teams.* — the permissions the caseworker must NOT inherit.
+        self.org_1_admin = baker.make(User, username=f"org_admin_{uuid.uuid4()}")
+        self.org_1.add_user(self.org_1_admin)
+        OrgRoleManager(self.org_1).add_roles(self.org_1_admin, ORG_ADMIN)
+
+        self._set_active_org(self.org_1)
+
+    def _create_team(self, name: str) -> dict:
+        return self.execute_graphql(CREATE_TEAM, {"data": {"name": name}})
+
+    def test_org_admin_can_create_a_team(self) -> None:
+        """The permission still works for the group that actually holds it."""
+        self.graphql_client.force_login(self.org_1_admin)
+
+        response = self._create_team("Admin Team")
+
+        team_id = response["data"]["createTeam"]["id"]
+        self.assertEqual(Team.objects.get(pk=team_id).organization_id, self.org_1.pk)
+
+    def test_caseworker_cannot_create_a_team(self) -> None:
+        """A caseworker holds no teams.* perms, even though Org Admin does."""
+        self.graphql_client.force_login(self.org_1_case_manager_1)
+
+        response = self._create_team("Caseworker Team")
+
+        payload = (response.get("data") or {}).get("createTeam") or {}
+        self.assertIsNone(payload.get("id"))
+        self.assertEqual(Team.objects.filter(name="Caseworker Team").count(), 0)


### PR DESCRIPTION
## The bug

`_org_perm_exists_across_fields` (which backs `HasOrgPerm` and `permissioned_queryset`) chained two `.filter()` calls on `Organization.permission_groups`:

```python
Organization.objects.filter(pk=OuterRef(f))
    .filter(permission_groups__group__user=user)   # join #1
    .filter(_perm_q(app_label, codename))          # join #2 — independent
```

`permission_groups` is a multi-valued reverse FK, and chained `.filter()` calls on a multi-valued relation build **independent joins**. So the group the user belongs to and the group holding the permission did not have to be the same group.

The check therefore meant:

> the user is in *some* group of this org, **and** *some* group of this org has the permission

rather than:

> the user is in a group of this org **that has** the permission

## Impact

Every organization is provisioned with every template, so in practice **any org member held the union of every template's permissions in their org.**

Confirmed: a **Caseworker can create, rename, and delete teams** — `Team.perms.*` belong only to `Organization Admin`. The same path reaches the rest of the Org Admin / Org Superuser set wherever `HasOrgPerm` gates it, including `ADD_ORG_MEMBER`, `REMOVE_ORG_MEMBER`, `VIEW_ORG_MEMBERS`, `VIEW_REPORTS`, and `CHANGE_ORG_MEMBER_ROLE`.

## The fix

Move both conditions into a single `.filter()` call, so Django reuses one join and they must be satisfied by the same `PermissionGroup`.

Verified against the compiled SQL — `JOIN "accounts_permissiongroup"` count drops from **2 to 1**:

```
OLD (chained .filter): JOINs on accounts_permissiongroup = 2
NEW (single .filter):  JOINs on accounts_permissiongroup = 1
```

The docstring now spells out why the conditions must stay in one `.filter()`, since re-splitting them silently restores the hole.

## Tests

`common/tests/test_org_permissions.py` covers both directions: an Org Admin can still create a team (the permission works for the group that holds it), and a Caseworker cannot (no inheritance across groups).

## Review notes

- **This is pre-existing, not from the teams stack.** It is on `main` today.
- **Please review this as a security change with wide blast radius.** `permissioned_queryset` backs shelters, accounts, reports, notes, and tasks. Tightening it may surface tests or flows that unknowingly relied on the loose behavior — if CI shows failures elsewhere, those are real permission assumptions worth examining, not noise to suppress.
- Deliberately kept **off** the org-scoped teams stack (#2317 → #2310 → #2311 → #2312) so it gets its own review and its own CI signal, and so unrelated fallout does not block that work.
- Found by a `createTeam` test written while verifying org-scoped team management. There were no team mutation tests before, which is why this went unnoticed.

## Summary by Sourcery

Enforce same-group organization permission checks to close cross-group permission inheritance.

Bug Fixes:
- Require organization permissions to be granted by the same permission group that contains the user, preventing members from inheriting permissions from unrelated groups.
- Prevent unauthorized organization members, such as caseworkers, from accessing organization-admin-only actions.

Enhancements:
- Document the multi-valued relationship constraint to prevent the permission check from being weakened in future changes.

Tests:
- Add end-to-end coverage confirming organization admins can create teams while caseworkers cannot.
- Add direct coverage confirming permissioned querysets only match when membership and permissions belong to the same group.