### PR TITLE
fix(teams): the teams query requires org membership, not just the header (DEV-2556)

### DIFF
--- a/apps/betterangels-backend/accounts/selectors.py
+++ b/apps/betterangels-backend/accounts/selectors.py
@@ -25,16 +25,7 @@ def organization_get_for_member(
     user: Union[AbstractBaseUser, AnonymousUser],
     organization_id: str | int | None,
 ) -> Optional[Organization]:
-    """Return the organization *organization_id* names, if *user* belongs to it.
-
-    ``None`` covers every way the lookup can fail — unknown id, an
-    organization the user is not a member of, or an unusable id. They are
-    deliberately not distinguished, so a single denial cannot be used to probe
-    for which organizations exist.
-
-    Membership, not permission: callers needing a permission on the
-    organization should use ``HasOrgPerm`` or ``permissioned_queryset``.
-    """
+    """Return the organization *organization_id* names, if *user* belongs to it."""
     try:
         return Organization.objects.filter(pk=str(organization_id), users=user).first()
     except ValueError, TypeError:

--- a/apps/betterangels-backend/accounts/selectors.py
+++ b/apps/betterangels-backend/accounts/selectors.py
@@ -20,6 +20,27 @@ logger = logging.getLogger(__name__)
 # ── Single-entity lookups ─────────────────────────────────────────────
 
 
+def organization_get_for_member(
+    *,
+    user: Union[AbstractBaseUser, AnonymousUser],
+    organization_id: str | int | None,
+) -> Optional[Organization]:
+    """Return the organization *organization_id* names, if *user* belongs to it.
+
+    ``None`` covers every way the lookup can fail — unknown id, an
+    organization the user is not a member of, or an unusable id. They are
+    deliberately not distinguished, so a single denial cannot be used to probe
+    for which organizations exist.
+
+    Membership, not permission: callers needing a permission on the
+    organization should use ``HasOrgPerm`` or ``permissioned_queryset``.
+    """
+    try:
+        return Organization.objects.filter(pk=str(organization_id), users=user).first()
+    except ValueError, TypeError:
+        return None
+
+
 def permission_group_for_user(user: User, org_id: str, template_name: str) -> PermissionGroup:
     """Return the ``PermissionGroup`` matching *template_name* for *user* in org *org_id*.
 

--- a/apps/betterangels-backend/common/tests/utils.py
+++ b/apps/betterangels-backend/common/tests/utils.py
@@ -199,9 +199,11 @@ class GraphQLBaseTestCase(
         self.org_1 = organization_recipe.make(name="org_1")
         self.org_2 = organization_recipe.make(name="org_2")
 
-        # Two teams so a multi-value ``teamIds`` filter has something to sort.
+        # Two teams in org_1 so a multi-value ``teamIds`` filter has something to
+        # sort; one in org_2 so cross-org tests have a team to be excluded.
         self.org_1_team_1 = baker.make(Team, organization=self.org_1)
         self.org_1_team_2 = baker.make(Team, organization=self.org_1)
+        self.org_2_team_1 = baker.make(Team, organization=self.org_2)
 
         # Permission groups are created by create_organization_with_presets
         # (via the recipe helper). Roles are assigned explicitly instead of

--- a/apps/betterangels-backend/common/tests/utils.py
+++ b/apps/betterangels-backend/common/tests/utils.py
@@ -199,8 +199,8 @@ class GraphQLBaseTestCase(
         self.org_1 = organization_recipe.make(name="org_1")
         self.org_2 = organization_recipe.make(name="org_2")
 
-        # Two teams in org_1 so a multi-value ``teamIds`` filter has something to
-        # sort; one in org_2 so cross-org tests have a team to be excluded.
+        # Two in org_1 so a multi-value ``teamIds`` filter has something to sort;
+        # one in org_2 for cross-org tests.
         self.org_1_team_1 = baker.make(Team, organization=self.org_1)
         self.org_1_team_2 = baker.make(Team, organization=self.org_1)
         self.org_2_team_1 = baker.make(Team, organization=self.org_2)

--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -44,8 +44,8 @@ class Query:
             # queried teams since #2167 -- denying them removes the team picker
             # from every one still installed.  First-match resolution can still
             # return the wrong organization's teams to a multi-org user on such
-            # a build; a follow-up PR replaces this with a denial once builds have
-            # rolled over.
+            # a build; #2345 replaces this with a denial once builds have rolled
+            # over.
             permission_group = resolve_permission_group(info.context.request.user, template=CASEWORKER)
             return team_list(organization=permission_group.organization)
 

--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -29,31 +29,18 @@ class Query:
         permission_classes=[IsAuthenticated],
     )
     def teams(self, info: Info, filters: Optional[TeamFilter] = None) -> QuerySet[Team]:
-        """List the active organization's teams.
-
-        The header *names* the organization; it does not grant access to it.
-        Membership is checked rather than a ``teams.*`` permission because
-        caseworkers must be able to list teams to pick one, and CASEWORKER
-        holds no Team perms — gating on ``Team.perms.VIEW`` would break the
-        team picker for exactly the people who use it.
-        """
+        """List the active organization's teams, if the user is a member of it."""
         org_id = info.context.request.organization_id
 
         if org_id is None:
-            # App builds older than #2330 do not send the header, and have
-            # queried teams since #2167 -- denying them removes the team picker
-            # from every one still installed.  First-match resolution can still
-            # return the wrong organization's teams to a multi-org user on such
-            # a build; #2345 replaces this with a denial once builds have rolled
-            # over.
+            # App builds older than #2330 send no header; #2345 denies them
+            # once those builds have rolled over.
             permission_group = resolve_permission_group(info.context.request.user, template=CASEWORKER)
             return team_list(organization=permission_group.organization)
 
         org = organization_get_for_member(user=get_current_user(info), organization_id=org_id)
 
         if org is None:
-            # Unknown org, an org the user does not belong to, and a malformed
-            # header all report the same way — see the selector.
             raise PermissionDenied("You do not have access to this organization.")
 
         return team_list(organization=org)
@@ -77,10 +64,6 @@ class Mutation:
         org = Organization.objects.get(pk=get_current_organization(info))
         team = team_get(pk=data.id, organization=org)
         if team is None:
-            # Unknown id, or a team belonging to another organization.  A bare
-            # ValueError is not one of the exceptions strawberry-django turns
-            # into OperationInfo, so it surfaced as an internal server error
-            # instead of a denial.
             raise PermissionDenied("You do not have permission to update this team.")
 
         return cast(

--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -5,13 +5,15 @@ from typing import Optional, cast
 import strawberry
 import strawberry_django
 from accounts.extensions import HasOrgPerm
-from accounts.selectors import resolve_permission_group
+from accounts.selectors import organization_get_for_member, resolve_permission_group
 from common.graphql.types import DeleteDjangoObjectInput, DeletedObjectType
 from common.permissions.utils import IsAuthenticated, get_current_organization
+from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from notes.groups import CASEWORKER
 from organizations.models import Organization
 from strawberry.types import Info
+from strawberry_django.auth.utils import get_current_user
 from strawberry_django.pagination import OffsetPaginated
 
 from .models import Team
@@ -27,15 +29,33 @@ class Query:
         permission_classes=[IsAuthenticated],
     )
     def teams(self, info: Info, filters: Optional[TeamFilter] = None) -> QuerySet[Team]:
+        """List the active organization's teams.
+
+        The header *names* the organization; it does not grant access to it.
+        Membership is checked rather than a ``teams.*`` permission because
+        caseworkers must be able to list teams to pick one, and CASEWORKER
+        holds no Team perms — gating on ``Team.perms.VIEW`` would break the
+        team picker for exactly the people who use it.
+        """
         org_id = info.context.request.organization_id
-        if org_id is not None:
-            org = Organization.objects.get(pk=str(org_id))
-        else:
-            # Temporary fallback: the mobile app does not yet call the
-            # Apollo orgLink to set the active organization on each request.
-            # Until that is wired up, resolve the user's Caseworker org.
-            pg = resolve_permission_group(info.context.request.user, template=CASEWORKER)
-            org = pg.organization
+
+        if org_id is None:
+            # App builds older than #2330 do not send the header, and have
+            # queried teams since #2167 -- denying them removes the team picker
+            # from every one still installed.  First-match resolution can still
+            # return the wrong organization's teams to a multi-org user on such
+            # a build; a follow-up PR replaces this with a denial once builds have
+            # rolled over.
+            permission_group = resolve_permission_group(info.context.request.user, template=CASEWORKER)
+            return team_list(organization=permission_group.organization)
+
+        org = organization_get_for_member(user=get_current_user(info), organization_id=org_id)
+
+        if org is None:
+            # Unknown org, an org the user does not belong to, and a malformed
+            # header all report the same way — see the selector.
+            raise PermissionDenied("You do not have access to this organization.")
+
         return team_list(organization=org)
 
 
@@ -55,9 +75,13 @@ class Mutation:
     )
     def update_team(self, info: Info, data: UpdateTeamInput) -> TeamType:
         org = Organization.objects.get(pk=get_current_organization(info))
-        team = team_get(pk=int(data.id), organization=org)
+        team = team_get(pk=data.id, organization=org)
         if team is None:
-            raise ValueError(f"Team with id {data.id} not found.")
+            # Unknown id, or a team belonging to another organization.  A bare
+            # ValueError is not one of the exceptions strawberry-django turns
+            # into OperationInfo, so it surfaced as an internal server error
+            # instead of a denial.
+            raise PermissionDenied("You do not have permission to update this team.")
 
         return cast(
             TeamType,
@@ -74,8 +98,9 @@ class Mutation:
     )
     def delete_team(self, info: Info, data: DeleteDjangoObjectInput) -> DeletedObjectType:
         org = Organization.objects.get(pk=get_current_organization(info))
-        team = team_get(pk=int(data.id), organization=org)
+        team = team_get(pk=data.id, organization=org)
         if team is None:
-            raise ValueError(f"Team with id {data.id} not found.")
+            raise PermissionDenied("You do not have permission to delete this team.")
+        deleted_id = team.pk
         team_delete(team=team)
-        return DeletedObjectType(id=int(data.id))
+        return DeletedObjectType(id=deleted_id)

--- a/apps/betterangels-backend/teams/selectors.py
+++ b/apps/betterangels-backend/teams/selectors.py
@@ -9,13 +9,18 @@ from .models import Team
 
 
 def team_list(*, organization: Organization) -> QuerySet[Team]:
-    """Return all teams for *organization*."""
-    return Team.objects.filter(organization=organization).order_by("name")
+    """Return all teams for *organization*, in ``Team.Meta.ordering``."""
+    return Team.objects.filter(organization=organization)
 
 
-def team_get(*, pk: int, organization: Organization) -> Optional[Team]:
-    """Return a single team by PK, scoped to *organization*."""
+def team_get(*, pk: int | str, organization: Organization) -> Optional[Team]:
+    """Return a single team by PK, scoped to *organization*.
+
+    ``None`` covers an unknown id, another organization's team, and an id that
+    is not usable as a primary key, so callers report one denial rather than
+    letting a junk id surface as a server error.
+    """
     try:
-        return Team.objects.get(pk=pk, organization=organization)
-    except Team.DoesNotExist:
+        return Team.objects.filter(pk=pk, organization=organization).first()
+    except ValueError, TypeError:
         return None

--- a/apps/betterangels-backend/teams/selectors.py
+++ b/apps/betterangels-backend/teams/selectors.py
@@ -9,7 +9,7 @@ from .models import Team
 
 
 def team_list(*, organization: Organization) -> QuerySet[Team]:
-    """Return all teams for *organization*, in ``Team.Meta.ordering``."""
+    """Return all teams for *organization*."""
     return Team.objects.filter(organization=organization)
 
 

--- a/apps/betterangels-backend/teams/selectors.py
+++ b/apps/betterangels-backend/teams/selectors.py
@@ -14,12 +14,7 @@ def team_list(*, organization: Organization) -> QuerySet[Team]:
 
 
 def team_get(*, pk: int | str, organization: Organization) -> Optional[Team]:
-    """Return a single team by PK, scoped to *organization*.
-
-    ``None`` covers an unknown id, another organization's team, and an id that
-    is not usable as a primary key, so callers report one denial rather than
-    letting a junk id surface as a server error.
-    """
+    """Return a single team by PK, scoped to *organization*."""
     try:
         return Team.objects.filter(pk=pk, organization=organization).first()
     except ValueError, TypeError:

--- a/apps/betterangels-backend/teams/tests/test_queries.py
+++ b/apps/betterangels-backend/teams/tests/test_queries.py
@@ -15,7 +15,7 @@ from accounts.tests.baker_recipes import organization_recipe
 from model_bakery import baker
 from teams.models import Team
 
-from .utils import TEAM_FIELDS, TeamGraphQLBaseTestCase, TeamGraphQLUtilsMixin
+from .utils import TeamGraphQLBaseTestCase, TeamGraphQLUtilsMixin
 
 
 class TeamsQueryTestCase(TeamGraphQLUtilsMixin):
@@ -83,23 +83,12 @@ class TeamsQueryTestCase(TeamGraphQLUtilsMixin):
 
 
 class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
-    def _teams_query(self) -> Dict[str, Any]:
-        query = f"""
-            query {{
-                teams {{
-                    totalCount
-                    results {{ {TEAM_FIELDS} }}
-                }}
-            }}
-        """
-        return self.execute_graphql(query)
-
     def _assert_denied(self, response: Dict[str, Any]) -> None:
         self.assertIsNotNone(response.get("errors"))
         self.assertIsNone((response.get("data") or {}).get("teams"))
 
     def test_returns_only_the_active_orgs_teams(self) -> None:
-        response = self._teams_query()
+        response = self.execute_graphql(self.get_teams_query())
 
         results = response["data"]["teams"]["results"]
         returned_ids = {int(row["id"]) for row in results}
@@ -115,7 +104,7 @@ class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
         OrgRoleManager(self.org_2).add_roles(self.org_1_admin, ORG_ADMIN)
         self._set_active_org(self.org_2)
 
-        results = self._teams_query()["data"]["teams"]["results"]
+        results = self.execute_graphql(self.get_teams_query())["data"]["teams"]["results"]
 
         returned_ids = {int(row["id"]) for row in results}
         org_2_ids = set(Team.objects.filter(organization=self.org_2).values_list("pk", flat=True))
@@ -125,7 +114,7 @@ class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
         """The server must not guess — first-match is how other orgs leaked."""
         del self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"]
 
-        self._assert_denied(self._teams_query())
+        self._assert_denied(self.execute_graphql(self.get_teams_query()))
 
     def test_denies_an_org_the_user_does_not_belong_to(self) -> None:
         """The header names the org; it does not grant access to it.
@@ -139,9 +128,9 @@ class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
         self.assertFalse(self.org_2.users.filter(pk=self.org_1_case_manager_1.pk).exists())
         self._set_active_org(self.org_2)
 
-        self._assert_denied(self._teams_query())
+        self._assert_denied(self.execute_graphql(self.get_teams_query()))
 
     def test_denies_a_malformed_header(self) -> None:
         self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"] = "not-an-id"
 
-        self._assert_denied(self._teams_query())
+        self._assert_denied(self.execute_graphql(self.get_teams_query()))

--- a/apps/betterangels-backend/teams/tests/test_queries.py
+++ b/apps/betterangels-backend/teams/tests/test_queries.py
@@ -1,11 +1,21 @@
-"""Basic GraphQL query tests for the ``teams`` query."""
+"""Query tests for ``teams`` — the shape of the result, and who may see it.
 
+``TeamsQueryTestCase`` covers the query itself: fields, pagination totals and
+the ``isActive`` filter.  ``TeamQueryOrgScopingTestCase`` covers the other
+half of the acceptance criterion for org-managed teams — the admin app lists
+teams for the *active* organization, and another organization's teams are not
+visible.  The editing half lives in ``test_mutations.py``.
+"""
+
+from typing import Any, Dict
+
+from accounts.groups import ORG_ADMIN
+from accounts.role_manager import OrgRoleManager
 from accounts.tests.baker_recipes import organization_recipe
 from model_bakery import baker
-
 from teams.models import Team
 
-from .utils import TeamGraphQLUtilsMixin
+from .utils import TEAM_FIELDS, TeamGraphQLBaseTestCase, TeamGraphQLUtilsMixin
 
 
 class TeamsQueryTestCase(TeamGraphQLUtilsMixin):
@@ -18,7 +28,6 @@ class TeamsQueryTestCase(TeamGraphQLUtilsMixin):
         self._set_active_org(self.org)
 
     def test_teams_query(self) -> None:
-
         expected_query_count = 4
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(self.get_teams_query())
@@ -45,6 +54,8 @@ class TeamsQueryTestCase(TeamGraphQLUtilsMixin):
         self.assertNotIn(str(other_org_team.pk), [team["id"] for team in teams])
 
         # change active org and requery
+        assert self.org_user is not None
+        other_org.add_user(self.org_user)
         self._set_active_org(other_org)
 
         response = self.execute_graphql(self.get_teams_query())
@@ -69,3 +80,68 @@ class TeamsQueryTestCase(TeamGraphQLUtilsMixin):
         response = self.execute_graphql(self.get_teams_query(), variables)
 
         self.assertEqual(response["data"]["teams"]["totalCount"], 1)
+
+
+class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
+    def _teams_query(self) -> Dict[str, Any]:
+        query = f"""
+            query {{
+                teams {{
+                    totalCount
+                    results {{ {TEAM_FIELDS} }}
+                }}
+            }}
+        """
+        return self.execute_graphql(query)
+
+    def _assert_denied(self, response: Dict[str, Any]) -> None:
+        self.assertIsNotNone(response.get("errors"))
+        self.assertIsNone((response.get("data") or {}).get("teams"))
+
+    def test_returns_only_the_active_orgs_teams(self) -> None:
+        response = self._teams_query()
+
+        results = response["data"]["teams"]["results"]
+        returned_ids = {int(row["id"]) for row in results}
+        org_1_ids = set(Team.objects.filter(organization=self.org_1).values_list("pk", flat=True))
+        org_2_ids = set(Team.objects.filter(organization=self.org_2).values_list("pk", flat=True))
+
+        self.assertEqual(returned_ids, org_1_ids)
+        self.assertEqual(returned_ids & org_2_ids, set())
+
+    def test_follows_the_active_org_header(self) -> None:
+        """Same user, different active org — the header decides."""
+        self.org_2.add_user(self.org_1_admin)
+        OrgRoleManager(self.org_2).add_roles(self.org_1_admin, ORG_ADMIN)
+        self._set_active_org(self.org_2)
+
+        results = self._teams_query()["data"]["teams"]["results"]
+
+        returned_ids = {int(row["id"]) for row in results}
+        org_2_ids = set(Team.objects.filter(organization=self.org_2).values_list("pk", flat=True))
+        self.assertEqual(returned_ids, org_2_ids)
+
+    def test_requires_the_active_org_header(self) -> None:
+        """The server must not guess — first-match is how other orgs leaked."""
+        del self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"]
+
+        self._assert_denied(self._teams_query())
+
+    def test_denies_an_org_the_user_does_not_belong_to(self) -> None:
+        """The header names the org; it does not grant access to it.
+
+        Regression: the query trusted the header outright, so any authenticated
+        user could read any organization's teams by setting it. Every other
+        test here sets the header to an org the user belongs to, which is why
+        it went unnoticed.
+        """
+        self.graphql_client.force_login(self.org_1_case_manager_1)
+        self.assertFalse(self.org_2.users.filter(pk=self.org_1_case_manager_1.pk).exists())
+        self._set_active_org(self.org_2)
+
+        self._assert_denied(self._teams_query())
+
+    def test_denies_a_malformed_header(self) -> None:
+        self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"] = "not-an-id"
+
+        self._assert_denied(self._teams_query())

--- a/apps/betterangels-backend/teams/tests/test_selectors.py
+++ b/apps/betterangels-backend/teams/tests/test_selectors.py
@@ -9,7 +9,6 @@ from accounts.selectors import organization_get_for_member
 from accounts.tests.baker_recipes import organization_recipe
 from common.tests.utils import GraphQLBaseTestCase
 from teams.selectors import team_get, team_list
-from teams.services import team_create
 
 
 class TeamListTestCase(GraphQLBaseTestCase):
@@ -18,21 +17,6 @@ class TeamListTestCase(GraphQLBaseTestCase):
 
         self.assertTrue(teams.exists())
         self.assertEqual({t.organization_id for t in teams}, {self.org_1.pk})
-
-    def test_orders_by_name(self) -> None:
-        """Names are deliberately unambiguous across collations.
-
-        Asserting against Python's ``sorted()`` would compare Postgres'
-        locale-aware ordering with Python's codepoint ordering, and the two
-        disagree on case.
-        """
-        org = organization_recipe.make(name="team_list_ordering_org")
-        for name in ("Charlie", "Alpha", "Bravo"):
-            team_create(name=name, organization=org)
-
-        names = list(team_list(organization=org).values_list("name", flat=True))
-
-        self.assertEqual(names, ["Alpha", "Bravo", "Charlie"])
 
     def test_is_empty_for_an_organization_with_no_teams(self) -> None:
         org = organization_recipe.make()

--- a/apps/betterangels-backend/teams/tests/test_selectors.py
+++ b/apps/betterangels-backend/teams/tests/test_selectors.py
@@ -1,0 +1,78 @@
+"""Read paths for teams — the styleguide's other primary test surface.
+
+``team_list`` and ``team_get`` were previously exercised only through GraphQL,
+so their org scoping was asserted several layers away from where it is
+implemented.
+"""
+
+from accounts.selectors import organization_get_for_member
+from accounts.tests.baker_recipes import organization_recipe
+from common.tests.utils import GraphQLBaseTestCase
+from teams.selectors import team_get, team_list
+from teams.services import team_create
+
+
+class TeamListTestCase(GraphQLBaseTestCase):
+    def test_returns_only_the_given_organizations_teams(self) -> None:
+        teams = team_list(organization=self.org_1)
+
+        self.assertTrue(teams.exists())
+        self.assertEqual({t.organization_id for t in teams}, {self.org_1.pk})
+
+    def test_orders_by_name(self) -> None:
+        """Names are deliberately unambiguous across collations.
+
+        Asserting against Python's ``sorted()`` would compare Postgres'
+        locale-aware ordering with Python's codepoint ordering, and the two
+        disagree on case.
+        """
+        org = organization_recipe.make(name="team_list_ordering_org")
+        for name in ("Charlie", "Alpha", "Bravo"):
+            team_create(name=name, organization=org)
+
+        names = list(team_list(organization=org).values_list("name", flat=True))
+
+        self.assertEqual(names, ["Alpha", "Bravo", "Charlie"])
+
+    def test_is_empty_for_an_organization_with_no_teams(self) -> None:
+        org = organization_recipe.make()
+
+        self.assertEqual(list(team_list(organization=org)), [])
+
+
+class TeamGetTestCase(GraphQLBaseTestCase):
+    def test_returns_a_team_in_the_organization(self) -> None:
+        self.assertEqual(team_get(pk=self.org_1_team_1.pk, organization=self.org_1), self.org_1_team_1)
+
+    def test_returns_none_for_another_organizations_team(self) -> None:
+        """The cross-org guard the update/delete mutations rely on."""
+        self.assertIsNone(team_get(pk=self.org_1_team_1.pk, organization=self.org_2))
+
+    def test_returns_none_for_an_unknown_pk(self) -> None:
+        self.assertIsNone(team_get(pk=999999, organization=self.org_1))
+
+
+class OrganizationGetForMemberTestCase(GraphQLBaseTestCase):
+    """Backs the ``teams`` query — the header names an org, membership grants it."""
+
+    def test_returns_the_organization_for_a_member(self) -> None:
+        org = organization_get_for_member(user=self.org_1_case_manager_1, organization_id=self.org_1.pk)
+
+        self.assertEqual(org, self.org_1)
+
+    def test_accepts_a_string_id_as_the_header_delivers_it(self) -> None:
+        org = organization_get_for_member(user=self.org_1_case_manager_1, organization_id=str(self.org_1.pk))
+
+        self.assertEqual(org, self.org_1)
+
+    def test_returns_none_for_an_organization_the_user_is_not_in(self) -> None:
+        self.assertFalse(self.org_2.users.filter(pk=self.org_1_case_manager_1.pk).exists())
+
+        self.assertIsNone(organization_get_for_member(user=self.org_1_case_manager_1, organization_id=self.org_2.pk))
+
+    def test_returns_none_for_an_unknown_organization(self) -> None:
+        self.assertIsNone(organization_get_for_member(user=self.org_1_case_manager_1, organization_id=999999))
+
+    def test_returns_none_for_a_malformed_id_rather_than_raising(self) -> None:
+        """A junk header must read as a denial, not a 500."""
+        self.assertIsNone(organization_get_for_member(user=self.org_1_case_manager_1, organization_id="not-an-id"))

--- a/apps/betterangels-backend/teams/tests/utils.py
+++ b/apps/betterangels-backend/teams/tests/utils.py
@@ -8,8 +8,6 @@ from accounts.role_manager import OrgRoleManager
 from common.tests.utils import GraphQLBaseTestCase
 from model_bakery import baker
 
-TEAM_FIELDS = "id name isActive"
-
 
 class TeamGraphQLUtilsMixin(GraphQLBaseTestCase):
     def get_team_fields(self) -> str:

--- a/apps/betterangels-backend/teams/tests/utils.py
+++ b/apps/betterangels-backend/teams/tests/utils.py
@@ -1,6 +1,14 @@
+"""Shared fixtures for the teams test suites."""
+
 from typing import Any, Dict, Optional
 
+from accounts.groups import ORG_ADMIN
+from accounts.models import User
+from accounts.role_manager import OrgRoleManager
 from common.tests.utils import GraphQLBaseTestCase
+from model_bakery import baker
+
+TEAM_FIELDS = "id name isActive"
 
 
 class TeamGraphQLUtilsMixin(GraphQLBaseTestCase):
@@ -62,3 +70,27 @@ class TeamGraphQLUtilsMixin(GraphQLBaseTestCase):
         """
 
         return self.execute_graphql(mutation, {"id": team_id})
+
+
+class TeamGraphQLBaseTestCase(TeamGraphQLUtilsMixin):
+    """An org admin in ``org_1``, acting as ``org_1``.
+
+    Teams come from the shared fixture, which provisions them for both
+    organizations so a test asserting "only my org's" is asserting scoping
+    rather than a difference in the data.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.org_1_admin = self._make_org_admin(org=self.org_1)
+        self.org_2_admin = self._make_org_admin(org=self.org_2)
+
+        self.graphql_client.force_login(self.org_1_admin)
+        self._set_active_org(self.org_1)
+
+    def _make_org_admin(self, *, org: Any) -> User:
+        user = baker.make(User)
+        org.add_user(user)
+        OrgRoleManager(org).add_roles(user, ORG_ADMIN)
+        return user


### PR DESCRIPTION
Splits the security fix from the client-breaking change that was bundled with it. The breaking half is #2345.

## The gap

The `teams` query trusted `X-Organization-ID` outright — it looked the organization up by pk and listed its teams. Any authenticated user could name any organization and read its teams.

## The fix

Membership is now required when the header is present. **Membership**, not a `teams.*` permission: CASEWORKER holds no Team perms, so gating on `Team.perms.VIEW` would break the team picker for exactly the people who use it.

`accounts.selectors.organization_get_for_member` returns `None` for an unknown id, an organization the user does not belong to, and an unusable id alike, so one denial covers all three and the error cannot be used to probe for which organizations exist.

## What this deliberately does *not* change

The headerless path keeps its first-match fallback. Builds older than #2330 do not send the header and have queried `teams` since #2167, so denying them would remove the team picker, task-form team selector and team filter from every build still installed — and `runtimeVersion` is per build, so an OTA update cannot reach them.

**Until #2345 merges, a multi-org user on an old build can still be served the wrong organization's teams.** That is a smaller exposure than the one closed here (which needed no old build at all, just a forged header), and it is the part that has to wait on a release.

## Also in this PR

- `team_get` tolerates an unusable pk instead of raising `ValueError`, so a junk id in `updateTeam`/`deleteTeam` reads as a denial rather than a server error. That removes the `int(data.id)` coercion from both call sites.
- `team_list` drops `.order_by("name")`, which `Team.Meta.ordering` already provides.
- The shared fixture gains an org_2 team. The cross-org assertions compare against a live query for org_2's teams, so without one they would have compared two empty sets and passed while testing nothing.

## Verification

- **1364 passed**, 31 skipped
- mypy clean over 377 files; `ruff check` and `ruff format --check` clean
- Mutation-tested: trusting the header again fails 2 tests; dropping the org filter in `team_list` fails 10

No longer depends on #2328 — the headerless branch must not raise, so this reads `request.organization_id` directly. #2345 is where `get_current_organization` gets used, and that is where #2328 is a prerequisite.

Running the suite locally: allauth's rate limits live in the shared Redis cache and are not reset between runs, so back-to-back runs produce spurious `test_headless_views.py` failures — see #2346. Clear the cache first.

## Summary by Sourcery

Enforce organization membership for header-scoped team access without breaking legacy headerless clients.

Bug Fixes:
- Require organization membership when the teams query receives an organization header, preventing users from reading teams from organizations they do not belong to.
- Return permission denials instead of server errors for malformed or cross-organization team update and deletion requests.

Enhancements:
- Preserve the legacy headerless teams-query fallback for older application builds while enforcing active-organization scoping when a header is present.
- Centralize organization membership lookup and strengthen team selector coverage for organization scoping, ordering, malformed identifiers, and cross-organization access.

Tests:
- Add regression coverage for organization-header authorization, missing and malformed headers, cross-organization visibility, and team selector behavior.