### PR TITLE
update prettier formatting commands in bash and package.json (DEV-2528)

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,7 +1,7 @@
 alias rebash="source .bash_aliases" # run this if you change this file
 
 # precommit
-alias ynx-precommit="ynx-lint && ynx-typecheck && ynx-validate-schema && ynx-check-migrations"
+alias ynx-precommit="ynx-lint && ynx-typecheck && ynx-validate-schema && ynx-check-migrations && ynx-pretty"
 
 # migrations
 alias ynx-check-migrations="yarn nx affected -t check-migrations"
@@ -22,6 +22,12 @@ alias ynx-lint-fe="yarn nx lint betterangels"
 alias ynx-lint="yarn nx affected -t lint"
 alias ynx-lint-all="yarn nx run-many -t lint"
 alias ynx-typecheck="yarn nx affected -t typecheck"
+
+# prettier formatting
+alias ynx-pretty="yarn nx format:check --verbose"
+alias ynx-pretty-fix="yarn nx format:write"
+alias ynx-pretty-all="yarn nx format:check --all --verbose"
+alias ynx-pretty-all-fix="yarn nx format:write --all"
 
 # db
 alias ynx-reset-db="yarn nx run betterangels-backend:reset_db"

--- a/docs/styleguides/python.md
+++ b/docs/styleguides/python.md
@@ -64,7 +64,7 @@ every `.env` — so every worktree, container shell and coding-agent session sha
 one `test_postgres`. `addopts = "--reuse-db"` hides that most of the time, but
 `pytest --create-db` drops and recreates it underneath anyone else mid-run.
 
-The symptom is failures that escalate and move between runs of *unchanged* code —
+The symptom is failures that escalate and move between runs of _unchanged_ code —
 5, then 14, then every test in the suite erroring, in apps you never touched.
 That is not a defect in your branch. Set `POSTGRES_TEST_NAME` before concluding
 anything about a failure you cannot reproduce:

--- a/libs/ba-platform/codegen.ts
+++ b/libs/ba-platform/codegen.ts
@@ -1,5 +1,8 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
-import { SCALAR_IMPORT_PLUGIN, SHARED_SCALAR_CONFIG } from '../../tools/codegen/scalars';
+import {
+  SCALAR_IMPORT_PLUGIN,
+  SHARED_SCALAR_CONFIG,
+} from '../../tools/codegen/scalars';
 
 const config: CodegenConfig = {
   overwrite: true,

--- a/libs/expo/betterangels/codegen.ts
+++ b/libs/expo/betterangels/codegen.ts
@@ -1,5 +1,8 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
-import { SCALAR_IMPORT_PLUGIN, SHARED_SCALAR_CONFIG } from '../../../tools/codegen/scalars';
+import {
+  SCALAR_IMPORT_PLUGIN,
+  SHARED_SCALAR_CONFIG,
+} from '../../../tools/codegen/scalars';
 
 const config: CodegenConfig = {
   overwrite: true,

--- a/libs/react/betterangels-admin/codegen.ts
+++ b/libs/react/betterangels-admin/codegen.ts
@@ -1,5 +1,8 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
-import { SCALAR_IMPORT_PLUGIN, SHARED_SCALAR_CONFIG } from '../../../tools/codegen/scalars';
+import {
+  SCALAR_IMPORT_PLUGIN,
+  SHARED_SCALAR_CONFIG,
+} from '../../../tools/codegen/scalars';
 
 const config: CodegenConfig = {
   overwrite: true,

--- a/libs/react/shelter-operator/codegen.ts
+++ b/libs/react/shelter-operator/codegen.ts
@@ -1,5 +1,8 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
-import { SCALAR_IMPORT_PLUGIN, SHARED_SCALAR_CONFIG } from '../../../tools/codegen/scalars';
+import {
+  SCALAR_IMPORT_PLUGIN,
+  SHARED_SCALAR_CONFIG,
+} from '../../../tools/codegen/scalars';
 
 const config: CodegenConfig = {
   overwrite: true,

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.test.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.test.tsx
@@ -60,7 +60,7 @@ function renderPage(mocks: Parameters<typeof MockedProvider>[0]['mocks']) {
           />
         </Routes>
       </MemoryRouter>
-    </MockedProvider>
+    </MockedProvider>,
   );
 }
 
@@ -79,7 +79,7 @@ describe('ShelterReportPage', () => {
     expect(exportButton().hasAttribute('disabled')).toBe(true);
 
     await waitFor(() =>
-      expect(screen.getByText('Test Organization')).toBeTruthy()
+      expect(screen.getByText('Test Organization')).toBeTruthy(),
     );
 
     expect(exportButton().hasAttribute('disabled')).toBe(false);
@@ -89,7 +89,7 @@ describe('ShelterReportPage', () => {
     renderPage([{ request, result: { data: { operatorShelter: OVERVIEW } } }]);
 
     await waitFor(() =>
-      expect(screen.getByRole('heading', { name: 'Bed Summary' })).toBeTruthy()
+      expect(screen.getByRole('heading', { name: 'Bed Summary' })).toBeTruthy(),
     );
 
     expect(screen.getByRole('heading', { name: 'Room Summary' })).toBeTruthy();
@@ -100,7 +100,9 @@ describe('ShelterReportPage', () => {
     renderPage([{ request, error: new Error('network down') }]);
 
     await waitFor(() =>
-      expect(screen.getByText('Failed to load the shelter report.')).toBeTruthy()
+      expect(
+        screen.getByText('Failed to load the shelter report.'),
+      ).toBeTruthy(),
     );
 
     expect(exportButton().hasAttribute('disabled')).toBe(true);
@@ -112,8 +114,8 @@ describe('ShelterReportPage', () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText('No shelter data available for this report.')
-      ).toBeTruthy()
+        screen.getByText('No shelter data available for this report.'),
+      ).toBeTruthy(),
     );
 
     expect(exportButton().hasAttribute('disabled')).toBe(true);

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPage.tsx
@@ -13,13 +13,16 @@ export function ShelterReportPage() {
   const targetRef = useRef<HTMLDivElement>(null);
   const { exportPdf, isExporting } = useExportPdf(
     targetRef,
-    `shelter-report-${shelterId ?? 'unknown'}.pdf`
+    `shelter-report-${shelterId ?? 'unknown'}.pdf`,
   );
 
-  const { data, loading, error } = useQuery(GetShelterOperatorOverviewDocument, {
-    variables: { shelterId: shelterId ?? '' },
-    skip: !shelterId,
-  });
+  const { data, loading, error } = useQuery(
+    GetShelterOperatorOverviewDocument,
+    {
+      variables: { shelterId: shelterId ?? '' },
+      skip: !shelterId,
+    },
+  );
 
   const report = data?.operatorShelter;
 

--- a/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.test.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/report/ShelterReportPrint.test.tsx
@@ -4,7 +4,7 @@ import { ShelterReportPrint } from './ShelterReportPrint';
 import type { ShelterReportData } from './types';
 
 function makeReport(
-  overrides: Partial<ShelterReportData> = {}
+  overrides: Partial<ShelterReportData> = {},
 ): ShelterReportData {
   return {
     id: '1',
@@ -48,7 +48,9 @@ describe('ShelterReportPrint', () => {
     render(<ShelterReportPrint data={makeReport()} />);
 
     expect(
-      within(screen.getByRole('banner')).getByText('Downtown Emergency Shelter')
+      within(screen.getByRole('banner')).getByText(
+        'Downtown Emergency Shelter',
+      ),
     ).toBeTruthy();
   });
 

--- a/libs/react/shelter-operator/src/lib/pages/report/types.ts
+++ b/libs/react/shelter-operator/src/lib/pages/report/types.ts
@@ -5,4 +5,5 @@ import type { GetShelterOperatorOverviewQuery } from '../../components/overview/
  * returned by GetShelterOperatorOverview. Derived from codegen so the report
  * follows the query rather than drifting from it.
  */
-export type ShelterReportData = GetShelterOperatorOverviewQuery['operatorShelter'];
+export type ShelterReportData =
+  GetShelterOperatorOverviewQuery['operatorShelter'];

--- a/libs/react/shelter-operator/src/lib/pages/report/useExportPdf.test.ts
+++ b/libs/react/shelter-operator/src/lib/pages/report/useExportPdf.test.ts
@@ -104,7 +104,7 @@ describe('useExportPdf', () => {
     mocks.html2canvas.mockReturnValue(
       new Promise((resolve) => {
         release = resolve;
-      })
+      }),
     );
 
     const { result } = renderExport();
@@ -132,7 +132,7 @@ describe('useExportPdf', () => {
 
     await act(async () => {
       await expect(result.current.exportPdf()).rejects.toThrow(
-        'canvas exploded'
+        'canvas exploded',
       );
     });
 
@@ -157,7 +157,7 @@ describe('useExportPdf', () => {
         MARGIN,
         MARGIN,
         USABLE_WIDTH,
-        (1842 * USABLE_WIDTH) / 1600
+        (1842 * USABLE_WIDTH) / 1600,
       );
     });
 
@@ -184,7 +184,7 @@ describe('useExportPdf', () => {
           MARGIN,
           MARGIN - page * USABLE_HEIGHT,
           USABLE_WIDTH,
-          imgHeight
+          imgHeight,
         );
       }
     });

--- a/libs/react/shelter-operator/src/lib/pages/report/useExportPdf.ts
+++ b/libs/react/shelter-operator/src/lib/pages/report/useExportPdf.ts
@@ -6,7 +6,7 @@ import { RefObject, useCallback, useState } from 'react';
  */
 export function useExportPdf(
   targetRef: RefObject<HTMLElement | null>,
-  filename: string
+  filename: string,
 ) {
   const [isExporting, setIsExporting] = useState(false);
 
@@ -53,7 +53,7 @@ export function useExportPdf(
           margin,
           margin - page * usablePageHeight,
           usableWidth,
-          imgHeight
+          imgHeight,
         );
       }
 

--- a/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.test.tsx
+++ b/libs/react/shelter-operator/src/lib/pages/shelterManagement/ReportsPage.test.tsx
@@ -20,7 +20,9 @@ function LocationProbe() {
   const { pathname } = useLocation();
   const { shelterId } = useParams();
 
-  return <div data-testid="location">{`${pathname} (shelter ${shelterId})`}</div>;
+  return (
+    <div data-testid="location">{`${pathname} (shelter ${shelterId})`}</div>
+  );
 }
 
 function renderReportsTab(shelterId = '5') {
@@ -38,7 +40,7 @@ function renderReportsTab(shelterId = '5') {
           element={<LocationProbe />}
         />
       </Routes>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 }
 
@@ -47,7 +49,7 @@ describe('ReportsPage', () => {
     renderReportsTab('5');
 
     expect(screen.getByTestId('reports-view').textContent).toBe(
-      'reports for 5'
+      'reports for 5',
     );
   });
 
@@ -57,7 +59,7 @@ describe('ReportsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /printable report/i }));
 
     expect(screen.getByTestId('location').textContent).toBe(
-      '/operator/shelter/5/report (shelter 5)'
+      '/operator/shelter/5/report (shelter 5)',
     );
   });
 
@@ -67,7 +69,7 @@ describe('ReportsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: /printable report/i }));
 
     expect(screen.getByTestId('location').textContent).toBe(
-      '/operator/shelter/42/report (shelter 42)'
+      '/operator/shelter/42/report (shelter 42)',
     );
   });
 
@@ -77,6 +79,8 @@ describe('ReportsPage', () => {
     const button = screen.getByRole('button', { name: /printable report/i });
 
     expect(button.closest('a')).toBeNull();
-    expect(screen.queryByRole('link', { name: /printable report/i })).toBeNull();
+    expect(
+      screen.queryByRole('link', { name: /printable report/i }),
+    ).toBeNull();
   });
 });

--- a/libs/react/shelter/codegen.ts
+++ b/libs/react/shelter/codegen.ts
@@ -1,5 +1,8 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
-import { SCALAR_IMPORT_PLUGIN, SHARED_SCALAR_CONFIG } from '../../../tools/codegen/scalars';
+import {
+  SCALAR_IMPORT_PLUGIN,
+  SHARED_SCALAR_CONFIG,
+} from '../../../tools/codegen/scalars';
 
 const config: CodegenConfig = {
   overwrite: true,

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "shelter": "nx serve shelter-web --port 8083",
     "fires": "nx serve wildfires --port 8200",
     "admin": "nx serve betterangels-admin --port 8084",
-    "pretty": "prettier --check .",
-    "pretty:fix": "prettier --write ."
+    "pretty": "nx format:check --verbose",
+    "pretty:fix": "nx format:write",
+    "pretty:all": "nx format:check --all --verbose",
+    "pretty:all:fix": "nx format:write --all"
   },
   "dependencies": {
     "@ant-design/charts": "^2.6.7",


### PR DESCRIPTION
### add prettier formatting to ynx-precommit
DEV-2528

- update commands for `prettier`
- update files in repo
  - this will keep happening, so we need to figure out a good way to enforce it

## Summary by Sourcery

Integrate Nx-based Prettier checks and fixes into the development and pre-commit workflows.

Enhancements:
- Update Prettier commands to use Nx formatting targets and add separate affected-project and all-project check and fix commands.
- Include Prettier validation in the standard pre-commit workflow.