### PR TITLE
fix(deps): bump vulnerable npm transitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "ws": ">=8.17.1",
-    "postcss": "8.5.16",
+    "postcss": "8.5.23",
     "@tootallnate/once": ">=3.0.1",
     "axios": ">=1.18.0",
     "brace-expansion": ">=2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13439,11 +13439,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:>=2.1.2":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/75d2d2ebc8f5f65156d16706216d23e48f499a1164e4b045e0ca4045d3ce6b16ced11ea2e4c76e3670b6c38454123213f43d23127df8fc6840980aea9a35e061
+  checksum: 10/d8683d612919212c7cf298861acd1c15101e7e2ad186e7ae9747390e5b3fc9e9b55ce71107570d32985784d9d88fbbe438d725863aed7b0f3d08d5f080535eec
   languageName: node
   linkType: hard
 
@@ -17606,9 +17606,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10/1c1ff8e7b6f7b38e997b1528aa2c97e290e0173d51250bfe4e11a303e454fc297a287555b5cb2ded59dbfce7876855fb15994a1a6b439f2497a2b8926513e397
+  version: 3.1.6
+  resolution: "fast-uri@npm:3.1.6"
+  checksum: 10/de34fceafd3a1d917989a1116b092d9b6ebe6fa3c9e908a308b988a6455449fa0a0256b6ef628aa7da80f1f84031d704c290d6ba0ea4c6f4c42b7974a3bd43ae
   languageName: node
   linkType: hard
 
@@ -20613,25 +20613,25 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
-  version: 3.15.0
-  resolution: "js-yaml@npm:3.15.0"
+  version: 3.15.1
+  resolution: "js-yaml@npm:3.15.1"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2fdf3a1453ed93a8e06d6ca8054c0bec145cf40ab51f305d1071736a03668b95e40f47cfd0239d7d50019b4780a18cdaca3c935def935594c9876964c49f1185
+  checksum: 10/905842ce08c18b154ff2c187ff81bb41294cc5dda214331b5d9b8bcf395894e48b00fa37b9d4dd4c3ffec672b7496a94558e3876d3a8ad4d12b06248112e6d92
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^4.1.0, js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/2bcec3a8118d7f744badeb04e14366578d234a736f353d41fe35d2305e4ce2409a8e041d277f07cd6bbc8aaa12128d650a68ce43247072519bede20962d2126f
+  checksum: 10/2ce71b5d632abbd77da80447bf860e8a0264e54bffe94840984887d58b023761495b523727547904517a6107a1ef189854b361e0fc44995ee13a84f222d7bd42
   languageName: node
   linkType: hard
 
@@ -22324,12 +22324,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.1, nanoid@npm:^3.3.12, nanoid@npm:^3.3.8":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+"nanoid@npm:^3.3.1, nanoid@npm:^3.3.16, nanoid@npm:^3.3.8":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 
@@ -23796,14 +23796,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.5.16":
-  version: 8.5.16
-  resolution: "postcss@npm:8.5.16"
+"postcss@npm:8.5.23":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.12"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/b39408900aa394bce6f567d539b7361e71c07f361313e5b01e40481c5120309a570e7a54c6a0c6ea5f0c0c06ff8c12b560beeebcc29ea173ad42ec74bae86069
+  checksum: 10/8387f421216696bf62a13e5a270e9fefdafc81e196903c0f8d7653f8bab315367cc2261b3c22cf197e492cb075f31bdfc07fd9c3be1cb165ff3cabe14c5a039a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Clears **7 open Dependabot alerts** against `yarn.lock`. Every affected package is transitive; all but postcss already sat within a range permitting the patched release, so a lockfile refresh covered them.

| Package | From | To | Advisory |
|---|---|---|---|
| nanoid | 3.3.16 | 3.3.18 | `GHSA-2v37-7h3g-55p8` |
| js-yaml | 3.15.0 | 3.15.1 | `GHSA-5p4m-2wfm-xmqj` |
| js-yaml | 4.3.0 | 4.3.1 | `GHSA-5p4m-2wfm-xmqj` |
| fast-uri | 3.1.4 | 3.1.6 | `GHSA-7p8r-x3mc-p8w7` |
| brace-expansion | 5.0.8 | 5.0.9 | `GHSA-rgw5-rvv9-x895` |
| postcss | 8.5.16 | 8.5.23 | `GHSA-r28c-9q8g-f849`, `GHSA-fxqj-rqcc-2cmp` |

### Why postcss also touches `package.json`

`resolutions` pinned postcss to exactly `8.5.16`, which overrode every consumer's range — a lockfile refresh alone could not move it. The pin is now `8.5.23`, covering both advisories (patched in 8.5.18 and 8.5.23 respectively).

`devDependencies.postcss` is deliberately left at `8.4.38`; the resolution is what actually governs the installed version.

Produced with `yarn up -R nanoid js-yaml fast-uri brace-expansion postcss`.

### Verification

- `yarn install --immutable` — passes (the peer-dependency warnings are pre-existing on `main`)
- `yarn nx run-many -t build --projects=shelter-web,wildfires,betterangels-admin --skip-nx-cache` — all succeed
- `yarn nx run-many -t test` — all pass
- `yarn nx run-many -t lint` — 0 errors (1 pre-existing warning in `useShelterRoutes.tsx`)
- `yarn why` confirms each package actually resolved to the patched version rather than being pinned back by a resolution

### Not covered here

`image-size` (`GHSA-5p2g-fcmc-qvqq`, `GHSA-w3rx-r6r6-pgpr`) has **no** patched release — every version through the current latest (2.0.2) is vulnerable. It is reached only via `metro`, i.e. build-time tooling. Proposing dismissal as tolerable risk separately.

`react-router` / `react-router-dom` need a v6→v7 migration and are being handled in their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Update vulnerable transitive npm dependencies to patched releases, clearing seven Dependabot alerts across nanoid, js-yaml, fast-uri, brace-expansion, and postcss.