### PR TITLE
test(admin): pin the guard that keeps a gated route from redirecting itself away

### DIFF
--- a/apps/betterangels-admin/project.json
+++ b/apps/betterangels-admin/project.json
@@ -6,9 +6,7 @@
   "tags": ["type:app", "scope:betterangels-admin"],
   "targets": {
     "test": {
-      "options": {
-        "passWithNoTests": true
-      },
+      "options": {},
       "configurations": {
         "ci": {
           "ci": true,

--- a/apps/betterangels-admin/src/app/routes/gatedRoutes.spec.tsx
+++ b/apps/betterangels-admin/src/app/routes/gatedRoutes.spec.tsx
@@ -1,0 +1,115 @@
+import {
+  ApolloClient,
+  ApolloLink,
+  InMemoryCache,
+  Observable,
+} from '@apollo/client';
+import { ApolloProvider } from '@apollo/client/react';
+import { UserProvider } from '@monorepo/ba-platform';
+import { TeamPermissions } from '@monorepo/ba-platform/permissions';
+import { AuthProvider } from '@monorepo/react/betterangels-admin';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { AppLayout } from '../Layout/AppLayout';
+import { PermissionGuard } from './PermissionGuard';
+
+/**
+ * ``PermissionGuard`` reads permissions off the active organization, which
+ * arrive with the user query -- so it reads "not known yet" as "denied" and
+ * redirects. What stops that is ``AuthProvider``: it renders nothing until the
+ * query has both settled *and* produced a user, and `/teams` is covered by it
+ * because ``routeAccess`` has no entry for that path and ``getRouteAccess``
+ * falls through ``startsWith`` to ``'/': 'safe'``.
+ *
+ * Both halves matter. ``isLoading`` alone is not enough: ``UserProvider`` sets
+ * ``user`` in an effect, so there is one commit where the query has settled and
+ * ``user`` is still undefined.
+ */
+
+const USER_RESULT = {
+  data: {
+    currentUser: {
+      __typename: 'UserType',
+      id: 'user-1',
+      username: 'someone',
+      firstName: 'Some',
+      lastName: 'One',
+      email: 'someone@example.com',
+      organizations: [
+        {
+          __typename: 'OrganizationType',
+          id: 'org-1',
+          name: 'Org One',
+          permissions: [TeamPermissions.View],
+        },
+      ],
+    },
+  },
+};
+
+/** A client whose only operation stays in flight until ``resolve`` is called. */
+function createDeferredClient() {
+  let emit: (() => void) | undefined;
+
+  const link = new ApolloLink(
+    () =>
+      new Observable((observer) => {
+        emit = () => {
+          observer.next(USER_RESULT as never);
+          observer.complete();
+        };
+      }),
+  );
+
+  return {
+    client: new ApolloClient({ link, cache: new InMemoryCache() }),
+    resolve: () => emit?.(),
+  };
+}
+
+function renderAtTeams() {
+  const { client, resolve } = createDeferredClient();
+
+  render(
+    <ApolloProvider client={client}>
+      <MemoryRouter initialEntries={['/teams']}>
+        <UserProvider>
+          <AuthProvider>
+            <Routes>
+              <Route path="/" element={<AppLayout />}>
+                <Route path="/" element={<div>home stand-in</div>} />
+                <Route
+                  path="/teams"
+                  element={
+                    <PermissionGuard permission={TeamPermissions.View}>
+                      <div>teams stand-in</div>
+                    </PermissionGuard>
+                  }
+                />
+              </Route>
+            </Routes>
+          </AuthProvider>
+        </UserProvider>
+      </MemoryRouter>
+    </ApolloProvider>,
+  );
+
+  return { resolve };
+}
+
+describe('permission-gated routes', () => {
+  it('are not rendered, or redirected, until the user is known', async () => {
+    const { resolve } = renderAtTeams();
+
+    expect(screen.queryByText('teams stand-in')).toBeNull();
+    expect(screen.queryByText('home stand-in')).toBeNull();
+
+    resolve();
+
+    // The route that was asked for, not whichever one Home would forward to.
+    await waitFor(() => expect(screen.getByText('teams stand-in')).toBeTruthy());
+    expect(screen.queryByText('home stand-in')).toBeNull();
+  });
+});

--- a/apps/betterangels-admin/vite.config.mts
+++ b/apps/betterangels-admin/vite.config.mts
@@ -76,7 +76,6 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       include: ['src/**/*.{test,spec}.{ts,tsx}'],
-      passWithNoTests: true,
     },
 
     build: {

--- a/apps/betterangels-admin/vite.config.mts
+++ b/apps/betterangels-admin/vite.config.mts
@@ -3,7 +3,10 @@ import tailwindcss from '@tailwindcss/postcss';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { ProxyOptions, defineConfig } from 'vite';
-import { monorepoTsconfigAliases } from '../../libs/vite-utils/src/index';
+import {
+  monorepoTsconfigAliases,
+  svgTestResolver,
+} from '../../libs/vite-utils/src/index';
 import {
   baseHrefPlugin,
   getBranchBasePath,
@@ -48,7 +51,13 @@ export default defineConfig(({ mode }) => {
       host: 'localhost',
     },
 
-    plugins: [react(), baseHrefPlugin(basePath)],
+    plugins: [
+      react(),
+      baseHrefPlugin(basePath),
+      // Vite handles ?raw SVG imports natively.
+      // Only stub SVGs during Vitest runs (avoids cross-package Denied ID).
+      ...(process.env.VITEST ? [svgTestResolver()] : []),
+    ],
 
     css: {
       postcss: {
@@ -62,6 +71,13 @@ export default defineConfig(({ mode }) => {
     },
 
     resolve: { alias: monorepoTsconfigAliases(WORKSPACE_ROOT) },
+
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      passWithNoTests: true,
+    },
 
     build: {
       outDir: '../../dist/apps/betterangels-admin',


### PR DESCRIPTION
**No production change.** `/teams` is already protected against the redirect `PermissionGuard` would otherwise perform before permissions are known. This is the test that says so, plus the vitest configuration `apps/betterangels-admin` needed in order to have a test at all.

## What protects the route

Two pieces, neither obvious, both load-bearing:

`PermissionGuard` reads permissions off `activeOrg`, which arrives with the user query — so on its own it reads "not known yet" as "denied" and `<Navigate to="/" replace/>`. `AuthProvider` (`libs/react/shared/src/lib/auth/providers/AuthProvider.tsx`) is what stops it ever getting the chance:

```tsx
if (isLoading) return null;
if (access === 'safe' && !user) return null;
```

And `/teams` is covered even though `routeAccess` has **no entry for it** — `getRouteAccess` sorts the keys longest-first and uses `startsWith`, so `/teams` falls through to `'/': 'safe'`.

The second return is separate from the first because `UserProvider` sets `user` in an effect, so there is one commit where the query has settled and `user` is still `undefined`. It keeps the guard from *rendering* on that commit. Whether the redirect **effect** above it is gated as tightly is a separate question I am checking on its own; either way it is not something this PR changes.

## The test

`apps/betterangels-admin` had a `test` target with no tests and no vitest block. Added:

- `test: { globals: true, environment: 'jsdom', include: ['src/**/*.{test,spec}.{ts,tsx}'] }` — byte-identical to `apps/shelter-web/vite.config.mts`, and the target's `options` are now empty as in `shelter-web` and `wildfires`. No `passWithNoTests` in either place: the app has a test now, so a renamed or deleted spec should fail the target rather than pass it.
- `svgTestResolver()` under `process.env.VITEST`, mirroring `apps/shelter-web/vite.config.mts` — without it the shell's icon imports fail with `Denied ID`. That is what `libs/vite-utils` exports it for.

`src/app/routes/gatedRoutes.spec.tsx` renders the real provider stack (`UserProvider` → `AuthProvider` → `AppLayout` → `PermissionGuard`) at `/teams` with the `currentUser` operation held in flight, and asserts nothing renders; then releases it and asserts `/teams` renders — not whichever route `Home` would forward to.

It **passes against unmodified application code**, which is the point: it documents protection that exists rather than adding any.

Mutation-tested:

| Mutation | Result |
| --- | --- |
| remove `AuthProvider` from the tree | fails — lands on the home stand-in, i.e. the redirect |
| `routeAccess` `'/': 'safe'` → `'neutral'` | fails — `/teams` loses its coverage |
| point the `include` glob at a path matching nothing | fails — `No test files found, exiting with code 1`, where it would previously have passed |

## Verification

- `nx test betterangels-admin` — 0 tests → **1 passed** (new)
- `nx test ba-platform` — **61 passed**, `expo-betterangels` — **153 passed**
- `nx run-many -t typecheck -p betterangels-admin,expo-betterangels,betterangels` clean
- lint unchanged: 0 errors, the same 5 pre-existing warnings

## Related

**Not a prerequisite for #2345.** That PR adopts a caller's sole organization rather than denying a headerless request, so it does not depend on clients being gated.

The branch name predates the PR's contents; there is nothing in the diff outside `apps/betterangels-admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
