### PR TITLE
docs: let a run opt into its own test database

### DIFF
--- a/apps/betterangels-backend/betterangels_backend/settings.py
+++ b/apps/betterangels-backend/betterangels_backend/settings.py
@@ -280,6 +280,12 @@ DATABASES = {
             "ENABLED": env("USE_IAM_AUTH"),
             "REGION_NAME": env("AWS_REGION"),
         },
+        # Django derives the test database from NAME, so every checkout sharing a
+        # POSTGRES_NAME shares one test database — and `pytest --create-db` drops
+        # it underneath whoever else is using it.  Pass POSTGRES_TEST_NAME on a
+        # run that needs its own; unset, which is the default everywhere, means
+        # Django's `test_<NAME>`.
+        "TEST": {"NAME": env("POSTGRES_TEST_NAME", default=None)},
     },
 }
 

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -40,6 +40,13 @@ This is the BetterAngels monorepo:
 - **You are running INSIDE the dev container.** Do NOT use `docker compose` or `docker` commands.
 - **Always use the NX wrapper for Python commands.** The backend uses `uv` with a shared venv at `/workspace/.venv`. Use `yarn nx run betterangels-backend:<command>` or `yarn nx test betterangels-backend`. If you MUST run raw Python, use `uv run python ...` — uv handles venv activation automatically.
 - See `docs/tooling.md` for the full command reference.
+- **One test database is shared by every checkout.** Use it by default. When you
+  are in a git worktree or alongside another agent session, pass
+  `POSTGRES_TEST_NAME` on the test command for that run — otherwise
+  `pytest --create-db` destroys the database another session is using, and you
+  will chase failures that are not in your code. Do not set it in `.env`; the
+  shared database stays the default. See the Testing section of
+  `docs/styleguides/python.md`.
 
 ## Before Committing Code
 

--- a/docs/backend_readme.md
+++ b/docs/backend_readme.md
@@ -95,6 +95,22 @@ To run an individual test, add the full path of the test in dot notation. Exampl
 yarn nx test betterangels-backend accounts.tests.UsersManagersTests.test_create_user
 ```
 
+#### Working in more than one checkout
+
+The test database name comes from `POSTGRES_NAME`, so every worktree and every
+container shell shares one `test_postgres`. Running with `--create-db` in one
+drops it under the others, which surfaces as large numbers of failures in apps
+you did not touch.
+
+When that is a risk, name a database for the run:
+
+```bash
+POSTGRES_TEST_NAME=test_myworktree uv run pytest -q --create-db
+```
+
+Per command, not in `.env` — the shared database stays the default so that
+running the suite by hand behaves the same way everywhere.
+
 #### Debugging Tests
 
 To run tests with breakpoints via the terminal, you'll need to use a `uv shell` as described in the section above, then:

--- a/docs/styleguides/python.md
+++ b/docs/styleguides/python.md
@@ -57,6 +57,29 @@ Push each rule to the lowest layer that can express it.
 - Use VCR cassettes (`test_utils/vcr_config.py`) for external HTTP calls
 - Test files mirror source structure: `tests/test_services.py`, `tests/test_queries.py`
 
+### Give each checkout its own test database
+
+Django derives the test database name from `POSTGRES_NAME`, which is `postgres` in
+every `.env` — so every worktree, container shell and coding-agent session shares
+one `test_postgres`. `addopts = "--reuse-db"` hides that most of the time, but
+`pytest --create-db` drops and recreates it underneath anyone else mid-run.
+
+The symptom is failures that escalate and move between runs of *unchanged* code —
+5, then 14, then every test in the suite erroring, in apps you never touched.
+That is not a defect in your branch. Set `POSTGRES_TEST_NAME` before concluding
+anything about a failure you cannot reproduce:
+
+```bash
+POSTGRES_TEST_NAME=test_myworktree uv run pytest -q --create-db
+```
+
+Pass it on the command that needs it rather than writing it into `.env`. The
+shared database is the default on purpose: it is what a developer gets running
+the same command by hand, and a checkout permanently pointed elsewhere both
+hides that and leaves stale databases behind. Reach for the override when a
+clash is actually possible — a second checkout, a concurrent session — and
+always before `--create-db`, which is the flag that destroys another run.
+
 ## Type Checking
 
 - Strict `mypy` via `mypy.ini` (disallow untyped defs, no implicit optional, etc.)


### PR DESCRIPTION
## What

Django derives the test database name from `POSTGRES_NAME`, which is `postgres` in every `.env`. Every worktree, container shell and coding-agent session therefore shares one `test_postgres`, and `pytest --create-db` drops and recreates it underneath whoever else is mid-run.

`POSTGRES_TEST_NAME` names the database for a run that asks for one:

```bash
POSTGRES_TEST_NAME=test_myworktree uv run pytest -q --create-db
```

| | `TEST.NAME` setting | Database used |
|---|---|---|
| Unset — the default everywhere | `None` | `test_postgres` |
| `POSTGRES_TEST_NAME=test_wtdocs` | `test_wtdocs` | `test_wtdocs` |

## Opt-in per run, not per checkout

The shared database stays the default, and the docs deliberately do **not** tell you to put this in `.env`. A checkout permanently pointed somewhere else stops matching what a developer gets running the same command by hand, and quietly accumulates stale test databases on the server. This is for the moment you know a clash is possible — a second checkout, a concurrent session — and especially before `--create-db`, which is the flag that actually destroys another run.

Nothing changes for CI or for anyone with a single checkout.

## Why it is worth documenting rather than just knowing

The failure mode does not look like a collision. The same unchanged code fails differently on each run, in apps the branch never touched, escalating as the two runs interleave — I hit 5 failures, then 14, then all 1441 tests erroring, across three runs of one commit. Every instinct says debug the branch.

Two of those runs cost ~6 minutes each before producing a list of failures to not-understand. Naming the symptom is most of the value here: *failures that move between runs of unchanged code, in code you did not touch, are not yours.*

## Where it is documented

Each audience reads a different file, so the note goes in all three:

- `docs/styleguides/python.md` — Testing section, which `docs/ai-instructions.md` points AI assistants at for conventions.
- `docs/ai-instructions.md` — Critical Environment Rules, the entry point itself, since an agent spawning a worktree is the most likely way to hit this.
- `docs/backend_readme.md` — the human test runbook.

## Testing

- Verified both directions against a live connection: unset resolves to `test_postgres`, `POSTGRES_TEST_NAME=test_wtdocs` resolves to `test_wtdocs`.
- Ran a suite end to end under the override and confirmed `test_postgres`, `test_wt2352` and `test_wtdocs` coexist — two of them created by concurrent work on other branches, which is the situation that prompted this.
- `ruff check`, `ruff format --check` and `mypy` clean on the changed settings file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)