### PR TITLE
test(backend): turn allauth's rate limits off in tests

### DIFF
--- a/apps/betterangels-backend/conftest.py
+++ b/apps/betterangels-backend/conftest.py
@@ -1,7 +1,19 @@
 from pathlib import Path
 
 import pytest
+from pytest_django.fixtures import SettingsWrapper
 from test_utils.vcr_config import scrubbed_vcr
+
+
+@pytest.fixture(autouse=True)
+def _no_rate_limits(settings: SettingsWrapper) -> None:
+    """Rate limits are a production concern and no test asserts one.
+
+    Left on, allauth's login-code limits are cached in a Redis instance every run
+    on this machine shares, so limits one run consumes are still spent on the next.
+    ``False`` is required -- an empty dict is merged into the defaults.
+    """
+    settings.ACCOUNT_RATE_LIMITS = False
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Fixes #2346.

## The bug

`accounts/tests/test_headless_views.py` degrades across back-to-back runs and stays broken until the cache is flushed by hand:

```
run 1: 3 passed
run 2: 1 failed, 2 passed
run 3: 2 failed, 1 passed
run 4: 3 failed          # saturates
```

allauth counts its rate limits in the Django cache. `CACHES` points at one Redis instance that every run on the machine shares, and nothing resets it between tests or between runs, so limits one run consumes are still spent on the next. `request_login_code` defaults to `20/m/ip,3/m/key`, and three tests in that file each request a login code.

## The fix

One autouse fixture in `conftest.py`. Rate limiting is a production concern, nothing in the repo asserts one, and all three of those tests expect success — the limit is purely an obstacle.

`False` is load-bearing. `allauth/account/app_settings.py` returns `{}` — every limit off — only for `False`; a dict is *merged into* the defaults, so `{}` changes nothing.

## Why not isolate the cache instead

The first pass gave every test its own `KEY_PREFIX`. That works, but it buys a much larger blast radius than the bug needs: `SESSION_ENGINE` is `django.contrib.sessions.backends.cache`, so swapping `CACHES` per test puts sessions in scope, and the key space grows without bound in a shared Redis. Turning off a setting that no test depends on is the smaller change.

It also carried a query-count change that turned out to be wrong. `expected_query_count = 6` in `test_creates_single_shelter_photo_and_returns_it` does not depend on cache state — measured with the `imgproxy_enabled` waffle keys deleted, it is 6 either way. The waffle read is the 8th query on `test_creates_multiple_shelter_photos_and_returns_them`, where `main` already warms the switch. That test file is untouched here.

## Verification

- Six consecutive runs of `accounts/tests/test_headless_views.py` stay at `3 passed`, **without** clearing Redis first — including starting from a cache already saturated by the mutation runs below.
- Full suite `1394 passed, 31 skipped` three times back to back, no clearing, under both `pytest-randomly` and `-p no:randomly`.
- `ruff check`, `ruff format --check` and `mypy` (382 files) clean.

Mutation-tested two ways:

| Change | Result |
| --- | --- |
| fixture removed | `3 passed` → `1 failed` → `2 failed` → `3 failed`, saturating |
| `ACCOUNT_RATE_LIMITS = {}` | `3 failed` on every run — proves `False` is what matters |

Restoring the fixture recovers a saturated cache immediately, with no flush.