### PR TITLE
fix(teams): the teams query stops guessing an organization

### DIFF
--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -5,13 +5,12 @@ from typing import Optional, cast
 import strawberry
 import strawberry_django
 from accounts.extensions import HasOrgPerm
-from accounts.selectors import organization_get_for_member, resolve_permission_group
+from accounts.selectors import organization_get_for_member, organization_get_sole_for_member
 from common.graphql.types import DeleteDjangoObjectInput, DeletedObjectType
 from common.graphql.utils import active_organization
 from common.permissions.utils import IsAuthenticated
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
-from notes.groups import CASEWORKER
 from strawberry.types import Info
 from strawberry_django.auth.utils import get_current_user
 from strawberry_django.pagination import OffsetPaginated
@@ -30,18 +29,19 @@ class Query:
     )
     def teams(self, info: Info, filters: Optional[TeamFilter] = None) -> QuerySet[Team]:
         """List the active organization's teams, if the user is a member of it."""
+        user = get_current_user(info)
         org_id = info.context.request.organization_id
 
         if org_id is None:
-            # App builds older than #2330 send no header; #2345 denies them
-            # once those builds have rolled over.
-            permission_group = resolve_permission_group(info.context.request.user, template=CASEWORKER)
-            return team_list(organization=permission_group.organization)
+            org = organization_get_sole_for_member(user=user)
 
-        org = organization_get_for_member(user=get_current_user(info), organization_id=org_id)
+            if org is None:
+                raise PermissionDenied("Organization ID (X-Organization-ID header) is required.")
+        else:
+            org = organization_get_for_member(user=user, organization_id=org_id)
 
-        if org is None:
-            raise PermissionDenied("You do not have access to this organization.")
+            if org is None:
+                raise PermissionDenied("You do not have access to this organization.")
 
         return team_list(organization=org)
 

--- a/apps/betterangels-backend/teams/tests/test_queries.py
+++ b/apps/betterangels-backend/teams/tests/test_queries.py
@@ -110,11 +110,31 @@ class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
         org_2_ids = set(Team.objects.filter(organization=self.org_2).values_list("pk", flat=True))
         self.assertEqual(returned_ids, org_2_ids)
 
-    def test_requires_the_active_org_header(self) -> None:
-        """The server must not guess — first-match is how other orgs leaked."""
+    def test_headerless_denies_a_caller_in_more_than_one_organization(self) -> None:
+        """The server must not guess — first-match is how other orgs leaked.
+
+        The caller has to belong to both organizations, or a denial here proves
+        only that they held no group anywhere.
+        """
+        self.org_2.add_user(self.org_1_admin)
+        OrgRoleManager(self.org_2).add_roles(self.org_1_admin, ORG_ADMIN)
         del self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"]
 
         self._assert_denied(self.execute_graphql(self.get_teams_query()))
+
+    def test_headerless_serves_the_callers_only_organization(self) -> None:
+        """What keeps app builds older than #2330 working.
+
+        One organization to belong to is not a guess, so those builds keep
+        their team pickers until the header is mandatory.
+        """
+        del self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"]
+
+        results = self.execute_graphql(self.get_teams_query())["data"]["teams"]["results"]
+
+        returned_ids = {int(row["id"]) for row in results}
+        org_1_ids = set(Team.objects.filter(organization=self.org_1).values_list("pk", flat=True))
+        self.assertEqual(returned_ids, org_1_ids)
 
     def test_denies_an_org_the_user_does_not_belong_to(self) -> None:
         """The header names the org; it does not grant access to it.


### PR DESCRIPTION
Stacked on #2310, which adds the selector this reuses. **No longer breaking, and no longer a draft** — see "What changed about this PR" below.

## The bug

When a request names no organization, the `teams` query picks one with `resolve_permission_group(user, template=CASEWORKER)` — first match. Two failures:

- A **multi-org user** is served whichever organization the database returned first, i.e. potentially another organization's teams. This is the leak the stack exists to close.
- An **organization admin who is not also a caseworker** gets `PermissionError: User does not hold a 'Caseworker' permission group in any organization` instead of their teams. That is the exact persona the admin app's Teams page serves, and it is reachable today: `createOrgInterceptor` omits the header when the active-org store is empty.

## The fix

Header absent → adopt the caller's **only** organization via `organization_get_sole_for_member` (#2310's selector); refuse when there is not exactly one. Header present → unchanged, `organization_get_for_member` verifies membership (#2340).

Belonging to exactly one organization is not a guess, so old builds keep their team pickers while the guessing is gone.

`resolve_permission_group` and the `CASEWORKER` import leave `teams/schema.py`.

## What changed about this PR

It previously replaced the fallback with `get_current_organization(info)`, making the header mandatory. That was breaking for every store build older than #2330 and was parked behind a rollover gate that nothing in the repo can observe: `app.config.js` sets `runtimeVersion` per build, so OTA cannot reach older builds, and there is no minimum-version gate.

Splitting it that way meant the **security** fix waited on a **compatibility** mechanism. It no longer does. Making the header mandatory happens once for the whole API, together with removing `allow_implicit_org` (`grep -rn allow_implicit_org` is the list) and #2342.

Note that `Team.perms.VIEW` is still not enforced on this read — deliberately. `CASEWORKER` holds no `Team` permission at all, so gating the query on it would break every caseworker's team picker in the mobile app. Changing that means changing the template, which is a separate decision.

## Also fixed here

`test_requires_the_active_org_header` passed for the wrong reason. Its caller was an org admin holding no Caseworker group, so the headerless request was denied by the *fallback erroring*, not by the server refusing to guess — the test would have gone on passing with first-match resolution intact. It is replaced by two cases that pin the actual behaviour:

- `test_headerless_denies_a_caller_in_more_than_one_organization` — the caller is made a member of **both** organizations, so a denial can only mean the server refused to choose
- `test_headerless_serves_the_callers_only_organization` — what keeps older builds working

## Verification

`1449 passed, 31 skipped`; 58 teams tests; mypy clean over 387 files; `ruff check` and `ruff format --check` clean; `export_schema` reproduces `schema.graphql` unchanged — this is not a schema change.

Mutation-tested, one test per behaviour:

| Mutation | Fails |
| --- | --- |
| sole-organization adoption → `.filter(users=user).first()` (the old guessing) | `test_headerless_denies_a_caller_in_more_than_one_organization` |
| headerless denied outright (the previous version of this PR) | `test_headerless_serves_the_callers_only_organization` |

## Still needed on the frontend

#2355 stops both clients issuing a headerless org-scoped query in the first place. That is worth having regardless of this PR — it is what the admin Teams page needs on a fresh session, before any organization is known.

## Summary by Sourcery

Stop the teams query from guessing an organization when the organization header is absent.

Bug Fixes:
- Prevent headerless team queries from selecting an arbitrary organization, avoiding cross-organization team exposure.
- Allow headerless team queries for users who belong to exactly one organization, including organization admins without Caseworker permissions.
- Reject headerless team queries when the caller belongs to multiple organizations.

Enhancements:
- Retain explicit organization header membership validation while adopting a caller’s sole organization when no header is supplied.

Tests:
- Replace the misleading active-organization header test with coverage for multi-organization denial and sole-organization support.