### PR TITLE
feat(notes,tasks): reject a team from another organization

### DIFF
--- a/apps/betterangels-backend/common/tests/utils.py
+++ b/apps/betterangels-backend/common/tests/utils.py
@@ -199,9 +199,11 @@ class GraphQLBaseTestCase(
         self.org_1 = organization_recipe.make(name="org_1")
         self.org_2 = organization_recipe.make(name="org_2")
 
-        # Two teams so a multi-value ``teamIds`` filter has something to sort.
+        # Two teams in org_1 so a multi-value ``teamIds`` filter has something to
+        # sort; one in org_2 so cross-org tests have a team to be refused.
         self.org_1_team_1 = baker.make(Team, organization=self.org_1)
         self.org_1_team_2 = baker.make(Team, organization=self.org_1)
+        self.org_2_team_1 = baker.make(Team, organization=self.org_2)
 
         # Permission groups are created by create_organization_with_presets
         # (via the recipe helper). Roles are assigned explicitly instead of

--- a/apps/betterangels-backend/common/tests/utils.py
+++ b/apps/betterangels-backend/common/tests/utils.py
@@ -199,8 +199,8 @@ class GraphQLBaseTestCase(
         self.org_1 = organization_recipe.make(name="org_1")
         self.org_2 = organization_recipe.make(name="org_2")
 
-        # Two teams in org_1 so a multi-value ``teamIds`` filter has something to
-        # sort; one in org_2 so cross-org tests have a team to be refused.
+        # Two in org_1 so a multi-value ``teamIds`` filter has something to sort;
+        # one in org_2 for cross-org tests.
         self.org_1_team_1 = baker.make(Team, organization=self.org_1)
         self.org_1_team_2 = baker.make(Team, organization=self.org_1)
         self.org_2_team_1 = baker.make(Team, organization=self.org_2)

--- a/apps/betterangels-backend/notes/models.py
+++ b/apps/betterangels-backend/notes/models.py
@@ -8,6 +8,7 @@ from betterangels_backend import settings
 from common.models import Attachment, BaseModel, Location
 from common.permissions.utils import permission_enums_to_django_meta_permissions
 from django.contrib.contenttypes.fields import GenericRelation
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
@@ -16,6 +17,7 @@ from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase
 from notes.permissions import PrivateDetailsPermissions
 from organizations.models import Organization
 from teams.models import Team
+from teams.validators import validate_team_in_org
 
 from .enums import ServiceRequestStatusEnum
 
@@ -165,6 +167,21 @@ class Note(BaseModel):
 
     def __str__(self) -> str:
         return self.purpose or str(self.id)
+
+    def clean(self) -> None:
+        """Reject a team from another organization.
+
+        Runs from the Django admin's ``ModelForm``, whose ``team`` field offers
+        every team in every organization. The services call the same validator
+        directly; that call is the redundant one once #2335 adds
+        ``full_clean()``.
+        """
+        super().clean()
+
+        try:
+            validate_team_in_org(team_id=self.team_id, organization_id=self.organization_id)
+        except ValidationError as exc:
+            raise ValidationError({"team": exc.messages}) from exc
 
     def revert_action(self, action: str, diff: Dict[str, Any], *args: Any, **kwargs: Any) -> None:
         match action:

--- a/apps/betterangels-backend/notes/models.py
+++ b/apps/betterangels-backend/notes/models.py
@@ -171,9 +171,7 @@ class Note(BaseModel):
     def clean(self) -> None:
         """Reject a team from another organization.
 
-        Runs from the Django admin's ``ModelForm``, whose ``team`` field offers
-        every team in every organization. The services call the same validator
-        directly; that call is the redundant one once #2335 adds
+        The services' explicit call is the duplicate to delete once #2335 adds
         ``full_clean()``.
         """
         super().clean()

--- a/apps/betterangels-backend/notes/services.py
+++ b/apps/betterangels-backend/notes/services.py
@@ -27,6 +27,7 @@ from notes.permissions import (
     ServiceRequestPermissions,
 )
 from tasks.services import task_create
+from teams.validators import validate_team_in_org
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -70,12 +71,20 @@ def note_update(
     Core fields are updated in-place. Nested relation fields use
     replace-all semantics: existing items are removed and new ones created.
     Caller is responsible for permission checks.
+
+    ``"team_id" in data`` is the presence test because ``strawberry.asdict``
+    omits keys for fields the client did not send. The team validation below
+    duplicates ``Note.clean()``, which this path never reaches; #2335 adds
+    ``full_clean()`` and the explicit call goes away.
     """
     # Extract nested relation data (handle separately)
     location_data = data.pop("location", None)
     provided_services_data = data.pop("provided_services", None)
     requested_services_data = data.pop("requested_services", None)
     tasks_data = data.pop("tasks", None)
+
+    if "team_id" in data:
+        validate_team_in_org(team_id=data["team_id"], organization_id=note.organization_id)
 
     with pghistory.context(note_id=str(note.id), timestamp=timezone.now(), label="note_update"):
         for field, value in data.items():
@@ -251,6 +260,8 @@ def note_create(
     All nested params (location, services, tasks) are optional,
     making this backward-compatible with callers that only send core fields.
     """
+
+    validate_team_in_org(team_id=team_id, organization_id=permission_group.organization_id)
 
     location = None
     if location_data:

--- a/apps/betterangels-backend/notes/services.py
+++ b/apps/betterangels-backend/notes/services.py
@@ -71,11 +71,6 @@ def note_update(
     Core fields are updated in-place. Nested relation fields use
     replace-all semantics: existing items are removed and new ones created.
     Caller is responsible for permission checks.
-
-    ``"team_id" in data`` is the presence test because ``strawberry.asdict``
-    omits keys for fields the client did not send. The team validation below
-    duplicates ``Note.clean()``, which this path never reaches; #2335 adds
-    ``full_clean()`` and the explicit call goes away.
     """
     # Extract nested relation data (handle separately)
     location_data = data.pop("location", None)

--- a/apps/betterangels-backend/notes/tests/test_models.py
+++ b/apps/betterangels-backend/notes/tests/test_models.py
@@ -2,10 +2,13 @@ from datetime import datetime, timezone
 
 import time_machine
 from accounts.models import User
+from accounts.tests.baker_recipes import organization_recipe
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from model_bakery import baker
 from notes.enums import ServiceRequestStatusEnum
-from notes.models import OrganizationService, ServiceRequest
+from notes.models import Note, OrganizationService, ServiceRequest
+from teams.models import Team
 
 
 class ServiceRequestModelTestCase(TestCase):
@@ -44,3 +47,32 @@ class ServiceRequestModelTestCase(TestCase):
             service_request_to_do.completed_on,
             datetime(2024, 3, 11, 10, 11, 12, tzinfo=timezone.utc),
         )
+
+
+class NoteTeamOrgValidationTestCase(TestCase):
+    """A note's team must belong to the note's organization."""
+
+    def setUp(self) -> None:
+        self.org = organization_recipe.make()
+        self.other_org = organization_recipe.make()
+        self.own_team = baker.make(Team, organization=self.org)
+        self.other_team = baker.make(Team, organization=self.other_org)
+
+    def test_clean_allows_a_team_from_the_same_org(self) -> None:
+        note = baker.make(Note, organization=self.org, team=self.own_team)
+
+        note.clean()
+
+    def test_clean_allows_no_team(self) -> None:
+        note = baker.make(Note, organization=self.org, team=None)
+
+        note.clean()
+
+    def test_clean_rejects_a_team_from_another_org(self) -> None:
+        # Unsaved: #2312 adds a composite FK that makes the row unstorable.
+        note = Note(organization=self.org, team=self.other_team)
+
+        with self.assertRaises(ValidationError) as ctx:
+            note.clean()
+
+        self.assertIn("team", ctx.exception.message_dict)

--- a/apps/betterangels-backend/notes/tests/test_mutations.py
+++ b/apps/betterangels-backend/notes/tests/test_mutations.py
@@ -65,7 +65,7 @@ class NoteMutationTestCase(NoteGraphQLBaseTestCase):
             "interactedAt": "2024-03-12T10:11:12+00:00",
         }
 
-        expected_query_count = 21
+        expected_query_count = 22
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self._update_note_fixture(variables)
 
@@ -1030,3 +1030,49 @@ class NoteRevertMutationTestCase(NoteGraphQLBaseTestCase, TaskGraphQLUtilsMixin)
         # Verify atomicity: the note should remain in its pre-revert state
         note = Note.objects.get(pk=note_id)
         self.assertEqual(note.purpose, "Discarded Purpose")
+
+
+class NoteTeamValidationMutationTestCase(NoteGraphQLBaseTestCase):
+    """A note may only reference a team from its own organization."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._handle_user_login("org_1_case_manager_1")
+
+    def test_create_note_rejects_a_team_from_another_org(self) -> None:
+        response = self._create_note_fixture(
+            {
+                "purpose": "Org 1 note",
+                "publicDetails": "Should not be created",
+                "clientProfile": self.client_profile_1.pk,
+                "teamId": str(self.org_2_team_1.pk),
+            }
+        )
+
+        messages = response["data"]["createNote"]["messages"]
+        self.assertEqual(messages[0]["kind"], "VALIDATION")
+        self.assertEqual(messages[0]["message"], "The selected team does not belong to this organization.")
+        self.assertEqual(Note.objects.filter(purpose="Org 1 note").count(), 0)
+
+    def test_create_note_rejects_a_nested_task_team_from_another_org(self) -> None:
+        response = self._create_note_fixture(
+            {
+                "purpose": "Org 1 note",
+                "publicDetails": "Should not be created",
+                "clientProfile": self.client_profile_1.pk,
+                "tasks": [{"summary": "Follow up", "teamId": str(self.org_2_team_1.pk)}],
+            }
+        )
+
+        messages = response["data"]["createNote"]["messages"]
+        self.assertEqual(messages[0]["kind"], "VALIDATION")
+        self.assertEqual(messages[0]["message"], "The selected team does not belong to this organization.")
+        self.assertEqual(Note.objects.filter(purpose="Org 1 note").count(), 0)
+
+    def test_update_note_rejects_a_team_from_another_org(self) -> None:
+        response = self._update_note_fixture({"id": self.note["id"], "teamId": str(self.org_2_team_1.pk)})
+
+        messages = response["data"]["updateNote"]["messages"]
+        self.assertEqual(messages[0]["kind"], "VALIDATION")
+        self.assertEqual(messages[0]["message"], "The selected team does not belong to this organization.")
+        self.assertIsNone(Note.objects.get(pk=self.note["id"]).team_id)

--- a/apps/betterangels-backend/tasks/models.py
+++ b/apps/betterangels-backend/tasks/models.py
@@ -59,9 +59,7 @@ class Task(BaseModel):
     def clean(self) -> None:
         """Reject a team from another organization.
 
-        Runs from the Django admin's ``ModelForm``, whose ``team`` field offers
-        every team in every organization. The services call the same validator
-        directly; that call is the redundant one once #2335 adds
+        The services' explicit call is the duplicate to delete once #2335 adds
         ``full_clean()``.
         """
         super().clean()

--- a/apps/betterangels-backend/tasks/models.py
+++ b/apps/betterangels-backend/tasks/models.py
@@ -2,10 +2,12 @@ import pghistory
 from accounts.models import User
 from common.models import BaseModel
 from django.contrib.postgres.indexes import GinIndex
+from django.core.exceptions import ValidationError
 from django.db import models
 from django_choices_field import IntegerChoicesField
 from organizations.models import Organization
 from teams.models import Team
+from teams.validators import validate_team_in_org
 
 from .managers import TaskManager
 
@@ -53,6 +55,21 @@ class Task(BaseModel):
 
     def __str__(self) -> str:
         return self.summary
+
+    def clean(self) -> None:
+        """Reject a team from another organization.
+
+        Runs from the Django admin's ``ModelForm``, whose ``team`` field offers
+        every team in every organization. The services call the same validator
+        directly; that call is the redundant one once #2335 adds
+        ``full_clean()``.
+        """
+        super().clean()
+
+        try:
+            validate_team_in_org(team_id=self.team_id, organization_id=self.organization_id)
+        except ValidationError as exc:
+            raise ValidationError({"team": exc.messages}) from exc
 
     class Meta:
         ordering = ["-updated_at"]

--- a/apps/betterangels-backend/tasks/services.py
+++ b/apps/betterangels-backend/tasks/services.py
@@ -8,6 +8,7 @@ from django.db import IntegrityError
 from hmis.models import HmisClientProfile, HmisNote
 from notes.models import Note
 from tasks.models import Task
+from teams.validators import validate_team_in_org
 
 # ---------------------------------------------------------------------------
 # Task
@@ -28,12 +29,14 @@ def task_create(
     created: List[Task] = []
 
     for item in data:
+        team_id = item.get("team_id")
+        validate_team_in_org(team_id=team_id, organization_id=permission_group.organization_id)
         try:
             task = Task.objects.create(
                 summary=item.get("summary", ""),
                 description=item.get("description") or "",
                 status=item.get("status") or Task.Status.TO_DO,
-                team_id=item.get("team_id"),
+                team_id=team_id,
                 note=note,
                 hmis_note=hmis_note,
                 client_profile=client_profile,
@@ -63,7 +66,16 @@ def task_update(
     task: Task,
     data: Dict[str, Any],
 ) -> Task:
-    """Update a Task. Caller is responsible for permission checks."""
+    """Update a Task. Caller is responsible for permission checks.
+
+    ``"team_id" in data`` is the presence test because ``strawberry.asdict``
+    omits keys for fields the client did not send. The team validation below
+    duplicates ``Task.clean()``, which this path never reaches; #2335 adds
+    ``full_clean()`` and the explicit call goes away.
+    """
+    if "team_id" in data:
+        validate_team_in_org(team_id=data["team_id"], organization_id=task.organization_id)
+
     for field, value in data.items():
         if field != "id":
             setattr(task, field, value)

--- a/apps/betterangels-backend/tasks/services.py
+++ b/apps/betterangels-backend/tasks/services.py
@@ -66,13 +66,7 @@ def task_update(
     task: Task,
     data: Dict[str, Any],
 ) -> Task:
-    """Update a Task. Caller is responsible for permission checks.
-
-    ``"team_id" in data`` is the presence test because ``strawberry.asdict``
-    omits keys for fields the client did not send. The team validation below
-    duplicates ``Task.clean()``, which this path never reaches; #2335 adds
-    ``full_clean()`` and the explicit call goes away.
-    """
+    """Update a Task. Caller is responsible for permission checks."""
     if "team_id" in data:
         validate_team_in_org(team_id=data["team_id"], organization_id=task.organization_id)
 

--- a/apps/betterangels-backend/tasks/tests/test_models.py
+++ b/apps/betterangels-backend/tasks/tests/test_models.py
@@ -1,0 +1,51 @@
+from accounts.tests.baker_recipes import organization_recipe
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from model_bakery import baker
+from tasks.models import Task
+from teams.models import Team
+
+
+class TaskTeamOrgValidationTestCase(TestCase):
+    """A task's team must belong to the task's organization."""
+
+    def setUp(self) -> None:
+        self.org = organization_recipe.make()
+        self.other_org = organization_recipe.make()
+        self.own_team = baker.make(Team, organization=self.org)
+        self.other_team = baker.make(Team, organization=self.other_org)
+
+    def test_clean_allows_a_team_from_the_same_org(self) -> None:
+        task = baker.make(Task, organization=self.org, team=self.own_team)
+
+        task.clean()
+
+    def test_clean_allows_no_team(self) -> None:
+        task = baker.make(Task, organization=self.org, team=None)
+
+        task.clean()
+
+    def test_clean_rejects_a_team_from_another_org(self) -> None:
+        # Unsaved: #2312 adds a composite FK that makes the row unstorable.
+        task = Task(organization=self.org, team=self.other_team)
+
+        with self.assertRaises(ValidationError) as ctx:
+            task.clean()
+
+        self.assertIn("team", ctx.exception.message_dict)
+
+    def test_clean_allows_an_org_less_task_without_a_team(self) -> None:
+        # Deleting an organization nulls both columns, so this is the only
+        # org-less shape that exists; it has to stay editable in the admin.
+        task = baker.make(Task, organization=None, team=None)
+
+        task.clean()
+
+    def test_clean_rejects_a_team_on_an_org_less_task(self) -> None:
+        task = baker.make(Task, organization=None, team=None)
+        task.team = self.other_team
+
+        with self.assertRaises(ValidationError) as ctx:
+            task.clean()
+
+        self.assertIn("team", ctx.exception.message_dict)

--- a/apps/betterangels-backend/tasks/tests/test_mutations.py
+++ b/apps/betterangels-backend/tasks/tests/test_mutations.py
@@ -26,7 +26,7 @@ class TaskMutationTestCase(GraphQLBaseTestCase, TaskGraphQLUtilsMixin):
         client_profile = baker.make(ClientProfile)
         assert self.org
 
-        expected_query_count = 22
+        expected_query_count = 23
         with self.assertNumQueriesWithoutCache(expected_query_count):
             variables = {
                 "clientProfile": str(client_profile.pk),
@@ -81,7 +81,7 @@ class TaskMutationTestCase(GraphQLBaseTestCase, TaskGraphQLUtilsMixin):
             "teamId": str(self.org_1_team_1.pk),
         }
 
-        expected_query_count = 7
+        expected_query_count = 8
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.update_task_fixture(variables)
 
@@ -187,3 +187,33 @@ class TaskMutationTestCase(GraphQLBaseTestCase, TaskGraphQLUtilsMixin):
         error_message = payload["messages"][0]["message"]
         self.assertIn("task_single_parent_check", error_message)
         self.assertIn("violates", error_message)
+
+
+class TaskTeamValidationMutationTestCase(GraphQLBaseTestCase, TaskGraphQLUtilsMixin):
+    """A task may only reference a team from its own organization."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.graphql_client.force_login(self.org_1_case_manager_1)
+        self.task_id = self.create_task_fixture(
+            {
+                "summary": "Org 1 task to amend",
+                "teamId": str(self.org_1_team_1.pk),
+            }
+        )["data"]["createTask"]["id"]
+
+    def test_create_task_rejects_a_team_from_another_org(self) -> None:
+        response = self.create_task_fixture({"summary": "Org 1 task", "teamId": str(self.org_2_team_1.pk)})
+
+        messages = response["data"]["createTask"]["messages"]
+        self.assertEqual(messages[0]["kind"], "VALIDATION")
+        self.assertEqual(messages[0]["message"], "The selected team does not belong to this organization.")
+        self.assertEqual(Task.objects.filter(summary="Org 1 task").count(), 0)
+
+    def test_update_task_rejects_a_team_from_another_org(self) -> None:
+        response = self.update_task_fixture({"id": self.task_id, "teamId": str(self.org_2_team_1.pk)})
+
+        messages = response["data"]["updateTask"]["messages"]
+        self.assertEqual(messages[0]["kind"], "VALIDATION")
+        self.assertEqual(messages[0]["message"], "The selected team does not belong to this organization.")
+        self.assertEqual(Task.objects.get(pk=self.task_id).team_id, self.org_1_team_1.pk)

--- a/apps/betterangels-backend/tasks/tests/test_mutations.py
+++ b/apps/betterangels-backend/tasks/tests/test_mutations.py
@@ -195,12 +195,6 @@ class TaskTeamValidationMutationTestCase(GraphQLBaseTestCase, TaskGraphQLUtilsMi
     def setUp(self) -> None:
         super().setUp()
         self.graphql_client.force_login(self.org_1_case_manager_1)
-        self.task_id = self.create_task_fixture(
-            {
-                "summary": "Org 1 task to amend",
-                "teamId": str(self.org_1_team_1.pk),
-            }
-        )["data"]["createTask"]["id"]
 
     def test_create_task_rejects_a_team_from_another_org(self) -> None:
         response = self.create_task_fixture({"summary": "Org 1 task", "teamId": str(self.org_2_team_1.pk)})
@@ -211,9 +205,16 @@ class TaskTeamValidationMutationTestCase(GraphQLBaseTestCase, TaskGraphQLUtilsMi
         self.assertEqual(Task.objects.filter(summary="Org 1 task").count(), 0)
 
     def test_update_task_rejects_a_team_from_another_org(self) -> None:
-        response = self.update_task_fixture({"id": self.task_id, "teamId": str(self.org_2_team_1.pk)})
+        task_id = self.create_task_fixture(
+            {
+                "summary": "Org 1 task to amend",
+                "teamId": str(self.org_1_team_1.pk),
+            }
+        )["data"]["createTask"]["id"]
+
+        response = self.update_task_fixture({"id": task_id, "teamId": str(self.org_2_team_1.pk)})
 
         messages = response["data"]["updateTask"]["messages"]
         self.assertEqual(messages[0]["kind"], "VALIDATION")
         self.assertEqual(messages[0]["message"], "The selected team does not belong to this organization.")
-        self.assertEqual(Task.objects.get(pk=self.task_id).team_id, self.org_1_team_1.pk)
+        self.assertEqual(Task.objects.get(pk=task_id).team_id, self.org_1_team_1.pk)

--- a/apps/betterangels-backend/teams/tests/test_validators.py
+++ b/apps/betterangels-backend/teams/tests/test_validators.py
@@ -1,0 +1,35 @@
+from accounts.tests.baker_recipes import organization_recipe
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from model_bakery import baker
+from teams.models import Team
+from teams.validators import validate_team_in_org
+
+
+class ValidateTeamInOrgTestCase(TestCase):
+    def setUp(self) -> None:
+        self.org_1 = organization_recipe.make()
+        self.org_2 = organization_recipe.make()
+        self.org_1_team = baker.make(Team, organization=self.org_1)
+        self.org_2_team = baker.make(Team, organization=self.org_2)
+
+    def test_team_in_org_passes(self) -> None:
+        validate_team_in_org(team_id=self.org_1_team.pk, organization_id=self.org_1.pk)
+
+    def test_team_from_other_org_raises(self) -> None:
+        with self.assertRaises(ValidationError):
+            validate_team_in_org(team_id=self.org_2_team.pk, organization_id=self.org_1.pk)
+
+    def test_unknown_team_raises(self) -> None:
+        with self.assertRaises(ValidationError):
+            validate_team_in_org(team_id=999_999, organization_id=self.org_1.pk)
+
+    def test_no_team_passes(self) -> None:
+        validate_team_in_org(team_id=None, organization_id=self.org_1.pk)
+
+    def test_no_organization_raises_when_a_team_is_requested(self) -> None:
+        with self.assertRaises(ValidationError):
+            validate_team_in_org(team_id=self.org_1_team.pk, organization_id=None)
+
+    def test_no_organization_passes_without_a_team(self) -> None:
+        validate_team_in_org(team_id=None, organization_id=None)

--- a/apps/betterangels-backend/teams/validators.py
+++ b/apps/betterangels-backend/teams/validators.py
@@ -30,15 +30,7 @@ def validate_has_alphanumeric(value: str) -> None:
 
 
 def validate_team_in_org(*, team_id: int | str | None, organization_id: int | None) -> None:
-    """Raise unless *team_id* names a team belonging to *organization_id*.
-
-    *team_id* is a ``str`` when it arrives from ``create_note``'s nested tasks,
-    which pass ``asdict`` output through without narrowing it.
-
-    A ``None`` *team_id* is always allowed — the team is optional. An unknown
-    team and a team owned by another organization are reported identically, so
-    the message cannot be used to probe for team ids.
-    """
+    """Raise unless *team_id* names a team belonging to *organization_id*."""
     from .models import Team
 
     if team_id is None:

--- a/apps/betterangels-backend/teams/validators.py
+++ b/apps/betterangels-backend/teams/validators.py
@@ -2,6 +2,10 @@
 
 Field validators run from ``full_clean()``, so a rule declared here holds for
 the Django admin and management commands as well as the GraphQL mutations.
+:func:`validate_team_in_org` is called explicitly rather than declared on a
+field, which is why it lives here and not in ``teams.services``: ``notes.models``
+and ``tasks.models`` call it from ``clean()``, and a models-depend-on-services
+import would invert the layering.
 
 Nothing in this module may import ``teams.models`` at module level: ``Team``
 imports *this* module for its field validators, so a top-level model import
@@ -23,3 +27,25 @@ def validate_has_alphanumeric(value: str) -> None:
     """
     if not any(character.isalnum() for character in value):
         raise ValidationError("Team name must contain at least one alphanumeric character.")
+
+
+def validate_team_in_org(*, team_id: int | str | None, organization_id: int | None) -> None:
+    """Raise unless *team_id* names a team belonging to *organization_id*.
+
+    *team_id* is a ``str`` when it arrives from ``create_note``'s nested tasks,
+    which pass ``asdict`` output through without narrowing it.
+
+    A ``None`` *team_id* is always allowed — the team is optional. An unknown
+    team and a team owned by another organization are reported identically, so
+    the message cannot be used to probe for team ids.
+    """
+    from .models import Team
+
+    if team_id is None:
+        return
+
+    if organization_id is None:
+        raise ValidationError("A team cannot be set on a record that has no organization.")
+
+    if not Team.objects.filter(pk=team_id, organization_id=organization_id).exists():
+        raise ValidationError("The selected team does not belong to this organization.")


### PR DESCRIPTION
Split out of #2310 so the rule can be reviewed on its own. **11 files, ~290 lines.**

## The gap

A note or task could reference a team belonging to a different organization. Nothing stopped it — the FK points at `teams_team` with no constraint tying it to the record's own organization, and no code checked.

## The rule

`teams.validators.validate_team_in_org` is the single definition, called from two places:

- **The note and task services**, so a GraphQL write gets a validation message rather than an integrity error.
- **`Note.clean()` / `Task.clean()`**, so the Django admin — whose `team` field is an unfiltered dropdown over every organization — cannot bypass it.

It lives in `teams.validators` rather than `teams.services` so `notes.models` and `tasks.models` can call it from `clean()` without models depending on services.

`clean()` covers **ModelForm writers**, which is the writer this design needs. It is not a general backstop: `objects.create()`, `bulk_create()`, `queryset.update()`, `loaddata`, data migrations and the shell all skip it, because nothing on the note/task path calls `full_clean()` yet. #2335 adds that, at which point the explicit service calls become the redundant ones — recorded in both `clean()` docstrings, per the layering `docs/styleguides/python.md` sets out on #2331.

## Tasks with no organization

`Task.organization` is nullable and `SET_NULL`, so deleting an organization leaves its tasks without one. Those tasks are still validated. `validate_team_in_org` allows a null team, so a legacy row stays editable in the admin and its organization can be repaired there; what is refused — in the admin and through GraphQL alike — is *attaching* a team to a record that has no organization.

Two things make the permissive alternative wrong. Deleting an organization cascades to its teams and nulls `team_id` in the same operation, so no org-less task ever carries a team that needed preserving. And #2312's composite FK is MATCH SIMPLE, satisfied whenever either column is null, so Postgres accepts any team on an org-less row — skipping the check in `clean()` would leave the admin as the one writer that could still introduce a cross-org reference.

## No storage-level backstop yet

This rule is enforced in Python only. #2312, two PRs up this stack, adds a composite foreign key on `(team_id, organization_id)` that makes a cross-org row unstorable.

## Verification

- **1367 passed**, 31 skipped
- mypy clean over 378 files; `ruff check` and `ruff format --check` clean
- No schema change — `schema.graphql` is byte-identical to #2331's
- Mutation-tested: neutering the validator fails **14** tests; dropping the `note_update` call fails **2**; restoring the org-less skip in `Task.clean()` fails **1**

Three query-count assertions rise by one — the existence check the validator performs.

## Deliberately not here

- A non-numeric `teamId` returns a top-level error rather than a validation message, on both the top-level and nested-task paths. It comes from `maybe_int_value`, so the fix belongs with it and covers every caller at once — #2343.
- A task nested in `createNote` takes its organization from the caller's permission group rather than from the parent note, so a note and its tasks are two separate decisions — #2344.

## Stack

Merges after #2331. #2312 and the rest follow via #2310.

## Summary by Sourcery

Enforce organization ownership when assigning teams to notes and tasks.

Bug Fixes:
- Prevent notes and tasks from referencing teams belonging to a different organization.
- Reject assigning teams to tasks that no longer have an organization while preserving organization-less tasks without teams.

Enhancements:
- Centralize note and task team-organization validation and apply it to GraphQL services and Django model validation so admin edits receive field-level validation errors.

Tests:
- Add validator, model, and GraphQL mutation coverage for valid, cross-organization, unknown-team, and organization-less team assignments.