### PR TITLE
fix(accounts): say why an owner cannot be deleted, and stop the API deleting one

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -5,6 +5,7 @@ from common.org_types import REGISTRY
 from common.permissions.config import TemplateConfig
 from django.contrib import admin, messages
 from django.contrib.admin import ModelAdmin
+from django.contrib.admin.utils import unquote
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User as DefaultUser
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -263,10 +264,100 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
     # raises NoReverseMatch. Offering "View on site" would error.
     view_on_site = False
 
+    ORG_TYPE_REMOVAL_CONFIRMED = "_confirm_org_type_removal"
+
     def save_related(self, request: HttpRequest, form: Any, formsets: Any, change: bool) -> None:
         """Reconcile permission groups once the profile's org types are saved."""
         super().save_related(request, form, formsets, change)
         reconcile_org_groups(form.instance)
+
+    def change_view(
+        self,
+        request: HttpRequest,
+        object_id: str,
+        form_url: str = "",
+        extra_context: dict[str, Any] | None = None,
+    ) -> HttpResponse:
+        """Confirm before a save takes a role away from people who hold it.
+
+        Unchecking an org type deletes its permission groups on reconcile, and
+        ``delete_orphaned_group`` takes the ``auth.Group`` with them — so every
+        member silently loses that role.  It is the one edit on this page whose
+        blast radius is invisible from the form.
+
+        Interposed here rather than in the form because the form cannot re-render
+        the whole change view, and because a ``clean()`` error would be the wrong
+        shape: this is a confirmation, not a rejection.
+        """
+        if request.method == "POST" and self.ORG_TYPE_REMOVAL_CONFIRMED not in request.POST:
+            organization = self.get_object(request, unquote(object_id))
+            if organization is not None and (
+                losses := self._roles_lost_to_org_type_removal(organization, request.POST)
+            ):
+                return self._confirm_org_type_removal_response(request, organization, losses)
+        return super().change_view(request, object_id, form_url, extra_context)
+
+    def _confirm_org_type_removal_response(
+        self, request: HttpRequest, organization: Organization, losses: list[tuple[str, int]]
+    ) -> HttpResponse:
+        """Re-offer the submitted save, spelling out what it revokes."""
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "organization": organization,
+            "losses": losses,
+            "posted": [(key, value) for key in request.POST for value in request.POST.getlist(key)],
+            "confirm_field": self.ORG_TYPE_REMOVAL_CONFIRMED,
+            "title": f"Remove org types from {organization.name}?",
+            "cancel_url": reverse("admin:organizations_organization_change", args=[organization.pk]),
+        }
+        return TemplateResponse(request, "admin/organizations/organization/confirm_org_types.html", context)
+
+    @staticmethod
+    def _roles_lost_to_org_type_removal(organization: Organization, posted: Any) -> list[tuple[str, int]]:
+        """Roles that reconciling *posted* would revoke, with how many hold each.
+
+        Empty when nothing is lost — a type nobody holds, or none removed at all.
+        A prompt that always fires stops being read.
+        """
+        profile_prefix = next(
+            (key.rsplit("-", 1)[0] for key in posted if key.endswith("-org_types")),
+            None,
+        )
+        if profile_prefix is None:
+            return []
+
+        submitted = set(posted.getlist(f"{profile_prefix}-org_types"))
+        current = (
+            {org_type.value for org_type in organization.profile.org_types}
+            if hasattr(organization, "profile")
+            else set()
+        )
+        removed = current - submitted
+        if not removed:
+            return []
+
+        kept_templates = {
+            template.name
+            for org_type in submitted
+            if (config := REGISTRY.org_type(org_type)) is not None
+            for template in config.templates
+        }
+        losing = {
+            template.name
+            for org_type in removed
+            if (config := REGISTRY.org_type(org_type)) is not None
+            for template in config.templates
+        } - kept_templates
+
+        losses = []
+        for permission_group in PermissionGroup.objects.filter(
+            organization=organization, template__name__in=sorted(losing)
+        ).select_related("group", "template"):
+            holders = permission_group.group.user_set.count()
+            if holders:
+                losses.append((permission_group.name, holders))
+        return sorted(losses)
 
     def get_urls(self) -> list[URLPattern]:
         custom_urls = [

--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -264,7 +264,7 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
     # raises NoReverseMatch. Offering "View on site" would error.
     view_on_site = False
 
-    ORG_TYPE_REMOVAL_CONFIRMED = "_confirm_org_type_removal"
+    ROLE_LOSS_CONFIRMED = "_confirm_role_loss"
 
     def save_related(self, request: HttpRequest, form: Any, formsets: Any, change: bool) -> None:
         """Reconcile permission groups once the profile's org types are saved."""
@@ -278,26 +278,30 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
         form_url: str = "",
         extra_context: dict[str, Any] | None = None,
     ) -> HttpResponse:
-        """Confirm before a save takes a role away from people who hold it.
+        """Confirm before a save takes a role away from the people holding it.
 
-        Unchecking an org type deletes its permission groups on reconcile, and
-        ``delete_orphaned_group`` takes the ``auth.Group`` with them — so every
-        member silently loses that role.  It is the one edit on this page whose
-        blast radius is invisible from the form.
+        Two edits on this page do that, and neither shows it: unchecking an org
+        type, and ticking Delete on a permission group row.  Both end with
+        ``delete_orphaned_group`` tearing out the ``auth.Group``, and every member
+        holding that role loses it.
 
         Interposed here rather than in the form because the form cannot re-render
         the whole change view, and because a ``clean()`` error would be the wrong
-        shape: this is a confirmation, not a rejection.
+        shape: this is a confirmation, not a rejection.  Deferring to
+        ``has_change_permission`` keeps the prompt from answering a question
+        Django is about to refuse.
         """
-        if request.method == "POST" and self.ORG_TYPE_REMOVAL_CONFIRMED not in request.POST:
+        if request.method == "POST" and self.ROLE_LOSS_CONFIRMED not in request.POST:
             organization = self.get_object(request, unquote(object_id))
-            if organization is not None and (
-                losses := self._roles_lost_to_org_type_removal(organization, request.POST)
+            if (
+                organization is not None
+                and self.has_change_permission(request, organization)
+                and (losses := self._roles_lost_to_save(organization, request.POST))
             ):
-                return self._confirm_org_type_removal_response(request, organization, losses)
+                return self._confirm_role_loss_response(request, organization, losses)
         return super().change_view(request, object_id, form_url, extra_context)
 
-    def _confirm_org_type_removal_response(
+    def _confirm_role_loss_response(
         self, request: HttpRequest, organization: Organization, losses: list[tuple[str, int]]
     ) -> HttpResponse:
         """Re-offer the submitted save, spelling out what it revokes."""
@@ -307,19 +311,27 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
             "organization": organization,
             "losses": losses,
             "posted": [(key, value) for key in request.POST for value in request.POST.getlist(key)],
-            "confirm_field": self.ORG_TYPE_REMOVAL_CONFIRMED,
-            "title": f"Remove org types from {organization.name}?",
+            "confirm_field": self.ROLE_LOSS_CONFIRMED,
+            "title": f"Revoke roles in {organization.name}?",
             "cancel_url": reverse("admin:organizations_organization_change", args=[organization.pk]),
         }
-        return TemplateResponse(request, "admin/organizations/organization/confirm_org_types.html", context)
+        return TemplateResponse(request, "admin/organizations/organization/confirm_role_loss.html", context)
 
-    @staticmethod
-    def _roles_lost_to_org_type_removal(organization: Organization, posted: Any) -> list[tuple[str, int]]:
-        """Roles that reconciling *posted* would revoke, with how many hold each.
+    @classmethod
+    def _roles_lost_to_save(cls, organization: Organization, posted: Any) -> list[tuple[str, int]]:
+        """Every role *posted* would take from someone, with how many hold each.
 
-        Empty when nothing is lost — a type nobody holds, or none removed at all.
-        A prompt that always fires stops being read.
+        Empty when nothing is lost, which is most saves.  A prompt that always
+        fires stops being read.
         """
+        return sorted(
+            set(cls._roles_lost_to_org_type_removal(organization, posted))
+            | set(cls._roles_lost_to_row_deletion(organization, posted))
+        )
+
+    @classmethod
+    def _roles_lost_to_org_type_removal(cls, organization: Organization, posted: Any) -> list[tuple[str, int]]:
+        """Roles reconciliation will delete because the type granting them is dropped."""
         profile_prefix = next(
             (key.rsplit("-", 1)[0] for key in posted if key.endswith("-org_types")),
             None,
@@ -350,14 +362,37 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
             for template in config.templates
         } - kept_templates
 
-        losses = []
-        for permission_group in PermissionGroup.objects.filter(
-            organization=organization, template__name__in=sorted(losing)
-        ).select_related("group", "template"):
-            holders = permission_group.group.user_set.count()
-            if holders:
-                losses.append((permission_group.name, holders))
-        return sorted(losses)
+        return cls._held_by(
+            PermissionGroup.objects.filter(organization=organization, template__name__in=sorted(losing))
+        )
+
+    @classmethod
+    def _roles_lost_to_row_deletion(cls, organization: Organization, posted: Any) -> list[tuple[str, int]]:
+        """Roles whose row is ticked for deletion on the Permission groups inline.
+
+        The quieter of the two routes: reconciliation recreates a derived row on
+        the same save, with a fresh and empty ``auth.Group``, so the page comes
+        back looking untouched while everyone who held the role has lost it.
+        """
+        deleted_row_ids = [
+            posted.get(f"{key.rsplit('-', 1)[0]}-id")
+            for key in posted
+            if key.startswith("permission_groups-") and key.endswith("-DELETE") and posted.get(key)
+        ]
+        return cls._held_by(
+            PermissionGroup.objects.filter(
+                organization=organization, pk__in=[row_id for row_id in deleted_row_ids if row_id]
+            )
+        )
+
+    @staticmethod
+    def _held_by(permission_groups: QuerySet[PermissionGroup]) -> list[tuple[str, int]]:
+        """Name each group and how many hold it, dropping the ones nobody does."""
+        return [
+            (permission_group.name, holders)
+            for permission_group in permission_groups.select_related("group", "template")
+            if (holders := permission_group.group.user_set.count())
+        ]
 
     def get_urls(self) -> list[URLPattern]:
         custom_urls = [

--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, Type, cast
 
 from common.org_types import REGISTRY
@@ -26,7 +26,12 @@ from .forms import (
     UserChangeForm,
     UserCreationForm,
 )
-from .selectors import member_role_names, role_names_by_organization
+from .selectors import (
+    member_role_names,
+    organizations_owned_by,
+    owned_organizations,
+    role_names_by_organization,
+)
 from .models import (
     ExtendedOrganizationInvitation,
     OrganizationProfile,
@@ -50,6 +55,16 @@ def _change_roles_link(obj: OrganizationUser) -> str:
         args=[obj.organization_id, obj.user_id],
     )
     return format_html('<a href="{}" class="changelink">Change roles</a>', url)
+
+
+def _ownerless_blocker(organization: Organization) -> str:
+    """Why a delete is refused, beside the link that lifts the refusal."""
+    url = reverse("admin:organizations_organization_transfer_ownership", args=[organization.pk])
+    return format_html(
+        '“{}” would be left with no owner. <a href="{}">Transfer ownership</a> first.',
+        organization.name,
+        url,
+    )
 
 
 def _invited_message(email: str, organization: Organization, role_templates: tuple[TemplateConfig, ...]) -> str:
@@ -101,8 +116,8 @@ class OrganizationMemberInline(admin.TabularInline[OrganizationUser, Organizatio
 
     Read-only: adding goes through **Add member** so roles are always chosen, and
     removing stays on the Organization user page, where the owner guard lives.  An
-    inline could not gate deletion per row anyway — ``has_delete_permission``
-    receives the parent organization, not the member.
+    inline could not gate deletion per row anyway — it deletes through a formset,
+    which ``get_deleted_objects`` never sees.
     """
 
     model = OrganizationUser
@@ -612,26 +627,45 @@ class CustomOrganizationUserAdmin(MemberInviteAdminMixin, ModelAdmin[Organizatio
         )
         return TemplateResponse(request, "admin/organizations/organization/member_form.html", context)
 
-    def has_delete_permission(self, request: HttpRequest, obj: OrganizationUser | None = None) -> bool:
-        """Withhold deletion for the rows ``organization_remove_member`` refuses.
+    def get_deleted_objects(
+        self, objs: QuerySet[OrganizationUser] | Sequence[OrganizationUser], request: HttpRequest
+    ) -> tuple[list[Any], dict[str, int], set[str], list[Any]]:
+        """Refuse the rows ``organization_remove_member`` refuses, and say why.
 
         That service rejects removing the organization's owner and removing
         yourself.  Deletion is routed through it, so a row it would refuse has to
-        be unavailable here or the admin turns its ``ValidationError`` into a 500.
+        be stopped here or the admin turns its ``ValidationError`` into a 500.
 
         This is also what protects the owner at all on the bulk path:
         ``AbstractOrganizationUser.delete`` raises ``OwnershipRequired``, but only
-        from ``Model.delete()``, so the changelist's ``queryset.delete()`` was
-        previously unguarded.  ``get_deleted_objects`` consults this per selected
-        row and ``delete_selected`` refuses the whole batch if any row is
-        protected.
+        from ``Model.delete()``, so the changelist's ``queryset.delete()`` would
+        otherwise be unguarded.
+
+        Reported through ``protected`` rather than by withholding
+        ``has_delete_permission``, which is where the rule used to live: Django
+        turns a withheld permission into ``perms_needed``, which renders as "your
+        account doesn't have permission to delete the following types of objects:
+        organization user" — a superuser told they lack a permission, naming the
+        thing they are trying to delete rather than the organization that blocks
+        it.  ``protected`` refuses the POST just as firmly, on both the single and
+        the bulk path, and leaves the sentence ours to write.
         """
-        if obj is not None:
-            if obj.user_id == request.user.pk:
-                return False
-            if OrganizationOwner.objects.filter(organization_user=obj).exists():
-                return False
-        return super().has_delete_permission(request, obj)
+        to_delete, model_count, perms_needed, protected = super().get_deleted_objects(objs, request)
+        return to_delete, model_count, perms_needed, [*protected, *self._removal_blockers(objs, request)]
+
+    @staticmethod
+    def _removal_blockers(
+        memberships: QuerySet[OrganizationUser] | Sequence[OrganizationUser], request: HttpRequest
+    ) -> list[str]:
+        """What stops each of these memberships being removed."""
+        owned = owned_organizations(membership_ids=[membership.pk for membership in memberships])
+        blockers = []
+        for membership in memberships:
+            if organization := owned.get(membership.pk):
+                blockers.append(_ownerless_blocker(organization))
+            elif membership.user_id == request.user.pk:
+                blockers.append(format_html("You cannot remove yourself from “{}”.", membership.organization.name))
+        return blockers
 
     def delete_model(self, request: HttpRequest, obj: OrganizationUser) -> None:
         """Remove the membership through the service, so roles are revoked with it.
@@ -709,6 +743,33 @@ class UserAdmin(BaseUserAdmin):
     list_display = ["id", "full_name", "email"]
     list_filter = ["organizations_organization", "is_active", "is_staff", "is_superuser"]
     readonly_fields = ("organizations_and_roles",)
+
+    def get_deleted_objects(
+        self, objs: QuerySet[User] | Sequence[User], request: HttpRequest
+    ) -> tuple[list[Any], dict[str, int], set[str], list[Any]]:
+        """Refuse to delete an account that still owns an organization, and say why.
+
+        ``User`` cascades to ``OrganizationUser``, which cascades to
+        ``OrganizationOwner``, so deleting an owner silently leaves the
+        organization with nobody able to administer it.  The membership admin's
+        own guard does not cover this: ``get_deleted_objects`` consults each
+        collected object's ``ModelAdmin``, not its ``get_deleted_objects``, so the
+        rule has to be asked again from here.
+
+        Deleting the account you are signed in with is refused for its own sake.
+        It used to be refused only as a side effect of the membership guard —
+        which meant a superuser holding no membership could delete themselves,
+        and one holding a membership was told they lacked a permission.
+        """
+        to_delete, model_count, perms_needed, protected = super().get_deleted_objects(objs, request)
+
+        user_ids = [user.pk for user in objs]
+        owned = organizations_owned_by(user_ids=user_ids)
+        blockers = [_ownerless_blocker(organization) for user_id in user_ids for organization in owned.get(user_id, [])]
+        if request.user.pk in user_ids:
+            blockers.append("You cannot delete the account you are signed in with.")
+
+        return to_delete, model_count, perms_needed, [*protected, *blockers]
 
     @admin.display(description="Organizations and roles")
     def organizations_and_roles(self, obj: User) -> str:

--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -19,6 +19,7 @@ from organizations.models import Organization, OrganizationInvitation, Organizat
 from .forms import (
     OrganizationMemberInviteForm,
     OrganizationMemberRoleForm,
+    OrganizationOwnerTransferForm,
     PermissionGroupInlineForm,
     OrganizationProfileForm,
     UserChangeForm,
@@ -37,6 +38,7 @@ from .services import (
     member_invite,
     member_roles_replace,
     organization_remove_member,
+    organization_transfer_ownership,
     reconcile_org_groups,
 )
 
@@ -278,6 +280,11 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
                 self.admin_site.admin_view(self.change_member_roles_view),
                 name="organizations_organization_change_member_roles",
             ),
+            path(
+                "<path:object_id>/transfer-ownership/",
+                self.admin_site.admin_view(self.transfer_ownership_view),
+                name="organizations_organization_transfer_ownership",
+            ),
         ]
         return custom_urls + super().get_urls()
 
@@ -360,6 +367,57 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
             "title": f"Roles for {member.email or member} in {organization.name}",
             "help_text": "Unchecking a role revokes it. Clearing them all leaves the person a member with no access.",
             "submit_label": "Save roles",
+            "cancel_url": organization_url,
+        }
+        return TemplateResponse(request, "admin/organizations/organization/member_form.html", context)
+
+    def transfer_ownership_view(self, request: HttpRequest, object_id: str) -> HttpResponse:
+        """Hand ownership of this organization to another member.
+
+        Without this the first person invited to a new organization is stuck:
+        ``Organization.add_user`` makes them the owner and
+        ``organization_remove_member`` refuses to remove an owner.  Editing the
+        ``OrganizationOwner`` row by hand was the only way out.
+        """
+        organization = get_object_or_404(Organization, pk=object_id)
+        organization_url = reverse("admin:organizations_organization_change", args=[organization.pk])
+        owner = (
+            OrganizationOwner.objects.filter(organization=organization)
+            .select_related("organization_user__user")
+            .first()
+        )
+        current_owner = owner.organization_user.user if owner else None
+
+        if request.method == "POST":
+            form = OrganizationOwnerTransferForm(request.POST, organization=organization, current_owner=current_owner)
+            if form.is_valid():
+                try:
+                    member = organization_transfer_ownership(
+                        organization=organization,
+                        new_owner_user_id=form.cleaned_data["new_owner"].pk,
+                    )
+                except ValidationError as error:
+                    self.message_user(request, "; ".join(error.messages), messages.ERROR)
+                    return redirect(request.get_full_path())
+
+                self.message_user(
+                    request,
+                    f"{member.email or member} now owns {organization.name}.",
+                    messages.SUCCESS,
+                )
+                return redirect(organization_url)
+        else:
+            form = OrganizationOwnerTransferForm(organization=organization, current_owner=current_owner)
+
+        current = current_owner.email or str(current_owner) if current_owner else "nobody"
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "organization": organization,
+            "form": form,
+            "title": f"Transfer ownership of {organization.name}",
+            "help_text": f"Currently owned by {current}. Only a member can own an organization.",
+            "submit_label": "Transfer ownership",
             "cancel_url": organization_url,
         }
         return TemplateResponse(request, "admin/organizations/organization/member_form.html", context)

--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -374,8 +374,12 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
         the same save, with a fresh and empty ``auth.Group``, so the page comes
         back looking untouched while everyone who held the role has lost it.
         """
+        # The inline names its pk field after the model's pk, which #2378 makes
+        # ``group_ptr``.  Hardcoding ``-id`` would stop matching and report no
+        # losses rather than failing.
+        pk_field = PermissionGroup._meta.pk.name
         deleted_row_ids = [
-            posted.get(f"{key.rsplit('-', 1)[0]}-id")
+            posted.get(f"{key.rsplit('-', 1)[0]}-{pk_field}")
             for key in posted
             if key.startswith("permission_groups-") and key.endswith("-DELETE") and posted.get(key)
         ]

--- a/apps/betterangels-backend/accounts/forms.py
+++ b/apps/betterangels-backend/accounts/forms.py
@@ -156,6 +156,29 @@ class OrganizationMemberInviteForm(OrganizationRoleSelectionForm):
         self.order_fields(["organization", "email", "permission_templates"])
 
 
+class OrganizationOwnerTransferForm(forms.Form):
+    """Choose which member of *organization* becomes its owner.
+
+    Only members are offered, because ``organization_transfer_ownership`` refuses
+    anyone else — the choices and the rule agree rather than the form promising
+    something the service rejects.
+    """
+
+    new_owner = forms.ModelChoiceField(
+        queryset=User.objects.none(),
+        label="New owner",
+        help_text="The current owner keeps their membership and roles; they simply stop owning.",
+    )
+
+    def __init__(self, *args: Any, organization: Organization, current_owner: User | None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        members = User.objects.filter(organizations_organization=organization).order_by("email")
+        if current_owner is not None:
+            members = members.exclude(pk=current_owner.pk)
+        new_owner = cast(forms.ModelChoiceField, self.fields["new_owner"])
+        new_owner.queryset = members
+
+
 class OrganizationMemberRoleForm(OrganizationRoleSelectionForm):
     """Set which of *organization*'s invitable roles an existing member holds.
 

--- a/apps/betterangels-backend/accounts/schema.py
+++ b/apps/betterangels-backend/accounts/schema.py
@@ -8,7 +8,6 @@ from common.org_types import REGISTRY
 from common.permissions.utils import IsAuthenticated, get_current_organization
 from django.contrib import auth
 from django.core.exceptions import PermissionDenied
-from django.db import transaction
 from django.db.models import Exists, OuterRef, QuerySet
 from organizations.backends import invitation_backend
 from strawberry.types import Info
@@ -28,6 +27,7 @@ from .services import (
     member_add,
     member_roles_replace,
     organization_remove_member,
+    user_delete,
 )
 from .types import (
     AuthResponse,
@@ -211,12 +211,7 @@ class Mutation:
         if user.pk is None:
             raise RuntimeError("Cannot delete user.")
 
-        user_id = user.pk
-
-        with transaction.atomic():
-            user.delete()
-
-        return DeletedObjectType(id=user_id)
+        return DeletedObjectType(id=user_delete(user=cast(User, user)))
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],

--- a/apps/betterangels-backend/accounts/selectors.py
+++ b/apps/betterangels-backend/accounts/selectors.py
@@ -4,13 +4,14 @@ Reference: https://github.com/HackSoftware/Django-Styleguide#selectors
 """
 
 import logging
+from collections.abc import Iterable
 from typing import Optional, Union
 
 from common.permissions.config import TemplateConfig
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
-from organizations.models import Organization
+from organizations.models import Organization, OrganizationOwner
 
 from .models import PermissionGroup, User
 
@@ -125,6 +126,44 @@ def resolve_permission_group(
         raise PermissionError(f"User does not hold a '{template_name}' permission group in any organization")
 
     return permission_group
+
+
+# ── Ownership ─────────────────────────────────────────────────────────
+
+
+def owned_organizations(*, membership_ids: Iterable[int]) -> dict[int, Organization]:
+    """The organization each of these memberships owns, keyed by membership id.
+
+    ``OrganizationOwner.organization_user`` cascades, so deleting one of these
+    rows — on its own, or by cascade from its ``User`` — leaves the organization
+    with no owner and no way to gain one.  Every caller that deletes a membership
+    asks this first.
+
+    Keyed by membership rather than by user because a user may belong to several
+    organizations and own only one of them.
+    """
+    return {
+        owner.organization_user_id: owner.organization
+        for owner in OrganizationOwner.objects.filter(organization_user_id__in=membership_ids).select_related(
+            "organization"
+        )
+    }
+
+
+def organizations_owned_by(*, user_ids: Iterable[int]) -> dict[int, list[Organization]]:
+    """Every organization each of these users owns, keyed by user id.
+
+    The ``User``-shaped question behind :func:`owned_organizations`: deleting the
+    account cascades through every membership it holds.
+    """
+    by_user: dict[int, list[Organization]] = {}
+    for owner in (
+        OrganizationOwner.objects.filter(organization_user__user_id__in=user_ids)
+        .select_related("organization", "organization_user")
+        .order_by("organization__name")
+    ):
+        by_user.setdefault(owner.organization_user.user_id, []).append(owner.organization)
+    return by_user
 
 
 # ── Role reporting ────────────────────────────────────────────────────

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -27,6 +27,7 @@ from .models import (
 )
 from .models import User as UserModel
 from .role_manager import OrgRoleManager
+from .selectors import organizations_owned_by, owned_organizations
 
 if TYPE_CHECKING:
     from .models import User
@@ -376,10 +377,7 @@ def organization_remove_member(
     except OrganizationUser.DoesNotExist:
         raise ValidationError("User is not a member of this organization.")
 
-    if OrganizationOwner.objects.filter(
-        organization=organization,
-        organization_user=org_user,
-    ).exists():
+    if owned_organizations(membership_ids=[org_user.pk]):
         raise ValidationError("You cannot remove the organization owner. Transfer ownership to another member first.")
 
     if user_id == removed_by.pk:
@@ -387,6 +385,31 @@ def organization_remove_member(
 
     OrgRoleManager(organization).clear_roles(org_user.user)
     org_user.delete()
+
+    return user_id
+
+
+@transaction.atomic
+def user_delete(*, user: UserModel) -> int:
+    """Delete *user*'s account, unless they still own an organization.
+
+    ``OrganizationOwner.organization_user`` cascades from ``OrganizationUser``,
+    which cascades from ``User``, so deleting the account takes the ownership row
+    with it and leaves the organization with no owner.  django-organizations'
+    own guard in ``AbstractOrganizationUser.delete`` does not fire here: the
+    deletion collector removes cascaded rows with queryset SQL and never calls
+    ``Model.delete()``.
+
+    Returns the deleted user's id.  Raises
+    :class:`~django.core.exceptions.ValidationError` while they own anything.
+    """
+    user_id = user.pk
+    owned = organizations_owned_by(user_ids=[user_id]).get(user_id, [])
+    if owned:
+        names = ", ".join(organization.name for organization in owned)
+        raise ValidationError(f"You own {names}. Transfer ownership to another member before deleting your account.")
+
+    user.delete()
 
     return user_id
 

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -380,7 +380,7 @@ def organization_remove_member(
         organization=organization,
         organization_user=org_user,
     ).exists():
-        raise ValidationError("You cannot remove the organization owner. Transfer ownership first.")
+        raise ValidationError("You cannot remove the organization owner. Transfer ownership to another member first.")
 
     if user_id == removed_by.pk:
         raise ValidationError("You cannot remove yourself from the organization.")
@@ -389,6 +389,45 @@ def organization_remove_member(
     org_user.delete()
 
     return user_id
+
+
+@transaction.atomic
+def organization_transfer_ownership(
+    *,
+    organization: Organization,
+    new_owner_user_id: int,
+) -> UserModel:
+    """Make *new_owner_user_id* the owner of *organization*.
+
+    ``Organization.add_user`` makes the first member the owner and
+    :func:`organization_remove_member` refuses to remove an owner, so without a
+    way to move ownership the first person invited to a new organization could
+    never be removed from it.  This is that way.
+
+    Ownership is a single row, so the previous owner simply stops being one; they
+    keep their membership and their roles.  Delegates the move to
+    ``Organization.change_owner`` so django-organizations' ``owner_changed``
+    signal still fires.
+
+    Raises :class:`~django.core.exceptions.ValidationError` if the new owner is
+    not a member of *organization*.
+    """
+    try:
+        new_owner = OrganizationUser.objects.select_related("user").get(
+            organization=organization,
+            user_id=new_owner_user_id,
+        )
+    except OrganizationUser.DoesNotExist:
+        raise ValidationError("Only a member of this organization can own it.")
+
+    if OrganizationOwner.objects.filter(organization=organization).exists():
+        organization.change_owner(new_owner)
+    else:
+        # An organization built without add_user has no owner row to move.
+        OrganizationOwner.objects.create(organization=organization, organization_user=new_owner)
+
+    member: UserModel = new_owner.user
+    return member
 
 
 @transaction.atomic

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -407,7 +407,9 @@ def organization_transfer_ownership(
     Ownership is a single row, so the previous owner simply stops being one; they
     keep their membership and their roles.  Delegates the move to
     ``Organization.change_owner`` so django-organizations' ``owner_changed``
-    signal still fires.
+    signal still fires.  An organization that never had an owner has no move to
+    make and no old owner to report, so it gets the row outright and no signal —
+    the shelter importer's ``get_or_create`` left most of them in that state.
 
     Raises :class:`~django.core.exceptions.ValidationError` if the new owner is
     not a member of *organization*.

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -713,6 +713,90 @@ class OrganizationMemberMultipleRolesTestCase(TestCase):
         )
 
 
+class OrganizationTypeRemovalConfirmationTestCase(TestCase):
+    """Unchecking an org type revokes its roles; the page has to say so first."""
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(
+            username="admin_orgtype_tests", email="admin_orgtype_tests@example.com", password="password"
+        )
+        self.client.force_login(self.superuser)
+        self.organization = organization_recipe.make(preset_names=["outreach", "shelter"], owner_roles=())
+        self.url = reverse("admin:organizations_organization_change", args=[self.organization.pk])
+
+    def _payload(self, org_types: list[str], **extra: str) -> dict:
+        rows = list(PermissionGroup.objects.filter(organization=self.organization).order_by("pk"))
+        payload: dict = {
+            "name": self.organization.name,
+            "is_active": "on",
+            "profile-TOTAL_FORMS": "1",
+            "profile-INITIAL_FORMS": "1",
+            "profile-MIN_NUM_FORMS": "1",
+            "profile-MAX_NUM_FORMS": "1",
+            "profile-0-id": str(self.organization.profile.pk),
+            "profile-0-organization": str(self.organization.pk),
+            "profile-0-org_types": org_types,
+            "permission_groups-TOTAL_FORMS": str(len(rows)),
+            "permission_groups-INITIAL_FORMS": str(len(rows)),
+            "permission_groups-MIN_NUM_FORMS": "0",
+            "permission_groups-MAX_NUM_FORMS": "1000",
+            "organization_users-TOTAL_FORMS": "0",
+            "organization_users-INITIAL_FORMS": "0",
+            "organization_users-MIN_NUM_FORMS": "0",
+            "organization_users-MAX_NUM_FORMS": "1000",
+        }
+        for index, row in enumerate(rows):
+            payload[f"permission_groups-{index}-id"] = str(row.pk)
+            payload[f"permission_groups-{index}-organization"] = str(self.organization.pk)
+            payload[f"permission_groups-{index}-name"] = row.name
+            payload[f"permission_groups-{index}-template"] = str(row.template_id or "")
+        return payload | extra
+
+    def _holds_shelter_operator(self) -> bool:
+        return PermissionGroup.objects.filter(
+            organization=self.organization,
+            template__name=SHELTER_OPERATOR.name,
+        ).exists()
+
+    def test_dropping_a_held_type_asks_first_and_changes_nothing(self) -> None:
+        member_add(
+            email="losesit@example.com",
+            first_name="",
+            last_name="",
+            middle_name=None,
+            organization=self.organization,
+            permission_templates=(SHELTER_OPERATOR,),
+        )
+
+        response = self.client.post(self.url, self._payload(["outreach"]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, SHELTER_OPERATOR.name)
+        self.assertContains(response, "1 member")
+        self.assertTrue(self._holds_shelter_operator())
+
+    def test_confirming_goes_through(self) -> None:
+        member = member_add(
+            email="confirmed@example.com",
+            first_name="",
+            last_name="",
+            middle_name=None,
+            organization=self.organization,
+            permission_templates=(SHELTER_OPERATOR,),
+        )
+
+        self.client.post(self.url, self._payload(["outreach"], _confirm_org_type_removal="1"))
+
+        self.assertFalse(self._holds_shelter_operator())
+        self.assertFalse(PermissionGroup.objects.filter(organization=self.organization, group__user=member).exists())
+
+    def test_dropping_a_type_nobody_holds_does_not_ask(self) -> None:
+        """A prompt that always fires stops being read."""
+        self.client.post(self.url, self._payload(["outreach"]))
+
+        self.assertFalse(self._holds_shelter_operator())
+
+
 class OrganizationOwnershipTransferTestCase(TestCase):
     """The owner cannot be removed, so there has to be a way to stop being one."""
 

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -4,7 +4,7 @@ Creating an organization in the admin used to produce one that could hold no
 roles and accept no members, and adding a member to it returned a 500.
 """
 
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from accounts.admin import CustomOrganizationUserAdmin
 from accounts.groups import ORG_ADMIN
@@ -15,7 +15,12 @@ from accounts.models import (
     PermissionGroupTemplate,
     User,
 )
-from accounts.services import invitation_role, member_add, reconcile_org_groups
+from accounts.services import (
+    invitation_role,
+    member_add,
+    organization_transfer_ownership,
+    reconcile_org_groups,
+)
 from common.permissions.config import TemplateConfig
 from django.contrib import admin
 from django.contrib.auth.models import Group, Permission
@@ -30,6 +35,11 @@ from organizations.models import Organization, OrganizationOwner, OrganizationUs
 from shelters.groups import GLOBAL_SHELTER_OPERATOR, SHELTER_OPERATOR
 
 from .baker_recipes import organization_recipe, permission_group_recipe
+
+if TYPE_CHECKING:
+    # What ``self.client`` returns: an ``HttpResponse`` that also carries the
+    # template ``context`` these tests assert against.
+    from django.test.client import _MonkeyPatchedWSGIResponse
 
 
 class OrganizationProfileAccessTestCase(TestCase):
@@ -329,8 +339,20 @@ class OrganizationMembershipDeletionTestCase(TestCase):
 
     ``organization_remove_member`` clears the member's org-scoped roles and
     refuses to remove the owner.  The admin deletes the row directly, so both
-    rules have to hold there too.
+    rules have to hold there too — and a refusal has to say which rule refused.
     """
+
+    def assertRefused(self, response: "_MonkeyPatchedWSGIResponse") -> None:
+        """The page explains the refusal instead of reporting a missing permission.
+
+        Django reports a withheld ``has_delete_permission`` as "your account
+        doesn't have permission to delete the following types of objects:
+        organization user", which tells a superuser they lack a permission and
+        names the row rather than the organization that blocks it.
+        """
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["perms_lacking"])
+        self.assertTrue(response.context["protected"])
 
     def setUp(self) -> None:
         self.superuser = User.objects.create_superuser(
@@ -384,7 +406,13 @@ class OrganizationMembershipDeletionTestCase(TestCase):
             {"post": "yes"},
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertRefused(response)
+        self.assertContains(response, "would be left with no owner")
+        self.assertContains(response, self.organization.name)
+        self.assertContains(
+            response,
+            reverse("admin:organizations_organization_transfer_ownership", args=[self.organization.pk]),
+        )
         self.assertTrue(OrganizationUser.objects.filter(pk=owner_membership.pk).exists())
         self.assertTrue(OrganizationOwner.objects.filter(organization=self.organization).exists())
 
@@ -405,15 +433,16 @@ class OrganizationMembershipDeletionTestCase(TestCase):
             {"post": "yes"},
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertRefused(response)
+        self.assertContains(response, "You cannot remove yourself from")
         self.assertTrue(OrganizationUser.objects.filter(pk=own_membership.pk).exists())
 
     def test_a_bulk_delete_including_the_owner_deletes_nothing(self) -> None:
         """``delete_selected`` refuses the whole batch if any row is protected.
 
-        ``get_deleted_objects`` consults ``has_delete_permission`` per selected
-        row, so the guard covers the bulk action without a ``delete_queryset``
-        override — and it is all-or-nothing rather than a silent partial delete.
+        ``get_deleted_objects`` covers the bulk action as well as the single one,
+        so the guard needs no ``delete_queryset`` override — and it is
+        all-or-nothing rather than a silent partial delete.
         """
         owner_membership = OrganizationOwner.objects.get(organization=self.organization).organization_user
 
@@ -426,11 +455,113 @@ class OrganizationMembershipDeletionTestCase(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertRefused(response)
+        self.assertContains(response, "would be left with no owner")
         self.assertTrue(OrganizationUser.objects.filter(pk=owner_membership.pk).exists())
         self.assertTrue(OrganizationOwner.objects.filter(organization=self.organization).exists())
         self.assertTrue(OrganizationUser.objects.filter(pk=self.membership.pk).exists())
         self.assertEqual(self._org_role_count(), 1)
+
+
+class UserDeletionTestCase(TestCase):
+    """Deleting a ``User`` account from the admin.
+
+    ``User`` cascades to ``OrganizationUser``, which cascades to
+    ``OrganizationOwner``, so deleting an owner would leave the organization
+    with nobody able to administer it.
+    """
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(
+            username="admin_user_delete", email="admin_user_delete@example.com", password="password"
+        )
+        self.client.force_login(self.superuser)
+        self.organization = organization_recipe.make(preset_names=["outreach"], owner_roles=())
+        self.owner = OrganizationOwner.objects.get(organization=self.organization).organization_user.user
+        self.member = member_add(
+            email="plain_member@example.com",
+            first_name="",
+            last_name="",
+            middle_name=None,
+            organization=self.organization,
+            permission_templates=(CASEWORKER,),
+        )
+
+    def _delete(self, user: User) -> "_MonkeyPatchedWSGIResponse":
+        return self.client.post(reverse("admin:accounts_user_delete", args=[user.pk]), {"post": "yes"})
+
+    def test_an_owners_account_cannot_be_deleted(self) -> None:
+        response = self._delete(self.owner)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "would be left with no owner")
+        self.assertContains(response, self.organization.name)
+        self.assertTrue(User.objects.filter(pk=self.owner.pk).exists())
+        self.assertTrue(OrganizationOwner.objects.filter(organization=self.organization).exists())
+
+    def test_the_refusal_offers_the_transfer_that_lifts_it(self) -> None:
+        response = self._delete(self.owner)
+
+        self.assertContains(
+            response,
+            reverse("admin:organizations_organization_transfer_ownership", args=[self.organization.pk]),
+        )
+
+    def test_the_owner_guard_is_not_reported_as_a_missing_permission(self) -> None:
+        """The bug this replaced: a superuser told they lacked a permission.
+
+        Django turns a withheld ``has_delete_permission`` on the cascaded
+        membership into "your account doesn't have permission to delete the
+        following types of objects: organization user".
+        """
+        response = self._delete(self.owner)
+
+        self.assertFalse(response.context["perms_lacking"])
+        self.assertNotContains(response, "doesn't have permission to delete")
+
+    def test_transferring_ownership_frees_the_account_for_deletion(self) -> None:
+        organization_transfer_ownership(organization=self.organization, new_owner_user_id=self.member.pk)
+
+        response = self._delete(self.owner)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(User.objects.filter(pk=self.owner.pk).exists())
+
+    def test_a_member_who_owns_nothing_is_deleted_with_their_membership(self) -> None:
+        membership_id = OrganizationUser.objects.get(organization=self.organization, user=self.member).pk
+
+        response = self._delete(self.member)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(User.objects.filter(pk=self.member.pk).exists())
+        self.assertFalse(OrganizationUser.objects.filter(pk=membership_id).exists())
+
+    def test_you_cannot_delete_the_account_you_are_signed_in_with(self) -> None:
+        """Refused for its own sake, not as a side effect of the membership guard.
+
+        The superuser here holds no membership, which is the case that used to
+        slip through.
+        """
+        response = self._delete(self.superuser)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You cannot delete the account you are signed in with")
+        self.assertTrue(User.objects.filter(pk=self.superuser.pk).exists())
+
+    def test_a_bulk_delete_including_an_owner_deletes_nothing(self) -> None:
+        response = self.client.post(
+            reverse("admin:accounts_user_changelist"),
+            {
+                "action": "delete_selected",
+                "_selected_action": [str(self.owner.pk), str(self.member.pk)],
+                "post": "yes",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "would be left with no owner")
+        self.assertTrue(User.objects.filter(pk=self.owner.pk).exists())
+        self.assertTrue(User.objects.filter(pk=self.member.pk).exists())
 
 
 class OrganizationUserAddViewTestCase(TestCase):

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -105,8 +105,9 @@ class OrganizationAdminTestCase(TestCase):
             "organization_users-MIN_NUM_FORMS": "0",
             "organization_users-MAX_NUM_FORMS": "1000",
         }
+        pk_field = PermissionGroup._meta.pk.name
         for index, row in enumerate(rows):
-            payload[f"permission_groups-{index}-id"] = str(row.pk)
+            payload[f"permission_groups-{index}-{pk_field}"] = str(row.pk)
             payload[f"permission_groups-{index}-organization"] = str(organization.pk)
             payload[f"permission_groups-{index}-name"] = row.name
             payload[f"permission_groups-{index}-template"] = str(

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -713,6 +713,59 @@ class OrganizationMemberMultipleRolesTestCase(TestCase):
         )
 
 
+class OrganizationOwnershipTransferTestCase(TestCase):
+    """The owner cannot be removed, so there has to be a way to stop being one."""
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(
+            username="admin_owner_tests", email="admin_owner_tests@example.com", password="password"
+        )
+        self.client.force_login(self.superuser)
+        self.organization = organization_recipe.make(preset_names=["outreach"])
+        self.owner_membership = OrganizationOwner.objects.get(organization=self.organization).organization_user
+        self.member = member_add(
+            email="successor@example.com",
+            first_name="",
+            last_name="",
+            middle_name=None,
+            organization=self.organization,
+            permission_templates=(CASEWORKER,),
+        )
+        self.url = reverse("admin:organizations_organization_transfer_ownership", args=[self.organization.pk])
+
+    def test_the_organization_page_offers_the_transfer(self) -> None:
+        page = self.client.get(
+            reverse("admin:organizations_organization_change", args=[self.organization.pk])
+        ).content.decode()
+
+        self.assertIn(self.url, page)
+
+    def test_the_form_offers_members_but_not_the_current_owner(self) -> None:
+        response = self.client.get(self.url)
+
+        offered = set(response.context["form"].fields["new_owner"].queryset)
+        self.assertIn(self.member, offered)
+        self.assertNotIn(self.owner_membership.user, offered)
+
+    def test_transferring_moves_ownership_and_frees_the_old_owner(self) -> None:
+        old_owner = self.owner_membership.user
+
+        response = self.client.post(self.url, {"new_owner": str(self.member.pk)})
+
+        self.assertRedirects(response, reverse("admin:organizations_organization_change", args=[self.organization.pk]))
+        self.assertEqual(
+            OrganizationOwner.objects.get(organization=self.organization).organization_user.user, self.member
+        )
+        # The old owner's row is now deletable, which it was not before.
+        old_membership = OrganizationUser.objects.get(organization=self.organization, user=old_owner)
+        deleted = self.client.post(
+            reverse("admin:organizations_organizationuser_delete", args=[old_membership.pk]),
+            {"post": "yes"},
+        )
+        self.assertEqual(deleted.status_code, 302)
+        self.assertFalse(OrganizationUser.objects.filter(pk=old_membership.pk).exists())
+
+
 class OrganizationMemberInlineQueryCountTestCase(TestCase):
     """The Members inline renders every row, so its cost must not grow per member."""
 

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -16,8 +16,9 @@ from accounts.models import (
     User,
 )
 from accounts.services import invitation_role, member_add, reconcile_org_groups
+from common.permissions.config import TemplateConfig
 from django.contrib import admin
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection
 from django.test import SimpleTestCase, TestCase
@@ -713,8 +714,8 @@ class OrganizationMemberMultipleRolesTestCase(TestCase):
         )
 
 
-class OrganizationTypeRemovalConfirmationTestCase(TestCase):
-    """Unchecking an org type revokes its roles; the page has to say so first."""
+class OrganizationRoleLossConfirmationTestCase(TestCase):
+    """A save that takes someone's role away has to say so first, by either route."""
 
     def setUp(self) -> None:
         self.superuser = User.objects.create_superuser(
@@ -724,8 +725,11 @@ class OrganizationTypeRemovalConfirmationTestCase(TestCase):
         self.organization = organization_recipe.make(preset_names=["outreach", "shelter"], owner_roles=())
         self.url = reverse("admin:organizations_organization_change", args=[self.organization.pk])
 
+    def _rows(self) -> list[PermissionGroup]:
+        return list(PermissionGroup.objects.filter(organization=self.organization).order_by("pk"))
+
     def _payload(self, org_types: list[str], **extra: str) -> dict:
-        rows = list(PermissionGroup.objects.filter(organization=self.organization).order_by("pk"))
+        rows = self._rows()
         payload: dict = {
             "name": self.organization.name,
             "is_active": "on",
@@ -752,6 +756,30 @@ class OrganizationTypeRemovalConfirmationTestCase(TestCase):
             payload[f"permission_groups-{index}-template"] = str(row.template_id or "")
         return payload | extra
 
+    def _tick_delete(self, template: TemplateConfig) -> dict[str, str]:
+        """The POST key the inline's Delete checkbox sends for *template*'s row."""
+        index = next(
+            index for index, row in enumerate(self._rows()) if row.template and row.template.name == template.name
+        )
+        return {f"permission_groups-{index}-DELETE": "on"}
+
+    def _member_holding(self, template: TemplateConfig, email: str) -> User:
+        return member_add(
+            email=email,
+            first_name="",
+            last_name="",
+            middle_name=None,
+            organization=self.organization,
+            permission_templates=(template,),
+        )
+
+    def _holds(self, member: User, template: TemplateConfig) -> bool:
+        return PermissionGroup.objects.filter(
+            organization=self.organization,
+            template__name=template.name,
+            group__user=member,
+        ).exists()
+
     def _holds_shelter_operator(self) -> bool:
         return PermissionGroup.objects.filter(
             organization=self.organization,
@@ -759,14 +787,7 @@ class OrganizationTypeRemovalConfirmationTestCase(TestCase):
         ).exists()
 
     def test_dropping_a_held_type_asks_first_and_changes_nothing(self) -> None:
-        member_add(
-            email="losesit@example.com",
-            first_name="",
-            last_name="",
-            middle_name=None,
-            organization=self.organization,
-            permission_templates=(SHELTER_OPERATOR,),
-        )
+        self._member_holding(SHELTER_OPERATOR, "losesit@example.com")
 
         response = self.client.post(self.url, self._payload(["outreach"]))
 
@@ -776,16 +797,9 @@ class OrganizationTypeRemovalConfirmationTestCase(TestCase):
         self.assertTrue(self._holds_shelter_operator())
 
     def test_confirming_goes_through(self) -> None:
-        member = member_add(
-            email="confirmed@example.com",
-            first_name="",
-            last_name="",
-            middle_name=None,
-            organization=self.organization,
-            permission_templates=(SHELTER_OPERATOR,),
-        )
+        member = self._member_holding(SHELTER_OPERATOR, "confirmed@example.com")
 
-        self.client.post(self.url, self._payload(["outreach"], _confirm_org_type_removal="1"))
+        self.client.post(self.url, self._payload(["outreach"], _confirm_role_loss="1"))
 
         self.assertFalse(self._holds_shelter_operator())
         self.assertFalse(PermissionGroup.objects.filter(organization=self.organization, group__user=member).exists())
@@ -795,6 +809,54 @@ class OrganizationTypeRemovalConfirmationTestCase(TestCase):
         self.client.post(self.url, self._payload(["outreach"]))
 
         self.assertFalse(self._holds_shelter_operator())
+
+    def test_a_role_the_remaining_type_keeps_is_not_named(self) -> None:
+        """Organization Admin belongs to both org types, so dropping one does not revoke it."""
+        self._member_holding(ORG_ADMIN, "stays_admin@example.com")
+        self._member_holding(SHELTER_OPERATOR, "loses_operator@example.com")
+
+        response = self.client.post(self.url, self._payload(["outreach"]))
+
+        # Against the context, not the HTML: the replayed POST carries every role
+        # name in a hidden field, so the page contains them either way.
+        losses = dict(response.context["losses"])
+        self.assertIn(SHELTER_OPERATOR.name, losses)
+        self.assertNotIn(ORG_ADMIN.name, losses)
+
+    def test_deleting_a_role_row_asks_first_and_changes_nothing(self) -> None:
+        """The quieter route: reconcile rebuilds the row, so the saved page looks untouched."""
+        member = self._member_holding(SHELTER_OPERATOR, "row_delete@example.com")
+
+        response = self.client.post(
+            self.url, self._payload(["outreach", "shelter"], **self._tick_delete(SHELTER_OPERATOR))
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, SHELTER_OPERATOR.name)
+        self.assertContains(response, "1 member")
+        self.assertTrue(self._holds(member, SHELTER_OPERATOR))
+
+    def test_confirming_a_row_deletion_goes_through(self) -> None:
+        member = self._member_holding(SHELTER_OPERATOR, "row_delete_ok@example.com")
+
+        self.client.post(
+            self.url,
+            self._payload(["outreach", "shelter"], _confirm_role_loss="1", **self._tick_delete(SHELTER_OPERATOR)),
+        )
+
+        self.assertFalse(self._holds(member, SHELTER_OPERATOR))
+
+    def test_a_view_only_staff_user_is_refused_rather_than_asked(self) -> None:
+        """The prompt must not answer a question Django is about to refuse."""
+        self._member_holding(SHELTER_OPERATOR, "viewonly_subject@example.com")
+        viewer = User.objects.create_user(username="orgtype_viewer", password="password", is_staff=True)
+        viewer.user_permissions.add(Permission.objects.get(codename="view_organization"))
+        self.client.force_login(viewer)
+
+        response = self.client.post(self.url, self._payload(["outreach"]))
+
+        self.assertEqual(response.status_code, 403)
+        self.assertNotContains(response, SHELTER_OPERATOR.name, status_code=403)
 
 
 class OrganizationOwnershipTransferTestCase(TestCase):
@@ -830,6 +892,17 @@ class OrganizationOwnershipTransferTestCase(TestCase):
         offered = set(response.context["form"].fields["new_owner"].queryset)
         self.assertIn(self.member, offered)
         self.assertNotIn(self.owner_membership.user, offered)
+
+    def test_an_organization_with_no_owner_offers_every_member(self) -> None:
+        """The shelter importer left 97 of 99 production organizations with no owner row."""
+        OrganizationOwner.objects.filter(organization=self.organization).delete()
+
+        response = self.client.get(self.url)
+
+        self.assertIn("Currently owned by nobody", response.context["help_text"])
+        offered = set(response.context["form"].fields["new_owner"].queryset)
+        self.assertIn(self.member, offered)
+        self.assertIn(self.owner_membership.user, offered)
 
     def test_transferring_moves_ownership_and_frees_the_old_owner(self) -> None:
         old_owner = self.owner_membership.user

--- a/apps/betterangels-backend/accounts/tests/test_delete_account_view.py
+++ b/apps/betterangels-backend/accounts/tests/test_delete_account_view.py
@@ -1,0 +1,43 @@
+"""The web account-deletion page, the second way a user deletes their own account."""
+
+from accounts.models import User
+from accounts.services import organization_transfer_ownership
+from django.test import TestCase
+from django.urls import reverse
+from organizations.models import OrganizationOwner, OrganizationUser
+
+from .baker_recipes import organization_recipe
+
+
+class DeleteAccountViewTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username="delete_account_view", email="delete_account_view@example.com", password="password"
+        )
+        self.client.force_login(self.user)
+        self.url = reverse("delete_account")
+        self.organization = organization_recipe.make(preset_names=["outreach"], owner_roles=())
+
+    def _join(self) -> None:
+        OrganizationUser.objects.create(organization=self.organization, user=self.user)
+
+    def test_an_account_that_owns_nothing_is_deleted(self) -> None:
+        user_id = self.user.pk
+
+        response = self.client.post(self.url)
+
+        self.assertRedirects(response, "/", fetch_redirect_response=False)
+        self.assertFalse(User.objects.filter(pk=user_id).exists())
+
+    def test_an_owner_is_refused_and_told_why(self) -> None:
+        """The cascade would leave the organization with nobody able to administer it."""
+        self._join()
+        organization_transfer_ownership(organization=self.organization, new_owner_user_id=self.user.pk)
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Transfer ownership to another member")
+        self.assertContains(response, self.organization.name)
+        self.assertTrue(User.objects.filter(pk=self.user.pk).exists())
+        self.assertTrue(OrganizationOwner.objects.filter(organization=self.organization).exists())

--- a/apps/betterangels-backend/accounts/tests/test_mutations.py
+++ b/apps/betterangels-backend/accounts/tests/test_mutations.py
@@ -548,7 +548,7 @@ class OrganizationMemberMutationTestCase(GraphQLBaseTestCase, ParametrizedTestCa
         self.assertEqual(len(response["data"]["removeOrganizationMember"]["messages"]), 1)
         self.assertEqual(
             response["data"]["removeOrganizationMember"]["messages"][0]["message"],
-            "You cannot remove the organization owner. Transfer ownership first.",
+            "You cannot remove the organization owner. Transfer ownership to another member first.",
         )
 
         self.assertTrue(

--- a/apps/betterangels-backend/accounts/tests/test_mutations.py
+++ b/apps/betterangels-backend/accounts/tests/test_mutations.py
@@ -5,6 +5,7 @@ from accounts.enums import OrgRoleEnum
 from accounts.groups import ORG_ADMIN, ORG_SUPERUSER
 from accounts.models import PermissionGroup, User
 from accounts.role_manager import OrgRoleManager
+from accounts.services import organization_transfer_ownership
 from accounts.tests.utils import CurrentUserGraphQLBaseTestCase
 from accounts.types import PermissionTemplateEnum
 from common.tests.utils import GraphQLBaseTestCase
@@ -89,6 +90,39 @@ class CurrentUserGraphQLTests(CurrentUserGraphQLBaseTestCase, TestCase):
         response = self.execute_graphql(mutation)["data"]["deleteCurrentUser"]
         self.assertEqual(response["id"], self.user.pk)
         self.assertEqual(User.objects.count(), initial_user_count - 1)
+
+    def test_an_owner_cannot_delete_their_account(self) -> None:
+        """Deleting the account cascades to the OrganizationOwner row.
+
+        That would leave the organization with nobody able to administer it, so
+        the mutation reports it instead of succeeding.
+        """
+        organization_transfer_ownership(organization=self.user_organization, new_owner_user_id=self.user.pk)
+        initial_user_count = User.objects.count()
+        self.graphql_client.force_login(self.user)
+
+        mutation: str = """
+            mutation DeleteCurrentUser {
+                deleteCurrentUser {
+                    ... on OperationInfo {
+                        messages {
+                            kind
+                            field
+                            message
+                        }
+                    }
+                    ... on DeletedObjectType {
+                        id
+                    }
+                }
+            }
+        """
+
+        response = self.execute_graphql(mutation)["data"]["deleteCurrentUser"]
+
+        self.assertIn("Transfer ownership to another member", response["messages"][0]["message"])
+        self.assertIn(self.user_organization.name, response["messages"][0]["message"])
+        self.assertEqual(User.objects.count(), initial_user_count)
 
 
 @ignore_warnings(category=UserWarning)

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -15,6 +15,7 @@ from accounts.services import (
     organization_remove_member,
     organization_transfer_ownership,
     reactivate_user,
+    user_delete,
 )
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
@@ -757,3 +758,67 @@ class TestOrganizationTransferOwnership:
             organization_transfer_ownership(organization=org, new_owner_user_id=stranger.pk)
 
         assert OrganizationOwner.objects.get(organization=org).organization_user.user == owner
+
+
+# ── user_delete ───────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestUserDelete:
+    """Tests for user_delete."""
+
+    def _org_with_member(self, name: str) -> tuple[User, User, "Organization"]:
+        owner = baker.make(User)
+        org = create_organization_with_presets(name, ["outreach"], owner=owner)
+        member = member_add(
+            email=f"{name.replace(' ', '').lower()}@example.com",
+            first_name="A",
+            last_name="Member",
+            middle_name=None,
+            organization=org,
+            permission_templates=(CASEWORKER,),
+        )
+        return owner, member, org
+
+    def test_deletes_an_account_that_owns_nothing(self) -> None:
+        user = baker.make(User)
+        user_id = user.pk
+
+        assert user_delete(user=user) == user_id
+        assert not User.objects.filter(pk=user_id).exists()
+
+    def test_a_members_account_goes_with_their_membership(self) -> None:
+        owner, member, org = self._org_with_member("Member Delete Org")
+
+        member_id = member.pk
+
+        user_delete(user=member)
+
+        assert not User.objects.filter(pk=member_id).exists()
+        assert not OrganizationUser.objects.filter(organization=org, user_id=member_id).exists()
+
+    def test_an_owner_cannot_delete_their_account(self) -> None:
+        """The cascade would take the OrganizationOwner row and leave the org unadministrable."""
+        owner, member, org = self._org_with_member("Owner Delete Org")
+
+        with pytest.raises(ValidationError, match="Transfer ownership to another member"):
+            user_delete(user=owner)
+
+        assert User.objects.filter(pk=owner.pk).exists()
+        assert OrganizationOwner.objects.filter(organization=org).exists()
+
+    def test_the_refusal_names_the_organization(self) -> None:
+        owner, member, org = self._org_with_member("Named Org")
+
+        with pytest.raises(ValidationError, match=org.name):
+            user_delete(user=owner)
+
+    def test_transferring_ownership_frees_the_account(self) -> None:
+        owner, member, org = self._org_with_member("Freed Org")
+        owner_id = owner.pk
+        organization_transfer_ownership(organization=org, new_owner_user_id=member.pk)
+
+        user_delete(user=owner)
+
+        assert not User.objects.filter(pk=owner_id).exists()
+        assert OrganizationOwner.objects.get(organization=org).organization_user.user == member

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -737,6 +737,18 @@ class TestOrganizationTransferOwnership:
 
         assert not OrganizationUser.objects.filter(organization=org, user=owner).exists()
 
+    def test_an_organization_with_no_owner_row_gains_one(self) -> None:
+        """The shelter importer never called add_user, so most production orgs own nothing."""
+        owner, member, org = self._org_with_member("Ownerless Org")
+        OrganizationOwner.objects.filter(organization=org).delete()
+        # Refetched, or change_owner finds the deleted row still cached on the instance.
+        org = Organization.objects.get(pk=org.pk)
+
+        returned = organization_transfer_ownership(organization=org, new_owner_user_id=member.pk)
+
+        assert returned == member
+        assert OrganizationOwner.objects.get(organization=org).organization_user.user == member
+
     def test_a_non_member_cannot_own_the_organization(self) -> None:
         owner, member, org = self._org_with_member("Stranger Owner Org")
         stranger = baker.make(User)

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -13,13 +13,14 @@ from accounts.services import (
     member_add,
     member_roles_replace,
     organization_remove_member,
+    organization_transfer_ownership,
     reactivate_user,
 )
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from model_bakery import baker
 from notes.groups import CASEWORKER
-from organizations.models import Organization, OrganizationUser
+from organizations.models import Organization, OrganizationOwner, OrganizationUser
 from shelters.groups import SHELTER_OPERATOR
 
 # ── create_organization_with_presets ──────────────────────────────────
@@ -683,3 +684,64 @@ def test_same_named_organizations_keep_separate_members_and_roles() -> None:
     first_group = PermissionGroup.objects.get(organization=first, template__name=CASEWORKER.name)
     second_group = PermissionGroup.objects.get(organization=second, template__name=CASEWORKER.name)
     assert first_group.group.name != second_group.group.name, "the pk segment must disambiguate"
+
+
+@pytest.mark.django_db
+class TestOrganizationTransferOwnership:
+    """Tests for organization_transfer_ownership."""
+
+    def _org_with_member(self, name: str) -> tuple[User, User, "Organization"]:
+        owner = baker.make(User)
+        org = create_organization_with_presets(name, ["outreach"], owner=owner)
+        member = member_add(
+            email=f"{name.replace(' ', '').lower()}@example.com",
+            first_name="A",
+            last_name="Member",
+            middle_name=None,
+            organization=org,
+            permission_templates=(CASEWORKER,),
+        )
+        return owner, member, org
+
+    def test_moves_ownership_to_another_member(self) -> None:
+        owner, member, org = self._org_with_member("Transfer Org")
+
+        returned = organization_transfer_ownership(organization=org, new_owner_user_id=member.pk)
+
+        assert returned == member
+        assert OrganizationOwner.objects.get(organization=org).organization_user.user == member
+
+    def test_the_previous_owner_keeps_membership_and_roles(self) -> None:
+        owner, member, org = self._org_with_member("Keeps Org")
+        before = set(
+            PermissionGroup.objects.filter(organization=org, group__user=owner).values_list("template__name", flat=True)
+        )
+
+        organization_transfer_ownership(organization=org, new_owner_user_id=member.pk)
+
+        assert OrganizationUser.objects.filter(organization=org, user=owner).exists()
+        after = set(
+            PermissionGroup.objects.filter(organization=org, group__user=owner).values_list("template__name", flat=True)
+        )
+        assert after == before
+
+    def test_the_previous_owner_can_then_be_removed(self) -> None:
+        """The whole point: an owner was un-removable with no way to stop being one."""
+        owner, member, org = self._org_with_member("Unstick Org")
+
+        with pytest.raises(ValidationError, match="cannot remove the organization owner"):
+            organization_remove_member(organization=org, user_id=owner.pk, removed_by=member)
+
+        organization_transfer_ownership(organization=org, new_owner_user_id=member.pk)
+        organization_remove_member(organization=org, user_id=owner.pk, removed_by=member)
+
+        assert not OrganizationUser.objects.filter(organization=org, user=owner).exists()
+
+    def test_a_non_member_cannot_own_the_organization(self) -> None:
+        owner, member, org = self._org_with_member("Stranger Owner Org")
+        stranger = baker.make(User)
+
+        with pytest.raises(ValidationError, match="Only a member"):
+            organization_transfer_ownership(organization=org, new_owner_user_id=stranger.pk)
+
+        assert OrganizationOwner.objects.get(organization=org).organization_user.user == owner

--- a/apps/betterangels-backend/accounts/views/class_views.py
+++ b/apps/betterangels-backend/accounts/views/class_views.py
@@ -1,10 +1,14 @@
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.views.generic import TemplateView
+
+from accounts.models import User
+from accounts.services import user_delete
 
 T = TypeVar("T")
 
@@ -20,9 +24,12 @@ class DeleteAccountPage(TemplateView):
 @login_required
 def delete_account(request: HttpRequest) -> HttpResponse:
     if request.method == "POST":
-        user = request.user
-        user.delete()
-        messages.success(request, "Your account has been deleted successfully.")
-        return redirect("/")
+        try:
+            user_delete(user=cast(User, request.user))
+        except ValidationError as error:
+            messages.error(request, "; ".join(error.messages))
+        else:
+            messages.success(request, "Your account has been deleted successfully.")
+            return redirect("/")
 
     return render(request, "account/delete_account.html")

--- a/apps/betterangels-backend/templates/account/delete_account.html
+++ b/apps/betterangels-backend/templates/account/delete_account.html
@@ -37,6 +37,11 @@
         <main>
             <h1>Delete Account</h1>
             <p>WARNING: This will permanently delete your Better Angels account. You cannot undo this action.</p>
+            {% if messages %}
+                <ul class="messages">
+                    {% for message in messages %}<li>{{ message }}</li>{% endfor %}
+                </ul>
+            {% endif %}
             <form method="post" action="{% url 'delete_account' %}">
                 {% csrf_token %}
                 <button type="submit">Delete my account</button>

--- a/apps/betterangels-backend/templates/admin/organizations/organization/change_form.html
+++ b/apps/betterangels-backend/templates/admin/organizations/organization/change_form.html
@@ -8,6 +8,12 @@
       </a>
     </li>
     <li>
+      {# The owner cannot be removed, so there has to be a way to stop being one. #}
+      <a href="{% url 'admin:organizations_organization_transfer_ownership' original.pk %}" class="changelink">
+        Transfer ownership
+      </a>
+    </li>
+    <li>
       {# The Members inline renders every row; this list is filterable and paginated. #}
       <a href="{% url 'admin:organizations_organizationuser_changelist' %}?organization__id__exact={{ original.pk }}"
          class="viewlink">

--- a/apps/betterangels-backend/templates/admin/organizations/organization/confirm_org_types.html
+++ b/apps/betterangels-backend/templates/admin/organizations/organization/confirm_org_types.html
@@ -1,0 +1,28 @@
+{% extends "admin/base_site.html" %}
+
+{% block content_title %}
+  <h1>{{ title }}</h1>
+{% endblock %}
+
+{% block content %}
+  <p>Removing an org type revokes its roles from everyone holding them. This save would take:</p>
+  <ul>
+    {% for role, holders in losses %}
+      <li><strong>{{ role }}</strong> — from {{ holders }} member{{ holders|pluralize }}</li>
+    {% endfor %}
+  </ul>
+  <p>Re-adding the org type afterwards creates the roles again, but does not give them back to anyone.</p>
+  <form method="post">
+    {% csrf_token %}
+    {% for name, value in posted %}
+      {% if name != "csrfmiddlewaretoken" %}
+        <input type="hidden" name="{{ name }}" value="{{ value }}">
+      {% endif %}
+    {% endfor %}
+    <input type="hidden" name="{{ confirm_field }}" value="1">
+    <div class="submit-row">
+      <input type="submit" value="Yes, revoke these roles" class="default">
+      <a href="{{ cancel_url }}" class="closelink">Cancel</a>
+    </div>
+  </form>
+{% endblock %}

--- a/apps/betterangels-backend/templates/admin/organizations/organization/confirm_role_loss.html
+++ b/apps/betterangels-backend/templates/admin/organizations/organization/confirm_role_loss.html
@@ -5,13 +5,14 @@
 {% endblock %}
 
 {% block content %}
-  <p>Removing an org type revokes its roles from everyone holding them. This save would take:</p>
+  <p>This save takes these roles away from the people who hold them:</p>
   <ul>
     {% for role, holders in losses %}
       <li><strong>{{ role }}</strong> — from {{ holders }} member{{ holders|pluralize }}</li>
     {% endfor %}
   </ul>
-  <p>Re-adding the org type afterwards creates the roles again, but does not give them back to anyone.</p>
+  <p>Putting a role back — re-adding the org type, or re-adding the row — creates it again, but does not
+     give it back to anyone.</p>
   <form method="post">
     {% csrf_token %}
     {% for name, value in posted %}

--- a/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
+++ b/libs/expo/betterangels/src/lib/screens/UserProfile/index.tsx
@@ -1,4 +1,8 @@
 import { useMutation } from '@apollo/client/react';
+import {
+  OperationInfoError,
+  unwrapPayload,
+} from '@monorepo/expo/shared/services';
 import { Colors, Radiuses, Spacings } from '@monorepo/expo/shared/static';
 import {
   Avatar,
@@ -57,14 +61,30 @@ export default function UserProfile() {
 
   async function deleteCurrentUserFunction() {
     try {
-      await deleteCurrentUser();
+      const result = await deleteCurrentUser();
+
+      // The server refuses while this account still owns an organization.
+      // Without unwrapping, that refusal resolves like a success and signs the
+      // user out of an account that still exists.
+      unwrapPayload(
+        result.data?.deleteCurrentUser,
+        'delete account',
+        'DeletedObjectType'
+      );
+
       router.navigate('/auth');
       signOut();
     } catch (err) {
+      if (err instanceof OperationInfoError) {
+        showSnackbar({ message: err.message, type: 'error' });
+
+        return;
+      }
+
       console.error(err);
 
       showSnackbar({
-        message: `Sorry, there was an error logging you out.`,
+        message: `Sorry, there was an error deleting your account.`,
         type: 'error',
       });
     }


### PR DESCRIPTION
Stacked on #2372 — it adds the transfer-ownership view this PR's message links to. Review after that one; the base retargets to `main` when it merges.

## The report

Deleting an organization owner from the User admin was already refused, but the page blamed the wrong thing:

> Deleting the user “934” would result in deleting related objects, but your account doesn't have permission to delete the following types of objects: **organization user**

That sentence is Django's. `CustomOrganizationUserAdmin.has_delete_permission` withheld deletion for the owner's membership, and `get_deleted_objects` turns a withheld permission into `perms_needed` — so a superuser is told they lack a permission, and the object named is the row being deleted rather than the organization that blocks it.

Read from outside, the rule looks like *"you cannot delete an org user"* — both wrong and wider than the real one. Only an **owner** is blocked; a plain member deletes fine.

It now reads:

> Deleting the user “Dale Cooper” would require deleting the following protected related objects:
> • “Acme Shelter” would be left with no owner. **[Transfer ownership]** first.

## Admin

The rule reports through `protected` instead of withholding a permission. It refuses the POST just as firmly on both the single and the bulk path, and leaves the sentence ours to write. `protected` is also why `has_delete_permission` had to go rather than sit alongside it — the template renders `perms_lacking` first, so our sentence would never be reached. A direct POST now re-renders the explanation instead of returning a bare 403.

`UserAdmin` has to ask the question again: `get_deleted_objects` consults each collected object's `ModelAdmin`, not its `get_deleted_objects`, so the membership admin's guard never covered the account that cascades into it. Both call the same selectors, so the rule is defined once.

Deleting the account you are signed in with is now refused for its own sake. It used to be refused only as a side effect of the membership guard, so a superuser holding no membership could delete themselves.

## The same hole outside the admin

`OrganizationOwner` cascades from `OrganizationUser`, which cascades from `User`, and django-organizations' guard in `AbstractOrganizationUser.delete` never fires — the deletion collector removes cascaded rows with queryset SQL and never calls `Model.delete()`. So `deleteCurrentUser` and the `delete_account` page both let an owner delete themselves and leave the organization unadministrable. Both now route through `user_delete`.

No schema change: `DeleteCurrentUserPayload` was already a union with `OperationInfo`, and `MUTATIONS_DEFAULT_HANDLE_ERRORS` turns the `ValidationError` into one.

The mobile screen signed the user out on any resolved response, so that refusal would have read as success — an account that still exists, signed out of, with nothing said. It unwraps the payload now, via the same `unwrapPayload` the upload flows use.

## Verification

1513 backend tests, mypy, and ruff all pass. Two properties are pinned that the old tests could not fail on — that the refusal is never reported as a missing permission, and that the mobile screen keeps the user signed in when the server refuses. Reverting either fix fails them.

By hand in the admin: an owner's delete page names the organization and links to the transfer; transferring then lets the delete through; a bulk delete containing an owner deletes neither user.

## Not included

- **The mobile test.** `UserProfile/index.test.tsx` is written and passing locally, but it only loads with the expo native-module stubs currently in flight in `test-setup.ts`. It goes in as a follow-up commit here once those land.
- **`OrganizationOwner` is never unregistered** ([admin.py](https://github.com/BetterAngelsLA/monorepo/blob/main/apps/betterangels-backend/accounts/admin.py) unregisters `Organization`, `OrganizationUser` and `OrganizationInvitation` only), so django-organizations' default admin still lets a staff user delete an owner row outright. Same class of hole, third entry point — happy to fold it in.
- **`User.__str__` falls back to the pk** when there is no name, which is why the old message said `the user “934”`. Email would be the better fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Protect organization ownership across every account-deletion path and explain how ownership transfer resolves blocked deletions.

New Features:
- Add clear, organization-specific explanations and ownership-transfer links when account or membership deletion is blocked.

Bug Fixes:
- Prevent organization owners from being deleted through admin, bulk admin actions, account deletion, or the current-user GraphQL mutation.
- Prevent signed-in users from deleting their own accounts and ensure refused mobile deletions do not sign users out.
- Replace misleading missing-permission messages with protected-object explanations.

Enhancements:
- Centralize account deletion and ownership checks in shared services and selectors across all deletion entry points.

Tests:
- Add coverage for protected owner and self-deletion behavior across admin, service, web, and GraphQL flows.