### PR TITLE
fix(shelters): stop the CSV import from minting organizations

### DIFF
--- a/apps/betterangels-backend/shelters/admin.py
+++ b/apps/betterangels-backend/shelters/admin.py
@@ -814,7 +814,12 @@ class ShelterResource(resources.ModelResource):
         for column in row.keys():
             rowInDict[column] = row.get(column)
         if rowInDict["organization"]:
-            org, created = Organization.objects.get_or_create(name=rowInDict["organization"])
+            if not Organization.objects.filter(name=rowInDict["organization"]).exists():
+                # Returning matters here where the other checks fall through: the
+                # processing below geocodes against a billable API and creates
+                # Address rows, neither of which a skipped row should pay for.
+                self.skip_or_raise(row, "organization")
+                return
             # This process SPA name considering the ManyToMany nature of the field
             # Gets existing object or makes it if one doesn't exist
             if rowInDict["status"] and rowInDict["status"] not in [j for _, j in StatusChoices.choices]:

--- a/apps/betterangels-backend/shelters/tests/test_admin.py
+++ b/apps/betterangels-backend/shelters/tests/test_admin.py
@@ -1,6 +1,12 @@
+from typing import Any
+from unittest.mock import patch
+
+from accounts.tests.baker_recipes import organization_recipe
+from django.core.exceptions import ValidationError
 from django.http import QueryDict
 from django.test import TestCase
-from shelters.admin import GroupedServiceWidget, ShelterForm
+from organizations.models import Organization
+from shelters.admin import GroupedServiceWidget, ShelterForm, ShelterResource
 from shelters.models import Service, ServiceCategory, Shelter
 
 
@@ -86,3 +92,66 @@ class ShelterFormPendingServicesTestCase(TestCase):
         self.assertEqual(Service.objects.filter(category=self.category, display_name__iexact="Showers").count(), 1)
         self.assertEqual(Service.objects.filter(category=self.category, name="showers", is_other=True).count(), 1)
         self.assertEqual(self.shelter.services.count(), 2)
+
+
+class ShelterResourceOrganizationTestCase(TestCase):
+    """The Shelter import resolves organizations, it does not create them."""
+
+    CUSTOM_FIELDS = (
+        "demographics",
+        "special_situation_restrictions",
+        "shelter_types",
+        "shelter_programs",
+        "room_styles",
+        "funders",
+        "entry_requirements",
+        "vaccination_requirement",
+        "storage",
+        "pets",
+        "cities_served",
+        "accessibility",
+        "parking",
+    )
+
+    def _row(self, **overrides: Any) -> dict[str, Any]:
+        row: dict[str, Any] = {"organization": "", "status": "", "location": "", "additional_contacts": ""}
+        row.update({field: "" for field in self.CUSTOM_FIELDS})
+        row.update(overrides)
+        return row
+
+    def test_known_organization_is_reused(self) -> None:
+        organization_recipe.make(name="Alpha Housing")
+        row = self._row(organization="Alpha Housing")
+
+        ShelterResource().before_import_row(row)
+
+        self.assertFalse(row["jumpthis"])
+        self.assertEqual(Organization.objects.filter(name="Alpha Housing").count(), 1)
+
+    def test_unknown_organization_skips_the_row(self) -> None:
+        resource = ShelterResource()
+        resource.skip_row_not_val_error = True
+        row = self._row(organization="Nowhere Housing")
+
+        resource.before_import_row(row)
+
+        self.assertTrue(row["jumpthis"])
+        self.assertFalse(Organization.objects.filter(name="Nowhere Housing").exists())
+
+    def test_unknown_organization_raises_when_not_skipping(self) -> None:
+        resource = ShelterResource()
+        resource.skip_row_not_val_error = False
+
+        with self.assertRaises(ValidationError):
+            resource.before_import_row(self._row(organization="Nowhere Housing"))
+
+        self.assertFalse(Organization.objects.filter(name="Nowhere Housing").exists())
+
+    def test_unknown_organization_stops_before_geocoding(self) -> None:
+        resource = ShelterResource()
+        row = self._row(organization="Nowhere Housing", location="123 Main Street")
+
+        with patch.object(ShelterResource, "process_address_import") as process_address:
+            resource.before_import_row(row)
+
+        process_address.assert_not_called()


### PR DESCRIPTION
## Why

Item 4 of the #2352 / #2354 follow-ups was "near-duplicate organizations". The census against production turned the data question into a code one: **99 organizations, 7 near-duplicate groups, 14 rows** — and `owner_email` null on every one of them.

That shape has a single cause. `ShelterResource.before_import_row` did:

```python
org, created = Organization.objects.get_or_create(name=rowInDict["organization"])
```

against the raw spreadsheet cell. Every spelling variant in an import mints a new organization, and because it bypasses `organization_create` those rows get no `OrganizationProfile`, no `org_types`, no reconciled permission groups and no `OrganizationOwner`. That is precisely the unusable organization #2352 was titled after — created here, silently, one CSV row at a time.

Neither `org` nor `created` was used. The call existed only so the `ForeignKeyWidget(Organization, "name")` lookup on the next pass would find something.

Cleaning up the duplicate rows without this change would just mean the next spreadsheet recreates them.

## What changes

An unrecognised organization name becomes a validation failure instead of a new row, routed through the `skip_or_raise` helper the resource already uses for every other bad column — so it skips or raises according to `skip_row_not_val_error` exactly like a bad `status` or `location`.

One deliberate difference from its siblings: this check `return`s rather than falling through. Everything below it calls the Google geocoding API and `Location.get_or_create_address`, so falling through would spend a billable request and leave an orphan `Address` behind for a row that is about to be discarded.

## Cost

Importing a shelter for a genuinely new organization now needs someone to create that organization in the admin first. That is the intended trade — an importer-invented organization could not function anyway — but it is a workflow change for whoever runs these imports, so flagging it rather than burying it.

## Tests

`shelters/admin.py` had no importer tests at all; these are the first.

- a known organization is reused and no row is created
- an unknown organization sets `jumpthis` under `skip_row_not_val_error`
- an unknown organization raises `ValidationError` without it
- an unknown organization stops before geocoding

Each was mutation-tested. Restoring `get_or_create` fails three of the four; removing only the `return` fails the geocoding one alone. The fourth — "a known organization is reused" — passes against both versions by design: it is a regression guard on the happy path, not evidence of the fix.

Full backend suite: 1474 passed, 31 skipped. `ruff`, `ruff format --check` and `mypy` clean.

## Note for review

The styleguide puts existence checks in a service. There is no service layer behind this CSV importer, and the check is row validation belonging to the `Resource`, so it follows the file's established `skip_or_raise` pattern instead. Worth a second opinion if you'd rather see the importer grow a service seam.

## Not in this PR

Retiring the 7 duplicate groups already in production is a separate, guarded data migration, still blocked on one number: the census omitted `Shelter.organization`, a `SET_NULL` FK, so we do not yet know whether any of those rows own shelters. Nothing gets deleted until that is counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Require shelter CSV imports to reference existing organizations instead of minting unusable organization records.

Bug Fixes:
- Prevent shelter CSV imports from creating organizations when the organization name is not already registered.
- Handle unknown organizations through the existing skip-or-raise validation behavior and stop processing before geocoding or address creation.

Tests:
- Add importer coverage for reusing known organizations, skipping or raising for unknown organizations, and avoiding geocoding for rejected rows.