### PR TITLE
cache CurrentUserType in ConsentModal (DEV-2529)

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -19,19 +19,13 @@ from organizations.models import Organization, OrganizationInvitation, Organizat
 from .forms import (
     OrganizationMemberInviteForm,
     OrganizationMemberRoleForm,
-    PermissionGroupInlineForm,
     OrganizationProfileForm,
+    PermissionGroupInlineForm,
     UserChangeForm,
     UserCreationForm,
 )
+from .models import ExtendedOrganizationInvitation, OrganizationProfile, PermissionGroup, PermissionGroupTemplate, User
 from .selectors import member_role_names, role_names_by_organization
-from .models import (
-    ExtendedOrganizationInvitation,
-    OrganizationProfile,
-    PermissionGroup,
-    PermissionGroupTemplate,
-    User,
-)
 from .services import (
     invitation_role,
     member_invite,
@@ -535,6 +529,15 @@ class UserAdmin(BaseUserAdmin):
     fieldsets = (
         (None, {"fields": ("email", "password")}),
         (("Personal info"), {"fields": ("first_name", "last_name", "middle_name")}),
+        (
+            ("Consent"),
+            {
+                "fields": (
+                    "has_accepted_tos",
+                    "has_accepted_privacy_policy",
+                ),
+            },
+        ),
         (
             ("Permissions"),
             {

--- a/libs/expo/betterangels/src/lib/ui-components/ConsentModal.tsx
+++ b/libs/expo/betterangels/src/lib/ui-components/ConsentModal.tsx
@@ -59,7 +59,29 @@ export default function ConsentModal({
   height = 'auto',
 }: IConsentModalProps) {
   const { setUser } = useUser();
-  const [updateCurrentUser] = useMutation(UpdateCurrentUserDocument);
+  const [updateCurrentUser] = useMutation(UpdateCurrentUserDocument, {
+    update: (cache) => {
+      // `updateCurrentUser` returns `UserType`, which Apollo normalizes under a
+      // DIFFERENT cache key than the `currentUser` query's `CurrentUserType`.
+      // Without writing the accepted flags into the `CurrentUserType` cache
+      // object, the next query re-render (e.g. after `UserProfileEdit` saves the
+      // name) would overwrite the context with the stale flags and flip
+      // `accepted` back to false.
+      const currentUserRef = cache.identify({
+        __typename: 'CurrentUserType',
+        id: user.id,
+      });
+      if (currentUserRef) {
+        cache.modify({
+          id: currentUserRef,
+          fields: {
+            hasAcceptedTos: () => checkedItems.isTosChecked,
+            hasAcceptedPrivacyPolicy: () => checkedItems.isPrivacyPolicyChecked,
+          },
+        });
+      }
+    },
+  });
   const [checkedItems, setCheckedItems] = useState<CheckedItems>({
     isTosChecked: false,
     isPrivacyPolicyChecked: false,
@@ -83,7 +105,6 @@ export default function ConsentModal({
       return;
     }
 
-    closeModal();
     setUser((prev) =>
       prev
         ? {
@@ -93,6 +114,16 @@ export default function ConsentModal({
           }
         : prev,
     );
+
+    // Accepting the agreements flips `accepted` to true, so this modal
+    // transitions in place to the "Complete Your Registration" name form when
+    // the user has no name yet. Only close it once registration is fully done
+    // (the user already has a name); otherwise the tabs layout re-opens the
+    // modal right after we close it — because it still needs the user's name —
+    // and the modal visibly renders again after submitting.
+    if (user.firstName && user.lastName) {
+      closeModal();
+    }
   };
 
   const { signOut } = useSignOut();


### PR DESCRIPTION
### Consent modal reopens after completed
DEV-2529

## Summary by Sourcery

Prevent consent state from becoming stale and keep the modal open only until the user's registration is complete.

Bug Fixes:
- Prevent the consent modal from reopening after agreements are accepted, including when registration details still need to be completed.
- Keep accepted consent flags synchronized in Apollo's current-user cache to prevent stale data from resetting the modal state.

Enhancements:
- Expose users' terms-of-service and privacy-policy consent fields in the Django admin.