### PR TITLE
fix(accounts): stop the organization page editing a role every organization shares (DEV-2552)

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -5,12 +5,14 @@ from common.org_types import REGISTRY
 from common.permissions.config import TemplateConfig
 from django.contrib import admin, messages
 from django.contrib.admin import ModelAdmin
+from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User as DefaultUser
 from django.contrib.sites.models import Site
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db.models import Model, QuerySet
+from django.forms import Field as FormField
+from django.db.models import Field, Model, QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
@@ -117,12 +119,67 @@ class PermissionGroupTemplateAdmin(admin.ModelAdmin):
         "name",
     ]
 
+    def _is_code_owned(self, obj: PermissionGroupTemplate | None) -> bool:
+        return obj is not None and obj.name in REGISTRY.template_names()
+
+    def get_readonly_fields(self, request: HttpRequest, obj: Any = None) -> tuple[str, ...]:
+        """A role the code names is read here, not written.
+
+        ``sync_group_permissions`` re-applies its ``TemplateConfig`` on every
+        ``migrate`` and every org reconcile, so editing one of these is undone
+        without saying so.  A role created in the admin is the opposite -- its
+        ``permissions`` are the definition -- and stays editable.
+        """
+        if self._is_code_owned(obj):
+            return ("name", "permissions")
+
+        return tuple(super().get_readonly_fields(request, obj))
+
+    def has_delete_permission(self, request: HttpRequest, obj: Any = None) -> bool:
+        """Deleting a code-owned role succeeds quietly and breaks reconciliation.
+
+        ``template`` is ``SET_NULL``, so every organization's row survives the
+        delete holding its label, its members and no template -- indistinguishable
+        from a hand-managed row, so reconciliation stops treating it as derived.
+        ``post_migrate`` then re-seeds the template, and the next reconcile's
+        ``get_or_create`` for that role collides with the orphan's group name:
+        ``duplicate key value violates unique constraint "auth_group_name_key"``.
+        The same failure ``PermissionGroupInlineForm`` refuses a repointed
+        template for, reached by a different route.
+        """
+        if self._is_code_owned(obj):
+            return False
+
+        return super().has_delete_permission(request, obj)
+
 
 class PermissionGroupInline(admin.TabularInline):
     model = PermissionGroup
     form = PermissionGroupInlineForm
     extra = 1
     fields = ("template", "label")
+
+    def formfield_for_dbfield(self, db_field: Field, request: HttpRequest, **kwargs: Any) -> FormField | None:
+        """Keep the organization page out of the global template admin.
+
+        Django wraps a related field in ``RelatedFieldWidgetWrapper``, whose add,
+        change and delete links open ``PermissionGroupTemplate`` -- one row shared
+        by every organization holding the role.  On this page they read as editing
+        *this* organization's row.  The view link stays: what a role grants is
+        worth being able to look at.
+        """
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+
+        if (
+            formfield is not None
+            and db_field.name == "template"
+            and isinstance(formfield.widget, RelatedFieldWidgetWrapper)
+        ):
+            formfield.widget.can_add_related = False
+            formfield.widget.can_change_related = False
+            formfield.widget.can_delete_related = False
+
+        return formfield
 
 
 class OrganizationMemberInline(admin.TabularInline[OrganizationUser, Organization]):

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -15,11 +15,12 @@ from accounts.models import (
     PermissionGroupTemplate,
     User,
 )
+from accounts.seed import seed_permission_templates
 from accounts.services import invitation_role, member_add, reconcile_org_groups
 from django.contrib import admin
 from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import connection
+from django.db import IntegrityError, connection, transaction
 from django.test import SimpleTestCase, TestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import NoReverseMatch, reverse
@@ -933,3 +934,94 @@ class PermissionGroupDeleteWarningTestCase(TestCase):
         response = self.client.get(reverse("admin:accounts_permissiongroup_delete", args=[self.permission_group.pk]))
 
         self.assertContains(response, "revoked from 1 member<")
+
+
+class PermissionGroupTemplateAdminTestCase(TestCase):
+    """A template is one row shared by every organization holding the role.
+
+    Two ways the admin implied otherwise: the organization page linked into the
+    template admin from a row that reads as belonging to that organization, and
+    the template admin let a role the code owns be edited or deleted, which
+    ``sync_group_permissions`` undoes on the next reconcile.
+    """
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(
+            username="template_admin_tests", email="template_admin_tests@example.com", password="password"
+        )
+        self.client.force_login(self.superuser)
+        self.organization = organization_recipe.make(preset_names=["outreach"], owner_roles=())
+        self.code_owned = PermissionGroupTemplate.objects.get(name=ORG_ADMIN.name)
+        self.hand_defined = PermissionGroupTemplate.objects.create(name="Weekend Volunteers")
+
+    def test_the_organization_page_does_not_link_into_the_template_admin(self) -> None:
+        response = self.client.get(
+            reverse("admin:organizations_organization_change", args=[self.organization.pk]),
+        )
+
+        for action in ("add", "change", "delete"):
+            self.assertNotContains(response, f"{action}_id_permission_groups-0-template")
+            self.assertNotContains(response, f"{action}_id_permission_groups-__prefix__-template")
+
+    def test_the_organization_page_still_lets_the_template_be_viewed(self) -> None:
+        """Read-only, not hidden -- what a role grants is worth being able to see."""
+        response = self.client.get(
+            reverse("admin:organizations_organization_change", args=[self.organization.pk]),
+        )
+
+        self.assertContains(response, "view_id_permission_groups-0-template")
+
+    def test_a_role_the_code_owns_is_read_only(self) -> None:
+        response = self.client.get(
+            reverse("admin:accounts_permissiongrouptemplate_change", args=[self.code_owned.pk]),
+        )
+
+        self.assertNotContains(response, 'name="name"')
+        self.assertNotContains(response, 'name="permissions"')
+
+    def test_a_role_defined_in_the_admin_stays_editable(self) -> None:
+        response = self.client.get(
+            reverse("admin:accounts_permissiongrouptemplate_change", args=[self.hand_defined.pk]),
+        )
+
+        self.assertContains(response, 'name="name"')
+        self.assertContains(response, 'name="permissions"')
+
+    def test_a_role_the_code_owns_cannot_be_deleted(self) -> None:
+        response = self.client.post(
+            reverse("admin:accounts_permissiongrouptemplate_delete", args=[self.code_owned.pk]),
+            {"post": "yes"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(PermissionGroupTemplate.objects.filter(pk=self.code_owned.pk).exists())
+
+    def test_a_role_defined_in_the_admin_can_be_deleted(self) -> None:
+        response = self.client.post(
+            reverse("admin:accounts_permissiongrouptemplate_delete", args=[self.hand_defined.pk]),
+            {"post": "yes"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(PermissionGroupTemplate.objects.filter(pk=self.hand_defined.pk).exists())
+
+    def test_deleting_a_code_owned_role_breaks_the_next_reconcile(self) -> None:
+        """Why the guard is a refusal rather than a warning.
+
+        The delete itself succeeds quietly -- ``SET_NULL`` leaves each row with
+        its label and members and no template, so reconciliation stops seeing it
+        as derived.  ``post_migrate`` re-seeds the template, and the next
+        reconcile collides with the orphan on ``auth_group.name``.  Reached here
+        by deleting directly, which is what the admin guard now prevents.
+        """
+        row = PermissionGroup.objects.get(organization=self.organization, template=self.code_owned)
+
+        self.code_owned.delete()
+
+        row.refresh_from_db()
+        self.assertIsNone(row.template_id)
+        self.assertEqual(row.label, ORG_ADMIN.name)
+
+        seed_permission_templates()
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            reconcile_org_groups(self.organization)


### PR DESCRIPTION
> Stacked on #2378 — it rewrites this exact admin block (`name` → `label`, the `group` column), so this sits on top rather than underneath. Base changes to `main` as the stack lands.

Closes Mike's review comment on #2377.

## What he spotted

> "we should probably make these read-only. This is in the org admin form and looks like it's touching a permission group, but it's actually touching a template"

He is right, and the organization page is only half of it.

`PermissionGroupTemplate` is **one row shared by every organization holding the role**. Django wraps the inline's `template` field in `RelatedFieldWidgetWrapper`, so the organization page renders add / change / delete links straight into `/admin/accounts/permissiongrouptemplate/…` — from a row that reads as belonging to *this* organization. Verified rather than assumed:

```
can_add_related: True   can_change_related: True   can_delete_related: True
link: <a class="related-widget-wrapper-link change-related" id="change_id_template" …
```

`PermissionGroupInlineForm` already disables the *select* for an existing row, but `disabled` does not touch those links.

And what they open is either inert or global, per `seed.py`'s `sync_group_permissions`:

| Template | Editing its permissions in the admin |
| --- | --- |
| named in `REGISTRY` (Organization Admin, Caseworker, Global Shelter Operator, …) | **inert** — `template.permissions.set(wanted)` re-applies the code's `TemplateConfig` on the next `migrate` or reconcile |
| created in the admin | **global** — it is the definition, and it reaches every organization holding the role |

So the first case is the same defect #2377 removed from the organization form, and the second looks org-scoped and is not.

## What this does

1. **The organization page no longer links into the template admin.** `can_add_related`, `can_change_related`, `can_delete_related` off for `template`. `can_view_related` stays — what a role grants is worth being able to look at.
2. **A code-owned role is read-only in the template admin** (`name` and `permissions`), because code owns it. A hand-defined role stays fully editable, since `sync_group_permissions` *reads* those.
3. **A code-owned role cannot be deleted.**

## Why (3) is a refusal and not a warning

The delete used to succeed **quietly**, and the damage lands later. `template` is `SET_NULL`, so every organization's row survives holding its label, its members and no template — indistinguishable from a hand-managed row, which reconciliation deliberately leaves alone. `post_migrate` then re-seeds the template, and the next reconcile's `get_or_create` for that role hits the orphan's group name:

```
IntegrityError: duplicate key value violates unique constraint "auth_group_name_key"
```

One admin delete poisons reconciliation for that organization — the same failure `PermissionGroupInlineForm` already refuses a repointed template for, reached by a different route. `test_deleting_a_code_owned_role_breaks_the_next_reconcile` pins the whole chain by deleting directly, which is what the guard now prevents.

I had this wrong first time round: I expected the `permission_group_has_template_or_label` constraint to reject the delete outright. It does not, because derived rows carry a label. The test says what actually happens.

## Testing

- `1481 passed, 31 skipped` — full suite on a freshly created database. 7 new tests; `accounts` alone is 197.
- `ruff check` and `ruff format --check` clean.

Mutation-tested, each guard independently:

| Mutation | Fails |
| --- | --- |
| leave the wrapper's add/change/delete links on | the organization-page test |
| `get_readonly_fields` returns `()` | the code-owned read-only test |
| `has_delete_permission` defers to `super()` | the code-owned delete test |
| apply read-only to *every* template, not just code-owned | the hand-defined-stays-editable test |

## One thing for the reviewer of #2378

Running its own typecheck command locally on `355bc3d0` with the mypy cache cleared — `uv run mypy --config-file=../../mypy.ini .`, django-stubs 5.2.9 as pinned in `uv.lock` — reports **26 errors**, all `Cannot resolve keyword 'user' into field` on `PermissionGroup.objects.filter(…, user=…)`, which #2378 introduces. CI's run of the identical command on the same commit is **green in 17.4s**. My own five errors in this branch were real and are fixed; these 26 are not mine and I could not reconcile the two runs. Worth someone re-running that target with the nx cache skipped before trusting either — it is the same MTI/django-stubs family the PR body already describes wrestling with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent organization and template administration from modifying code-owned permission roles or exposing shared template actions as organization-scoped operations.

Bug Fixes:
- Prevent organization administration from exposing actions that can modify shared permission-group templates.
- Protect code-owned permission roles from edits and deletion that would be overwritten or break organization reconciliation.

Enhancements:
- Keep code-owned role definitions read-only while preserving full editability for administrator-defined roles.
- Retain view-only access to shared templates from the organization page.

Tests:
- Add admin coverage for shared-template links, role editability, deletion permissions, and reconciliation failure after an unguarded code-owned deletion.