### PR TITLE
fix(accounts): send an invited Shelter Operator to the operator app

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -7,8 +7,6 @@ from django.contrib import admin, messages
 from django.contrib.admin import ModelAdmin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User as DefaultUser
-from django.contrib.sites.models import Site
-from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models import Model, QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -220,7 +218,6 @@ class MemberInviteAdminMixin:
                 email=email,
                 permission_templates=role_templates,
                 invited_by=cast(User, request.user),
-                site=Site.objects.get(pk=settings.SITE_ID),
             )
         except ValidationError as error:
             self.message_user(request, "; ".join(error.messages), messages.ERROR)

--- a/apps/betterangels-backend/accounts/emails.py
+++ b/apps/betterangels-backend/accounts/emails.py
@@ -11,6 +11,17 @@ from accounts.models import Organization, User
 logger = logging.getLogger(__name__)
 
 
+def base_url_for(template_config: TemplateConfig) -> str:
+    """Base URL of the frontend app a holder of *template_config* signs in to.
+
+    Read from the Django setting named by ``base_url_setting`` — env-driven, so it
+    is right per environment, and it carries its own scheme.  Every email that
+    sends someone to their app resolves the host this way, so a welcome message
+    and the invitation that preceded it cannot point at different places.
+    """
+    return str(getattr(settings, template_config.base_url_setting, ""))
+
+
 def send_welcome_email(user: User, organization: Organization, template_config: TemplateConfig) -> None:
     """Send a welcome email using the given template config.
 
@@ -28,7 +39,7 @@ def send_welcome_email(user: User, organization: Organization, template_config: 
         logger.warning(f"No welcome email templates for '{template_config.name}' — skipping.")
         return
 
-    base_url = getattr(settings, template_config.base_url_setting, "")
+    base_url = base_url_for(template_config)
 
     context = {
         "user_email": user.email,

--- a/apps/betterangels-backend/accounts/schema.py
+++ b/apps/betterangels-backend/accounts/schema.py
@@ -6,9 +6,7 @@ import strawberry_django
 from common.graphql.types import DeletedObjectType
 from common.org_types import REGISTRY
 from common.permissions.utils import IsAuthenticated, get_current_organization
-from django.conf import settings
 from django.contrib import auth
-from django.contrib.sites.models import Site
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Exists, OuterRef, QuerySet
@@ -19,7 +17,7 @@ from strawberry_django.mutations import resolvers
 from strawberry_django.pagination import OffsetPaginated
 from strawberry_django.permissions import HasPerm
 
-from accounts.emails import send_welcome_emails_for_org
+from accounts.emails import base_url_for, send_welcome_emails_for_org
 from accounts.extensions import HasOrgPerm
 from accounts.permissions import UserOrganizationPermissions, get_user_permitted_org
 
@@ -244,12 +242,11 @@ class Mutation:
             organization=organization, invited_by_user=current_user, invitee_user=user
         )
 
-        site = Site.objects.get(pk=settings.SITE_ID)
         invitation_backend().send_invitation(
             user=user,
             sender=current_user,
             organization=organization,
-            domain=site,
+            base_url=base_url_for(template),
             role_template=template,
         )
 

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -11,12 +11,12 @@ from typing import TYPE_CHECKING, Any
 
 from common.org_types import REGISTRY
 from common.permissions.config import TemplateConfig
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from organizations.backends import invitation_backend
 from organizations.models import Organization, OrganizationOwner, OrganizationUser
 
+from .emails import base_url_for
 from .groups import ORG_ADMIN
 from .seed import sync_group_permissions
 from .models import (
@@ -179,7 +179,6 @@ def member_invite(
     email: str,
     permission_templates: tuple[TemplateConfig, ...],
     invited_by: UserModel,
-    site: Site,
 ) -> UserModel:
     """Add someone to *organization* with the given roles and email them an invitation.
 
@@ -209,7 +208,7 @@ def member_invite(
             user=user,
             sender=invited_by,
             organization=organization,
-            domain=site,
+            base_url=base_url_for(permission_template),
             role_template=permission_template,
         )
 

--- a/apps/betterangels-backend/accounts/tests/test_mutations.py
+++ b/apps/betterangels-backend/accounts/tests/test_mutations.py
@@ -191,7 +191,7 @@ class OrganizationMemberMutationTestCase(GraphQLBaseTestCase, ParametrizedTestCa
         }
 
         with patch("accounts.backends.CustomInvitations.send_invitation") as mock_send_invitation:
-            with self.assertNumQueriesWithoutCache(21):
+            with self.assertNumQueriesWithoutCache(20):
                 response = self.execute_graphql(mutation, {"data": variables})
 
             mock_send_invitation.assert_called_once()

--- a/apps/betterangels-backend/accounts/tests/test_send_invitation.py
+++ b/apps/betterangels-backend/accounts/tests/test_send_invitation.py
@@ -6,10 +6,12 @@ from common.permissions.config import TemplateConfig
 from django.test import TestCase, override_settings
 from model_bakery import baker
 from notes.groups import CASEWORKER
+from shelters.groups import SHELTER_OPERATOR
 from organizations.models import Organization, OrganizationInvitation
 from post_office.models import Email
 
 from ..backends import CustomInvitations
+from ..emails import base_url_for
 from ..models import User
 
 
@@ -76,7 +78,7 @@ class SendInvitationTestCase(TestCase):
             user,
             sender,
             organization=self.organization,
-            domain="localhost:8000",
+            base_url="http://localhost:4200",
         )
         self.assertIsInstance(result, int)
         self.assertEqual(Email.objects.filter(to=self.email).count(), 1)
@@ -102,7 +104,7 @@ class SendInvitationTestCase(TestCase):
                 user,
                 sender,
                 organization=self.organization,
-                domain="localhost:8000",
+                base_url="http://localhost:4200",
                 role_template=CASEWORKER,
             )
             mock_resolve.assert_called_once()
@@ -113,27 +115,52 @@ class SendInvitationTestCase(TestCase):
         """send_invitation raises ValueError if user has no email."""
         user = baker.make(User, email="")
         with self.assertRaisesRegex(ValueError, r"Cannot send invitation"):
-            self.invitation_backend.send_invitation(user, organization=self.organization, domain="localhost:8000")
+            self.invitation_backend.send_invitation(
+                user, organization=self.organization, base_url="http://localhost:4200"
+            )
+
+    @override_settings(SHELTER_WEB_BASE_URL="https://shelter.example.org")
+    def test_a_shelter_operator_invitation_links_to_the_operator_app(self) -> None:
+        """The link has to match where the welcome email sends them.
+
+        It used to come from the ``django_site`` row, which holds the API host —
+        ``api.dev.betterangels.la`` on dev — so the invitation and the welcome
+        email named two different places, and neither environment's row was ever
+        the operator app.
+        """
+        user = baker.make(User, email=self.email)
+
+        self.invitation_backend.send_invitation(
+            user,
+            baker.make(User, email="admin@test.com"),
+            organization=self.organization,
+            base_url=base_url_for(SHELTER_OPERATOR),
+            role_template=SHELTER_OPERATOR,
+        )
+
+        body = Email.objects.get(to=self.email).html_message
+        self.assertIn("https://shelter.example.org", body)
+        self.assertNotIn("betterangels.la", body)
 
     # ── invite_by_email ────────────────────────────────────────────────
 
     @patch("accounts.backends.CustomInvitations.send_invitation")
     def test_invite_by_email_creates_user(self, mock_send: Mock) -> None:
         """invite_by_email creates a new user and sends invitation."""
-        abstract_user = self.invitation_backend.invite_by_email(self.email, domain="localhost:8000")
+        abstract_user = self.invitation_backend.invite_by_email(self.email, base_url="http://localhost:4200")
         assert isinstance(abstract_user, User)
         self.assertEqual(abstract_user.email, self.email)
         self.assertFalse(abstract_user.has_usable_password())
-        mock_send.assert_called_once_with(abstract_user, None, domain="localhost:8000")
+        mock_send.assert_called_once_with(abstract_user, None, base_url="http://localhost:4200")
 
     @patch("accounts.backends.CustomInvitations.send_invitation")
     def test_invite_by_email_existing_user(self, mock_send: Mock) -> None:
         """invite_by_email reuses existing user by email."""
         existing = baker.make(User, email=self.email, username="existing")
-        abstract_user = self.invitation_backend.invite_by_email(self.email, domain="localhost:8000")
+        abstract_user = self.invitation_backend.invite_by_email(self.email, base_url="http://localhost:4200")
         assert isinstance(abstract_user, User)
         self.assertEqual(abstract_user.pk, existing.pk)  # reused
-        mock_send.assert_called_once_with(abstract_user, None, domain="localhost:8000")
+        mock_send.assert_called_once_with(abstract_user, None, base_url="http://localhost:4200")
 
     @patch("accounts.backends.CustomInvitations.send_invitation")
     def test_invite_by_email_reactivates_inactive_user(self, mock_send: Mock) -> None:
@@ -141,14 +168,14 @@ class SendInvitationTestCase(TestCase):
         instead of duplicated."""
         existing = baker.make(User, email=self.email, username="existing", is_active=False)
 
-        abstract_user = self.invitation_backend.invite_by_email(self.email.upper(), domain="localhost:8000")
+        abstract_user = self.invitation_backend.invite_by_email(self.email.upper(), base_url="http://localhost:4200")
 
         assert isinstance(abstract_user, User)
         self.assertEqual(abstract_user.pk, existing.pk)  # reused, not duplicated
         self.assertEqual(User.objects.filter(email=self.email).count(), 1)
         abstract_user.refresh_from_db()
         self.assertTrue(abstract_user.is_active)
-        mock_send.assert_called_once_with(abstract_user, None, domain="localhost:8000")
+        mock_send.assert_called_once_with(abstract_user, None, base_url="http://localhost:4200")
 
     def test_send_invitation_case(self) -> None:
         """Original smoke test — invite_by_email creates an Email record."""

--- a/apps/betterangels-backend/templates/account/email/shelter_operator_invite.html
+++ b/apps/betterangels-backend/templates/account/email/shelter_operator_invite.html
@@ -72,7 +72,7 @@
                                     Log in using <strong>{{ login_email }}</strong> at:
                                 </p>
                                 <p style="margin:0 0 12px 0;">
-                                    <a href="https://{{ domain }}" style="color:#1976D2; text-decoration:underline">{{ domain }}</a>
+                                    <a href="{{ base_url }}" style="color:#1976D2; text-decoration:underline">{{ base_url }}</a>
                                 </p>
                                 {% if is_demo %}
                                     <p style="margin:0 0 12px 0; color:#B45309;">

--- a/apps/betterangels-backend/templates/account/messages/shelter_operator_invite.txt
+++ b/apps/betterangels-backend/templates/account/messages/shelter_operator_invite.txt
@@ -4,7 +4,7 @@ You've been added as a Shelter Operator at {{ organization_name }}.
 
 As a Shelter Operator, you can manage beds, rooms, and reservations.
 
-Log in using {{ login_email }} at https://{{ domain }}.
+Log in using {{ login_email }} at {{ base_url }}.
 {% if is_demo %}
 IMPORTANT: Because this is the demo environment, you must enter
 your email as {{ login_email }} (with "+demo" before the @) so it


### PR DESCRIPTION
## What

A new Shelter Operator gets two emails naming two different places.

| Email | Link | Source |
|---|---|---|
| Welcome | `{{ base_url }}/operator` | `SHELTER_WEB_BASE_URL` — the operator app |
| Invitation | `https://{{ domain }}` | the `django_site` row |

The `django_site` row holds the **API host** — `api.dev.betterangels.la` on dev, `betterangels.la` in production. Neither has ever been the operator app, so the invitation has been sending people somewhere they cannot sign in, and then the welcome email sends them somewhere else.

`base_url_for` puts the rule in one place, and both emails now use it: the base URL of the app a role signs in to comes from the setting its `TemplateConfig` names. Being env-driven it is right per environment, and it carries its own scheme — so the hardcoded `https://` goes with it, which is also what makes the link work locally, where there is no TLS.

Rendered locally, before and after:

```
- https://localhost:8000     API host, over TLS that does not exist locally
+ http://localhost:4200      the operator app
```

## Scope

Only the Shelter Operator templates ever rendered `{{ domain }}` — the generic organization invitation does not use it, so no other email changes.

Both senders are converted: the `addOrganizationMember` mutation in `accounts/schema.py`, and `member_invite` in `accounts/services.py`. `member_invite` loses its `site` parameter, and `accounts/admin.py` was its only caller — which is why the admin stops looking a `Site` up too. Those three lines in `admin.py` are part of this change, not incidental to it.

Dropping `Site.objects.get(pk=settings.SITE_ID)` also removes a query from the invite mutation, which is the count change in `test_add_organization_member`.

`SITE_ID` and `django.contrib.sites` stay: the admin's "View on site" resolution depends on them.

## Testing

- `1471 passed, 31 skipped` — full suite. `mypy` clean on 387 files with the cache cleared; `ruff check` and `ruff format` clean.
- The new test overrides `SHELTER_WEB_BASE_URL` and asserts the rendered invitation contains it and *not* the Site domain. Mutation-tested — restoring `https://{{ domain }}` fails it.

  Worth noting the first version of that mutation was vacuous: reverting only the `href` left the link *text* still rendering `{{ base_url }}`, so the assertion passed anyway. The real check reverts the whole anchor.
- Also verified by rendering a real invitation through the file email backend rather than trusting the test alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure Shelter Operator invitations direct recipients to the application where they can sign in.

Bug Fixes:
- Route Shelter Operator invitation emails to the configured operator application instead of the API host, keeping invitation and welcome links consistent across environments.

Enhancements:
- Centralize role-specific application URL resolution and remove the unnecessary site lookup from invitation flows.

Tests:
- Add coverage verifying Shelter Operator invitations use the configured operator application URL and exclude the Django Site domain.
- Update invitation tests and query-count expectations for the new URL handling.
