### PR TITLE
fix(accounts): warn before a permission group delete revokes roles, and drop the inert Active switch (DEV-2552)

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -77,6 +77,40 @@ class PermissionGroupAdmin(admin.ModelAdmin):
     # group's members with it.
     fields = ("organization", "template", "name")
 
+    def get_deleted_objects(
+        self, objs: Any, request: HttpRequest
+    ) -> tuple[list[Any], dict[str, int], set[str], list[str]]:
+        """Name the ``auth.Group`` going with each row, and who loses the role.
+
+        Django cannot work this out on its own: the group is torn down by
+        :func:`accounts.signals.delete_orphaned_group` from ``post_delete`` rather
+        than by cascade, and the foreign key points the other way, so nothing
+        appears downstream of the row being deleted — least of all the people
+        about to lose their access.
+
+        Hooked here because it is what both the delete view and the
+        ``delete_selected`` action call, so one override covers a single delete
+        and a bulk one alike.
+        """
+        deletable, model_count, perms_needed, protected = super().get_deleted_objects(objs, request)
+
+        losses = []
+        for permission_group in objs:
+            holders = permission_group.group.user_set.count()
+            losses.append(
+                format_html(
+                    "Group: {} — revoked from {} member{}",
+                    permission_group.group.name,
+                    holders,
+                    "" if holders == 1 else "s",
+                )
+            )
+
+        if losses:
+            deletable = [*deletable, *losses]
+            model_count = {**model_count, "groups": len(losses)}
+        return deletable, model_count, perms_needed, protected
+
 
 @admin.register(PermissionGroupTemplate)
 class PermissionGroupTemplateAdmin(admin.ModelAdmin):

--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -290,7 +290,7 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
     inlines = [OrganizationProfileInline, OrganizationMemberInline, PermissionGroupInline]
     list_display = ("name",)
     search_fields = ("name",)
-    fields = ("name", "is_active", "slug")
+    fields = ("name", "slug")
     readonly_fields = ("slug",)
     change_form_template = "admin/organizations/organization/change_form.html"
     # django-organizations' models define get_absolute_url against its own generic

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -877,3 +877,53 @@ class OrganizationsGenericViewsNotRoutedTestCase(SimpleTestCase):
         ``ExtendedOrganizationInvitation.get_absolute_url`` reverses it.
         """
         self.assertEqual(reverse("invitations_register", kwargs={"user_id": 1, "token": "abc"}), "/invitations/1-abc/")
+
+
+class PermissionGroupDeleteWarningTestCase(TestCase):
+    """Deleting a permission group takes its auth.Group, and every member's role with it."""
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(
+            username="admin_pg_delete", email="admin_pg_delete@example.com", password="password"
+        )
+        self.client.force_login(self.superuser)
+        self.organization = organization_recipe.make(preset_names=["shelter"], owner_roles=())
+        for email in ("operator_one@example.com", "operator_two@example.com"):
+            member_add(
+                email=email,
+                first_name="",
+                last_name="",
+                middle_name=None,
+                organization=self.organization,
+                permission_templates=(SHELTER_OPERATOR,),
+            )
+        self.permission_group = PermissionGroup.objects.get(
+            organization=self.organization, template__name=SHELTER_OPERATOR.name
+        )
+
+    def test_the_delete_page_names_the_group_and_who_loses_it(self) -> None:
+        url = reverse("admin:accounts_permissiongroup_delete", args=[self.permission_group.pk])
+
+        response = self.client.get(url)
+
+        self.assertContains(response, self.permission_group.group.name)
+        self.assertContains(response, "revoked from 2 members")
+
+    def test_the_bulk_delete_page_names_them_too(self) -> None:
+        """``delete_selected`` is the likelier route, and goes through the same hook."""
+        response = self.client.post(
+            reverse("admin:accounts_permissiongroup_changelist"),
+            {"action": "delete_selected", "_selected_action": [str(self.permission_group.pk)]},
+        )
+
+        self.assertContains(response, self.permission_group.group.name)
+        self.assertContains(response, "revoked from 2 members")
+
+    def test_one_member_is_not_pluralised(self) -> None:
+        Group.objects.get(pk=self.permission_group.group_id).user_set.remove(
+            User.objects.get(email="operator_two@example.com")
+        )
+
+        response = self.client.get(reverse("admin:accounts_permissiongroup_delete", args=[self.permission_group.pk]))
+
+        self.assertContains(response, "revoked from 1 member<")

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -57,7 +57,6 @@ class OrganizationAdminTestCase(TestCase):
     def _add_payload(self, name: str, org_types: list[str]) -> dict:
         return {
             "name": name,
-            "is_active": "on",
             # Management form for the required profile inline.
             "profile-TOTAL_FORMS": "1",
             "profile-INITIAL_FORMS": "0",
@@ -81,7 +80,6 @@ class OrganizationAdminTestCase(TestCase):
         rows = list(PermissionGroup.objects.filter(organization=organization).order_by("pk"))
         payload = {
             "name": organization.name,
-            "is_active": "on",
             "profile-TOTAL_FORMS": "1",
             "profile-INITIAL_FORMS": "1",
             "profile-MIN_NUM_FORMS": "1",
@@ -126,6 +124,14 @@ class OrganizationAdminTestCase(TestCase):
             set(PermissionGroup.objects.filter(organization=organization).values_list("template__name", flat=True)),
             {t.name for t in (CASEWORKER,)} | {"Organization Admin", "Organization Superuser"},
         )
+
+    def test_the_form_does_not_offer_is_active(self) -> None:
+        """django-organizations' own field; nothing in this codebase filters on it."""
+        organization = organization_recipe.make(preset_names=["outreach"], owner_roles=())
+
+        response = self.client.get(reverse("admin:organizations_organization_change", args=[organization.pk]))
+
+        self.assertNotIn("is_active", response.context["adminform"].form.fields)
 
     def test_creating_an_organization_without_an_org_type_is_rejected(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
## What

Two things the organization admin promises and does not do. Both fall out of reviewing #2372; neither is caused by it.

## 1. A permission group delete says who loses the role

Deleting a `PermissionGroup` from its own admin page revokes that role from every member holding it, and the confirmation page never says so.

Django cannot work it out: `delete_orphaned_group` tears the `auth.Group` down from `post_delete` rather than by cascade, and the foreign key points from the row *to* the group — so nothing appears downstream of what is being deleted, least of all the people about to lose their access.

`get_deleted_objects` is the hook for exactly this. `ModelAdmin.delete_view` and the `delete_selected` action both call it, so one override covers a single delete and a bulk one alike, with no custom template. Each row now contributes a line naming its group and how many members lose the role.

This is the sibling of the confirmation #2372 adds on the organization page — and this is the page that fix sends you to when you actually want a row gone.

## 2. `is_active` comes off the organization form

The page has an **Active** checkbox. Unchecking it changes nothing: members keep signing in, keep their org-scoped permissions, and keep seeing everything.

`is_active` is django-organizations', and it ships an `ActiveOrgManager` that filters on it. This codebase never uses that manager — every query goes through the unfiltered default, `OrganizationType` exposes only `id` and `name`, and `OrganizationFilter` has no `is_active`. The column has never gated anything here.

Taking it off the form rather than wiring it up. What deactivation should mean is a real question with a real blast radius — header org resolution, the org-scoped permission checks, the shelter operator selectors, everyone in the org at once — and it is better answered when someone needs it than guessed at now. The column stays, so nothing is lost and nothing is migrated.

## Testing

- `1474 passed, 31 skipped` — full suite. `ruff check`, `ruff format --check` and `mypy` clean on 387 files with the cache cleared.
- Mutation-tested: removing the `get_deleted_objects` override fails all three of its tests, putting `is_active` back on the form fails its test, and always pluralising fails the one-member case.
- Both delete routes are covered, because `delete_selected` is the likelier one.

## Not included

`add_member_view`, `change_member_roles_view` and `transfer_ownership_view` reach `has_change_permission` through nothing but `admin_site.admin_view`, which only asks for `is_staff`. Every staff user in this codebase is a superuser today — the only `is_staff=True` grants are the local-dev admin and a seed command — so it is a gap rather than a live hole, and it belongs in its own PR covering all three.

## Note for whoever merges second

#2372 touches `accounts/tests/test_admin.py` as well, and its `_payload` helper still posts `is_active`. Harmless either way — an extra POST key for a field the form does not render — but worth dropping when the two meet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make permission-group deletion consequences explicit and remove the organization form control that does not affect application behavior.

Bug Fixes:
- Warn administrators which permission group and how many members will lose the role when deleting permission groups through either single or bulk deletion.
- Remove the non-functional Active field from the organization administration form.

Tests:
- Add coverage for single-delete and bulk-delete warnings, including correct singular wording and removal of the inactive organization field.