### PR TITLE
fix(dependabot): track uv instead of pip, and group interdependent updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,45 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+      dev-tooling:
+        patterns:
+          - '@nx/*'
+          - 'nx'
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - 'prettier'
+          - 'vite'
+          - 'vitest'
+          - '@vitest/*'
+          - 'typescript'
+          - '@types/*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
-  - package-ecosystem: 'pip'
+  - package-ecosystem: 'uv'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      python-security:
+        applies-to: security-updates
+        patterns:
+          - '*'
+      type-stubs:
+        patterns:
+          - 'django-stubs'
+          - 'django-stubs-ext'
+          - 'djangorestframework-stubs'
+          - 'types-*'
+          - 'celery-types'
+          - 'boto3-stubs'
 
   - package-ecosystem: 'docker'
     directory: '/'


### PR DESCRIPTION
Fixes the two configuration faults that have kept every Python Dependabot PR permanently red and prevented any security update from reaching `uv.lock`.

## 1. `pip` → `uv`

The repo migrated from Poetry to uv in `d6086be2f` (2026-06-22), but the config still declared `package-ecosystem: 'pip'`. The pip ecosystem edits `pyproject.toml` and **never regenerates `uv.lock`**, so every PR it opened shipped a stale lockfile and failed the Dockerfile's `uv sync --no-install-project`:

```
× No solution found when resolving dependencies:
  ╰─▶ Because only django-stubs[compatible-mypy]<=6.0.7 is available
      and django-stubs==6.0.7 depends on django-stubs-ext>=6.0.2 ...
      we can conclude that your workspace's requirements are unsatisfiable.
```

That is why **#2290–#2294** have been failing since 2026-08-03. It also means no security update could ever reach `uv.lock`, where 22 of the 45 open alerts live.

`directory: '/'` is unchanged and still correct — the root `pyproject.toml` is the uv workspace root (`[tool.uv.workspace] members = ["apps/betterangels-backend"]`), so the backend is already covered.

## 2. Grouping

**`type-stubs`** — django-stubs (#2294) and django-stubs-ext (#2293) were raised as separate PRs, but `django-stubs==6.0.7` requires `django-stubs-ext>=6.0.2` while `pyproject.toml` capped ext at `<6`. Neither PR was individually satisfiable, so both were red no matter how often they were rebased. Grouping keeps interdependent stubs moving together.

**`npm-security` / `python-security`** — `applies-to: security-updates`, pattern `*`. Enabling security updates against the current 45-alert backlog would otherwise open dozens of PRs at once; this produces one reviewable PR per ecosystem instead, mirroring how #2365 and #2366 were assembled by hand.

The tradeoff is that one broken package blocks the whole grouped security PR. Given the backlog size that seems the better default, and a group can always be split later.

**`dev-tooling`** — batches nx/eslint/vite/typescript minor+patch churn to cut PR volume.

## Follow-up (not in this PR)

Dependabot security updates are currently **disabled** — `GET /repos/BetterAngelsLA/monorepo/automated-security-fixes` returns `{"enabled": false}`. That is a repo setting, not a file, and it is why 45 alerts have produced zero security PRs. It should be enabled **after** this merges:

```
gh api -X PUT repos/BetterAngelsLA/monorepo/automated-security-fixes
```

Ordering matters — with the setting on but the ecosystem still `pip`, every Python security PR would ship a stale lockfile and fail exactly as #2290–#2294 do.

## Verification

Config parses as valid YAML. After merge, confirm a clean `uv` run under Insights → Dependency graph → Dependabot, and that the next Python PR touches `uv.lock` as well as `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct Dependabot’s Python ecosystem and organize related dependency updates into targeted groups.

Bug Fixes:
- Update Dependabot to use the uv ecosystem so Python dependency updates keep `uv.lock` synchronized.
- Group interdependent Python stub packages so related upgrades are proposed together.

Enhancements:
- Group npm and Python security updates into reviewable ecosystem-level pull requests.
- Batch minor and patch updates for frontend development tooling to reduce Dependabot pull request volume.