### PR TITLE
use openNow filter query instead of openNowFor (DEV-2517)

### DIFF
--- a/libs/react/shelter/src/lib/components/ShelterSearch/SheltersDisplay.tsx
+++ b/libs/react/shelter/src/lib/components/ShelterSearch/SheltersDisplay.tsx
@@ -70,7 +70,7 @@ export function SheltersDisplay(props: TProps) {
       if (openNowFor && openNowFor.length > 0) {
         vars = vars || {};
         vars.filters = vars.filters || {};
-        vars.filters.openNowFor = openNowFor;
+        vars.filters.openNow = { scheduleType: openNowFor };
       }
 
       if (isAccessCenter) {


### PR DESCRIPTION
### update open_now_for filter and rename to open_now: FE
DEV-2517

* update FE to use `openNow` instead of `openNowFor`

```
// schema.graphql

input ShelterFilter {
  ...
  properties: ShelterPropertyInput
  openNowFor: [ScheduleTypeChoices!] @deprecated(reason: "Use openNow instead")
  openNow: OpenNowInput
  ...
}
```

## Summary by Sourcery

Bug Fixes:
- Update shelter search requests to use the supported `openNow` filter structure for schedule-based availability filtering.

## Summary by Sourcery

Bug Fixes:
- Update shelter search requests to apply schedule-based availability filtering through the supported `openNow` query structure.