### PR TITLE
fix(accounts)!: organization creation stops joining an existing organization

### DIFF
--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -240,7 +240,11 @@ def create_organization_with_presets(
     :class:`~accounts.role_manager.OrgRoleManager`.  The caller decides which
     roles the owner gets — no implicit derivation from org type order.
 
-    Returns the new :class:`~organizations.models.Organization`.
+    Returns the new :class:`~organizations.models.Organization` — always a new
+    row, never an existing one matched on *name*.  Organization names are not
+    unique, and resolving one by name let any caller of the public
+    ``createOrganization`` mutation land on an organization someone else runs.
+    Joining an existing organization goes through an invitation.
     """
     org_types: list[str] = []
     for preset_name in preset_names:
@@ -250,21 +254,18 @@ def create_organization_with_presets(
         if org_config.name not in org_types:
             org_types.append(org_config.name)
 
-    org, _ = Organization.objects.get_or_create(name=name)
+    org = Organization.objects.create(name=name)
 
-    # Profile with org types — update_or_create to fill in on existing orgs too.
-    OrganizationProfile.objects.update_or_create(
+    OrganizationProfile.objects.create(
         organization=org,
-        defaults={"org_types": [OrgTypeChoices(org_type) for org_type in org_types]},
+        org_types=[OrgTypeChoices(org_type) for org_type in org_types],
     )
 
     # Create PermissionGroup per template for this org.
     reconcile_org_groups(org)
 
     # Link the owner (django-organizations auto-creates OrganizationOwner).
-    # Guarded so the function is safe to call repeatedly (idempotent).
-    if not org.users.filter(pk=owner.pk).exists():
-        org.add_user(owner)
+    org.add_user(owner)
 
     if owner_roles:
         OrgRoleManager(org).add_roles(owner, *owner_roles)

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -34,6 +34,8 @@ def delete_orphaned_group(sender: object, instance: PermissionGroup, **kwargs: o
 # ── Local dev data setup ──────────────────────────────────────────────
 # Connected via AppConfig.ready() with sender=self — fires once, not per-app.
 
+TEST_ORG_NAME = "test_org"
+
 
 def setup_local_dev_data(sender: object, **kwargs: object) -> None:
     """Create test users and org — local dev only.
@@ -95,18 +97,16 @@ def _ensure_test_org() -> None:
     """
     from accounts.services import create_organization_with_presets
 
-    admin = User.objects.get(username="admin")
-
     # The idempotency this seeding relies on lives here, not in the service:
     # create_organization_with_presets always creates, so that naming an existing
     # organization cannot join it.
-    if Organization.objects.filter(name="test_org").exists():
+    if Organization.objects.filter(name=TEST_ORG_NAME).exists():
         return
 
     create_organization_with_presets(
-        name="test_org",
+        name=TEST_ORG_NAME,
         preset_names=["shelter", "outreach"],
-        owner=admin,
+        owner=User.objects.get(username="admin"),
         owner_roles=(),  # roles assigned by sync_all_org_permission_groups
     )
 
@@ -144,7 +144,7 @@ def sync_all_org_permission_groups(sender: object, **kwargs: object) -> None:
     try:
         from accounts.groups import ORG_ADMIN
 
-        test_org = Organization.objects.get(name="test_org")
+        test_org = Organization.objects.get(name=TEST_ORG_NAME)
         admin = User.objects.get(username="admin")
         agent = User.objects.get(username="agent")
 

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -97,6 +97,12 @@ def _ensure_test_org() -> None:
 
     admin = User.objects.get(username="admin")
 
+    # The idempotency this seeding relies on lives here, not in the service:
+    # create_organization_with_presets always creates, so that naming an existing
+    # organization cannot join it.
+    if Organization.objects.filter(name="test_org").exists():
+        return
+
     create_organization_with_presets(
         name="test_org",
         preset_names=["shelter", "outreach"],

--- a/apps/betterangels-backend/accounts/tests/test_mutations.py
+++ b/apps/betterangels-backend/accounts/tests/test_mutations.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import ANY, patch
 
 from accounts.enums import OrgRoleEnum
@@ -556,3 +557,67 @@ class OrganizationMemberMutationTestCase(GraphQLBaseTestCase, ParametrizedTestCa
                 user=self.org_admin,
             ).exists()
         )
+
+
+@ignore_warnings(category=UserWarning)
+class CreateOrganizationMutationTests(GraphQLBaseTestCase):
+    """The mutation is gated on IsAuthenticated alone, so it is the attack surface.
+
+    Fixing the service alone would leave a future resolver free to reintroduce
+    resolving an organization by name; these pin the property where a caller
+    actually stands.
+    """
+
+    MUTATION = """
+        mutation CreateOrganization($data: CreateOrganizationInput!) {
+            createOrganization(data: $data) {
+                organization { id name }
+            }
+        }
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.incumbent = baker.make(User, email="incumbent@example.com")
+        self.organization = organization_recipe.make(
+            name="Acme Housing", owner=self.incumbent, owner_roles=(CASEWORKER,)
+        )
+        self.outsider = baker.make(User, email="outsider@example.com")
+
+    def _create(self, name: str) -> dict[str, Any]:
+        self.graphql_client.force_login(self.outsider)
+        response = self.execute_graphql(self.MUTATION, {"data": {"organizationName": name, "orgType": "shelter"}})
+        self.assertIsNone(response.get("errors"))
+        organization: dict[str, Any] = response["data"]["createOrganization"]["organization"]
+        return organization
+
+    def test_naming_an_existing_organization_creates_a_separate_one(self) -> None:
+        created = self._create("Acme Housing")
+
+        self.assertNotEqual(created["id"], str(self.organization.pk))
+        self.assertEqual(created["name"], "Acme Housing")
+
+    def test_naming_an_existing_organization_grants_no_membership_on_it(self) -> None:
+        self._create("Acme Housing")
+
+        self.assertFalse(OrganizationUser.objects.filter(user=self.outsider, organization=self.organization).exists())
+
+    def test_naming_an_existing_organization_grants_no_role_on_it(self) -> None:
+        self._create("Acme Housing")
+
+        held = set(
+            PermissionGroup.objects.filter(organization=self.organization, group__user=self.outsider).values_list(
+                "template__name", flat=True
+            )
+        )
+        self.assertSetEqual(held, set())
+
+    def test_naming_an_existing_organization_does_not_revoke_its_members_roles(self) -> None:
+        self._create("Acme Housing")
+
+        held = set(
+            PermissionGroup.objects.filter(organization=self.organization, group__user=self.incumbent).values_list(
+                "template__name", flat=True
+            )
+        )
+        self.assertIn(CASEWORKER.name, held)

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -7,6 +7,7 @@ from accounts.groups import ORG_ADMIN, ORG_SUPERUSER
 from accounts.models import OrganizationProfile, PermissionGroup, PermissionGroupTemplate, User
 from accounts.selectors import permission_group_for_user
 from accounts.services import (
+    create_organization_service,
     create_organization_with_presets,
     get_or_create_user_by_email,
     member_add,
@@ -590,3 +591,95 @@ def _role_names(org: Organization, member: User) -> set[str]:
     return set(
         PermissionGroup.objects.filter(organization=org, group__user=member).values_list("template__name", flat=True)
     )
+
+
+# ── create_organization_service: no implicit join ─────────────────────
+
+
+def _existing_org_with_caseworker() -> tuple[Organization, User]:
+    """An organization someone else already runs, with a member holding a role."""
+    incumbent = baker.make(User, email="incumbent@example.com")
+    org = create_organization_with_presets("Acme Housing", ["outreach"], owner=incumbent, owner_roles=(CASEWORKER,))
+    return org, incumbent
+
+
+@pytest.mark.django_db
+def test_creating_an_org_by_an_existing_name_does_not_join_it() -> None:
+    org, _ = _existing_org_with_caseworker()
+    outsider = baker.make(User, email="outsider@example.com")
+
+    _, created = create_organization_service(user=outsider, organization_name="Acme Housing", org_type_name="shelter")
+
+    assert created.pk != org.pk, "must not resolve onto the existing organization"
+    assert not OrganizationUser.objects.filter(user=outsider, organization=org).exists()
+
+
+@pytest.mark.django_db
+def test_creating_an_org_by_an_existing_name_leaves_its_org_types_alone() -> None:
+    org, _ = _existing_org_with_caseworker()
+    outsider = baker.make(User, email="outsider@example.com")
+
+    create_organization_service(user=outsider, organization_name="Acme Housing", org_type_name="shelter")
+
+    profile = OrganizationProfile.objects.get(organization=org)
+    assert [str(org_type) for org_type in profile.org_types] == ["outreach"]
+
+
+@pytest.mark.django_db
+def test_creating_an_org_by_an_existing_name_leaves_its_members_roles_alone() -> None:
+    org, incumbent = _existing_org_with_caseworker()
+    outsider = baker.make(User, email="outsider@example.com")
+
+    create_organization_service(user=outsider, organization_name="Acme Housing", org_type_name="shelter")
+
+    caseworker = Group.objects.get(permissiongroup__organization=org, permissiongroup__template__name=CASEWORKER.name)
+    assert caseworker in incumbent.groups.all()
+
+
+@pytest.mark.django_db
+def test_creating_an_org_by_an_existing_name_grants_no_role_on_it() -> None:
+    """The escalation itself: naming someone else's org must not make you its admin."""
+    org, _ = _existing_org_with_caseworker()
+    outsider = baker.make(User, email="outsider@example.com")
+
+    create_organization_service(user=outsider, organization_name="Acme Housing", org_type_name="shelter")
+
+    held = set(
+        PermissionGroup.objects.filter(organization=org, group__user=outsider).values_list("template__name", flat=True)
+    )
+    assert held == set(), f"outsider holds {held} on an organization they never joined"
+
+
+# ── duplicate organization names are supported ────────────────────────
+
+
+@pytest.mark.django_db
+def test_two_organizations_may_share_a_name() -> None:
+    """Pins a deliberate invariant, so nobody "fixes" this with a unique constraint.
+
+    Names are editable and two real organizations may genuinely share one, so
+    uniqueness must not be reintroduced — it is the assumption that made
+    resolving an organization by name look reasonable in the first place.
+    """
+    first = create_organization_with_presets("Shared Name", ["outreach"], owner=baker.make(User))
+    second = create_organization_with_presets("Shared Name", ["outreach"], owner=baker.make(User))
+
+    assert first.pk != second.pk
+    assert first.slug != second.slug, "slug is unique and must absorb the collision"
+
+
+@pytest.mark.django_db
+def test_same_named_organizations_keep_separate_members_and_roles() -> None:
+    first_owner = baker.make(User, email="first@example.com")
+    second_owner = baker.make(User, email="second@example.com")
+    first = create_organization_with_presets("Shared Name", ["outreach"], owner=first_owner, owner_roles=(CASEWORKER,))
+    second = create_organization_with_presets(
+        "Shared Name", ["outreach"], owner=second_owner, owner_roles=(CASEWORKER,)
+    )
+
+    assert not OrganizationUser.objects.filter(user=first_owner, organization=second).exists()
+    assert not PermissionGroup.objects.filter(organization=second, group__user=first_owner).exists()
+
+    first_group = PermissionGroup.objects.get(organization=first, template__name=CASEWORKER.name)
+    second_group = PermissionGroup.objects.get(organization=second, template__name=CASEWORKER.name)
+    assert first_group.group.name != second_group.group.name, "the pk segment must disambiguate"

--- a/apps/betterangels-backend/shelters/tests/test_shelter_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_shelter_queries.py
@@ -406,6 +406,23 @@ class PublicShelterQueryTestCase(ShelterGraphQLFixtureMixin, GraphQLBaseTestCase
         self.assertIsNone(response.get("errors"))
         self.assertEqual(response["data"]["shelter"]["id"], str(self.shelter.pk))
 
+    def test_an_anonymous_caller_can_read_the_organization_name(self) -> None:
+        """Organization names are public for any org owning an approved shelter.
+
+        Load-bearing rather than incidental: it is what makes the exact-name
+        lookups on Organization reachable by an outsider, so anything that starts
+        keying behaviour on a name being secret is wrong. Kept as a test so the
+        assumption is checked rather than remembered.
+        """
+        organization = organization_recipe.make(name="Publicly Named Org")
+        self.shelter.organization = organization
+        self.shelter.save()
+
+        response = self.execute_graphql("{ shelters { results { organization { name } } } }")
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["shelters"]["results"], [{"organization": {"name": "Publicly Named Org"}}])
+
 
 class ShelterMaxStayQueryTestCase(ShelterGraphQLFixtureMixin, GraphQLBaseTestCase):
     def test_shelter_max_stay_query(self) -> None:


### PR DESCRIPTION
## The bug

`create_organization_with_presets` opened with:

```python
org, _ = Organization.objects.get_or_create(name=name)
```

Naming an organization that already existed returned **that** organization, and the function carried on as though it had just created it:

1. `OrganizationProfile.update_or_create(defaults={"org_types": […]})` — overwrites the target's org types with the caller's choice
2. `reconcile_org_groups(org)` — deletes the `PermissionGroup` rows for any type just dropped, **revoking that role from every existing member**
3. `org.add_user(caller)` — adds the caller as a member
4. `add_roles(caller, member_template, ORG_ADMIN)` — `add_roles` doesn't check `is_invitable`, so the caller gets **Organization Admin** (`ADD_ORG_MEMBER`, `REMOVE_ORG_MEMBER`, `VIEW_ORG_MEMBERS`)

## Reachability

Each link verified rather than assumed:

- **`createOrganization` is gated on `IsAuthenticated` alone** — `accounts/schema.py:280`.
- **Anyone can obtain an account.** `AccountAdapter.is_open_for_signup` returns `True` unconditionally, the headless allauth URLs are mounted at `_allauth/{browser,app}/v1/`, and `AutoCreateRequestLoginCodeView` provisions a brand-new user for any unknown email requesting a login code — its own docstring calls this "self-signup". An attacker needs only an email address they control.
- **Organization names are readable anonymously.** Proven by a new test in `shelters/tests/test_shelter_queries.py`, not argued: an unauthenticated `shelters { results { organization { name } } }` returns names.
- **The match is exact**, so a name read from the public API is directly usable.

**Caveat, stated rather than buried:** the public query only exposes organizations that own an **approved, non-private** shelter, so enumeration reaches a subset — though that subset is the shelter-operator organizations, which are the interesting targets. And an attacker who learns a name any other way (a website, a partner list) needs no enumeration at all.

Net effect: **any registered user could become Organization Admin of an organization they have nothing to do with, and strip its members' roles on the way in.** Cross-tenant privilege escalation plus a denial of service against the target.

## Reproduced before fixing

The tests were written first. Against `main`:

```
assert 6 != 6                        # the "new" org IS the incumbent's row
assert ['shelter'] == ['outreach']   # its org types were overwritten
Group.DoesNotExist                   # its Caseworker group was deleted outright
outsider holds {'Shelter Operator', 'Organization Admin'}
```

Worse than first described: the permission group is *deleted*, not merely unassigned.

## The fix is a deletion

The docstring already promised *"Returns the **new** Organization"* — the implementation had drifted from its own contract. Three things existed only to cope with being handed an existing organization:

| Before | After |
|---|---|
| `Organization.objects.get_or_create(name=name)` | `Organization.objects.create(name=name)` |
| `OrganizationProfile.objects.update_or_create(…, defaults={…})` — commented *"to fill in on existing orgs too"* | `OrganizationProfile.objects.create(…)` |
| `if not org.users.filter(pk=owner.pk).exists(): org.add_user(owner)` | `org.add_user(owner)` |

`reconcile_org_groups` stays; a new organization still needs its groups.

`setup_local_dev_data` seeds `test_org` on every `post_migrate` and does need idempotency — its own docstring opens *"Idempotent: ensure test_org exists"*. It takes an existence check at its own call site, ahead of the `admin` lookup so the early return costs one query, with the name pulled into `TEST_ORG_NAME` so the guard and the sync-side lookup can't drift.

## Duplicate names stay legal — deliberately

Names are editable, two real organizations may genuinely share one, and display ambiguity is acceptable. The codebase already assumed this: `PermissionGroup.group_name()` states that *"`Organization.name` is not [unique]"* and disambiguates with the pk, while `Organization.slug` is unique and auto-suffixes.

Joining an existing organization should only ever happen through an invitation. That is the fix — not name uniqueness, which is the assumption that made resolving-by-name look reasonable in the first place.

## Breaking change

`createOrganization` with an existing organization's name now creates a second organization instead of returning the existing one. Any client relying on the old get-or-create behaviour to "find or make" an organization gets a new row. Nothing in this repo does.

## Tests

Eleven, deliberately at more than one level — a service-only fix would leave a future resolver free to reintroduce the pattern, and the mutation is where a caller actually stands.

**Service** (`test_services.py`): the created row is not the incumbent's; the caller gains no membership; the incumbent's `org_types` are unchanged; the incumbent keeps Caseworker; the caller holds no role on it.

**Mutation** (`test_mutations.py`): the same four properties through `createOrganization`.

**Invariant** (`test_services.py`): two same-named organizations coexist with distinct slugs and keep separate members, roles and `auth.Group` names — so this isn't later "fixed" with a unique constraint.

**Threat model** (`test_shelter_queries.py`): an anonymous caller reads `organization { name }`.

All mutation-tested. The ten behavioural ones fail when `get_or_create` is restored; the anonymous-read test fails when `shelters` is given `permission_classes=[IsAuthenticated]`. None are vacuous.

Full suite 1481 passed, 31 skipped. `ruff`, `ruff format --check`, `mypy` clean.

## Related

#2373 would have stopped the Shelter CSV importer minting an organization per spreadsheet spelling. It was closed unmerged by decision, so that *bulk* creation path is still open and `shelters/admin.py` still calls `get_or_create(name=…)`. This PR is independent of it and closes a different one: the *implicit join* through the public `createOrganization` mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
