### PR TITLE
fix(common): stop putting the literal "None" on the wire for a phone number

### DIFF
--- a/apps/betterangels-backend/common/graphql/types.py
+++ b/apps/betterangels-backend/common/graphql/types.py
@@ -83,6 +83,11 @@ def _parse_phone_number(v: str) -> DjangoPhoneNumber:
 
 
 def _serialize_phone_number(v: DjangoPhoneNumber) -> str:
+    # national_number is None when phonenumbers could not parse the stored
+    # value, and str() would then put the literal "None" on the wire.
+    if not v.national_number:
+        return ""
+
     if v.extension:
         return f"{v.national_number}x{v.extension}"
 

--- a/apps/betterangels-backend/common/tests/test_graphql_types.py
+++ b/apps/betterangels-backend/common/tests/test_graphql_types.py
@@ -1,0 +1,33 @@
+from typing import Any, Callable, Optional, cast
+
+from common.graphql.types import SCALAR_MAP, PhoneNumberScalar
+from common.models import Address, PhoneNumber
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from unittest_parametrize import ParametrizedTestCase, parametrize
+
+serialize_phone_number = cast(Callable[[Any], str], SCALAR_MAP[PhoneNumberScalar].serialize)
+
+
+class PhoneNumberScalarTestCase(ParametrizedTestCase, TestCase):
+    @parametrize(
+        "stored, expected",
+        [
+            ("2125551212", "2125551212"),
+            ("2125551212x99", "2125551212x99"),
+            ("125551212", "125551212"),
+            ("abc", ""),
+            ("", ""),
+        ],
+    )
+    def test_serialize(self, stored: str, expected: str) -> None:
+        content_type = ContentType.objects.get_for_model(Address)
+        phone_number = PhoneNumber.objects.create(content_type=content_type, object_id=1, number=stored)
+        phone_number.refresh_from_db()
+
+        self.assertEqual(serialize_phone_number(phone_number.number), expected)
+
+    def test_serialize_null(self) -> None:
+        number: Optional[str] = None
+
+        self.assertEqual(serialize_phone_number(number), "")


### PR DESCRIPTION
## The bug

`_serialize_phone_number` ends with `str(v.national_number)`. `national_number` is `None` whenever `phonenumbers` could not parse the stored value, so the wire gets the four characters `None`, indistinguishable from a real phone number to any client.

It is reachable. `PhoneNumberField` deliberately keeps unparseable input rather than refusing it:

```python
# phonenumber_field/modelfields.py
except phonenumbers.NumberParseException:
    # Store the raw string.
    return value
```

and `PhoneNumber.objects.create()` does not run `full_clean()`, so nothing between the two stops a row from holding `"abc"`.

```
stored 'abc'  ->  national_number=None  ->  serialized "None"
```

## The fix

Return `""`, which is what `SCALAR_MAP` already does one line away for a value that is not a `PhoneNumber` at all:

```python
serialize=lambda v: _serialize_phone_number(v) if isinstance(v, DjangoPhoneNumber) else "",
```

## Testing

`common/tests/test_graphql_types.py` round-trips five stored values through the real `SCALAR_MAP` entry, including one that parses to nothing. Reverting the fix fails it with `'None' != ''` — it is not a vacuous test.

Full backend suite: 1400 passed, 31 skipped.

## Three things I found next door and did *not* change

Flagging rather than fixing, because each needs a decision rather than a patch.

**1. The country code is dropped, and E.164 is not the fix.** `national_number` is the number *without* its country code, so a stored `+442071234567` is served as `2071234567` and renders as a Maine number. The obvious repair — `format_as(E164)` — returns `+12135551234` and **drops the extension outright**, trading one data loss for another. Preserving both needs RFC 3966 (`tel:+1-213-555-1234;ext=22`) or a custom `+{cc}{national}x{ext}`, and `PhoneNumber` appears 20 times in `schema.graphql` on both the input and output side, so it is a breaking change in both directions at once. Worth doing; worth deciding first.

**2. `parse_value`'s regex is a switch, not a gate — and that turns out to be load-bearing.** `_parse_phone_number` returns the raw string unchanged when `PHONE_NUMBER_REGEX` does not match, so nothing is rejected at coercion time. I tried tightening it to `raise`, which looks right next to `_parse_latitude` and `_parse_non_empty_string` in the same file. It breaks three tests, and correctly so: `validate_phone_numbers` in `clients/schema.py` produces a *field-located* error the frontend uses to highlight the offending input —

```json
{"field": "phoneNumbers", "location": "0__number", "errorCode": "PHONE_NUMBER_INVALID"}
```

— and a `ValueError` from `parse_value` fires first, during argument coercion, replacing that with a generic coercion error. So the permissive scalar is what keeps the good errors reachable. If the regex is meant to reject, the structured errors have to move ahead of coercion first.

**3. `update_hmis_client_profile` skips phone validation.** `create_client_profile` and `update_client_profile` both call `validate_client_profile_data` (which calls `validate_phone_numbers`) before writing. `hmis/schema.py:246` writes `PhoneNumber.objects.create(...)` with no validation at all — the one mutation that really can store junk. The fix wants `validate_phone_numbers` extracted out of `clients/schema.py` into a shared validators module, per the styleguide's `<app>/validators.py` convention; neither `common/validators.py` nor `clients/validators.py` exists yet, so that is a small structural change rather than a one-liner.

## Summary by Sourcery

Ensure invalid stored phone numbers are represented as empty values on the GraphQL wire.

Bug Fixes:
- Prevent unparseable phone numbers from being serialized as the literal string "None" by returning an empty value instead.

Tests:
- Add coverage for serializing valid, extended, unparseable, empty, and null phone number values through the production scalar mapping.