### PR TITLE
test(teams): pin cross-org refusal at the mutation boundary (DEV-2567)

### DIFF
--- a/apps/betterangels-backend/teams/tests/test_mutations.py
+++ b/apps/betterangels-backend/teams/tests/test_mutations.py
@@ -5,7 +5,7 @@ from unittest_parametrize import parametrize
 
 from teams.models import Team
 
-from .utils import TeamGraphQLUtilsMixin
+from .utils import TeamGraphQLBaseTestCase, TeamGraphQLUtilsMixin
 
 
 class TeamMutationTestCase(TeamGraphQLUtilsMixin):
@@ -117,3 +117,51 @@ class TeamMutationTestCase(TeamGraphQLUtilsMixin):
             kind="VALIDATION",
         )
         self.assertTrue(Team.objects.filter(id=team.pk).exists())
+
+
+class TeamMutationOrgScopingTestCase(TeamGraphQLBaseTestCase):
+    """The write half of the org-managed-teams acceptance criterion.
+
+    ``test_queries.py`` covers reads.  These go through GraphQL rather than calling
+    ``team_get`` directly, because the resolver is where an org admin reaches the
+    rule: a selector test passes just as well with the ``organization=`` argument
+    dropped from the resolver's call.
+    """
+
+    def test_update_refuses_another_organizations_team(self) -> None:
+        original = self.org_2_team_1.name
+
+        response = self.update_team_fixture({"id": self.org_2_team_1.pk, "name": "renamed by org 1"})
+
+        self.assertGraphQLOperationInfo(
+            response,
+            "updateTeam",
+            "You do not have permission to update this team.",
+            kind="PERMISSION",
+        )
+        self.org_2_team_1.refresh_from_db()
+        self.assertEqual(self.org_2_team_1.name, original)
+
+    def test_delete_refuses_another_organizations_team(self) -> None:
+        response = self.delete_team_fixture(self.org_2_team_1.pk)
+
+        self.assertGraphQLOperationInfo(
+            response,
+            "deleteTeam",
+            "You do not have permission to delete this team.",
+            kind="PERMISSION",
+        )
+        self.assertTrue(Team.objects.filter(pk=self.org_2_team_1.pk).exists())
+
+    def test_create_refuses_an_organization_the_caller_holds_no_role_in(self) -> None:
+        """The header names the organization; it does not grant the right to write to it.
+
+        Refused a layer earlier than the other two -- ``HasOrgPerm`` never reaches the
+        resolver -- so this one surfaces as a GraphQL error rather than OperationInfo.
+        """
+        self._set_active_org(self.org_2)
+
+        response = self.create_team_fixture({"name": "planted by org 1"})
+
+        self.assertIsNotNone(response.get("errors"))
+        self.assertFalse(Team.objects.filter(name="planted by org 1").exists())


### PR DESCRIPTION
> Stacked on #2388 (which is stacked on #2379). Base retargets as those land. Test-only — no source changes.

## Why

`teams/tests/test_mutations.py` had **five tests and no cross-organization case**, on the mutations that are the whole point of handing teams to organizations.

`test_selectors.py::test_returns_none_for_another_organizations_team` covers `team_get`, but that test passes just as well with the `organization=` argument dropped from the *resolver's* call — and the resolver is the surface an org admin actually reaches. Pinning it at the selector leaves the boundary unpinned.

## Three cases, through GraphQL

Acting as an `org_1` admin against `org_2`'s team:

| Case | Refused by | Answers |
| --- | --- | --- |
| `updateTeam` on another org's team | `team_get` returning `None` in the resolver | `OperationInfo`, kind `PERMISSION` |
| `deleteTeam` on another org's team | same | `OperationInfo`, kind `PERMISSION` |
| `createTeam` with the header pointed at an org the caller holds no role in | `HasOrgPerm`, before the resolver | GraphQL error |

Asserted as they actually behave rather than uniformly — the third is refused a layer earlier, so it never produces an `OperationInfo`. I probed the real responses rather than guessing the shape.

Each also asserts the state did not move: the name is unchanged, the team still exists, no team was created.

## Mutation-tested

Replacing both `team_get(pk=data.id, organization=org)` calls with `Team.objects.filter(pk=data.id).first()` fails the update and delete cases.

`createTeam`'s case is not reachable by that mutation — it is `HasOrgPerm` that refuses — which is the point of covering all three separately.

## Testing

`71 passed` in `teams/`; full backend suite green; `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Pin organization scoping behavior for team mutations at the GraphQL boundary.

Enhancements:
- Add GraphQL coverage ensuring organization admins cannot update or delete another organization's team, or create a team in an organization where they have no role.

Tests:
- Add mutation-boundary tests covering cross-organization update, delete, and create refusal responses and verifying that team state remains unchanged.