### PR TITLE
fix(teams)!: the teams query requires the organization header (DEV-2556)

### DIFF
--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -5,12 +5,11 @@ from typing import Optional, cast
 import strawberry
 import strawberry_django
 from accounts.extensions import HasOrgPerm
-from accounts.selectors import organization_get_for_member, resolve_permission_group
+from accounts.selectors import organization_get_for_member
 from common.graphql.types import DeleteDjangoObjectInput, DeletedObjectType
 from common.permissions.utils import IsAuthenticated, get_current_organization
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
-from notes.groups import CASEWORKER
 from organizations.models import Organization
 from strawberry.types import Info
 from strawberry_django.auth.utils import get_current_user
@@ -30,15 +29,10 @@ class Query:
     )
     def teams(self, info: Info, filters: Optional[TeamFilter] = None) -> QuerySet[Team]:
         """List the active organization's teams, if the user is a member of it."""
-        org_id = info.context.request.organization_id
-
-        if org_id is None:
-            # App builds older than #2330 send no header; #2345 denies them
-            # once those builds have rolled over.
-            permission_group = resolve_permission_group(info.context.request.user, template=CASEWORKER)
-            return team_list(organization=permission_group.organization)
-
-        org = organization_get_for_member(user=get_current_user(info), organization_id=org_id)
+        org = organization_get_for_member(
+            user=get_current_user(info),
+            organization_id=get_current_organization(info),
+        )
 
         if org is None:
             raise PermissionDenied("You do not have access to this organization.")

--- a/apps/betterangels-backend/teams/tests/test_queries.py
+++ b/apps/betterangels-backend/teams/tests/test_queries.py
@@ -111,7 +111,18 @@ class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
         self.assertEqual(returned_ids, org_2_ids)
 
     def test_requires_the_active_org_header(self) -> None:
-        """The server must not guess — first-match is how other orgs leaked."""
+        """Belonging to one organization is not a licence to assume it.
+
+        The caller belongs to exactly one organization, which is the case both
+        discarded fallbacks would have served — first-match resolution, and
+        sole-organization adoption. So a denial here can only mean the server
+        requires the header.
+
+        The previous version of this test used a caller holding no Caseworker
+        group, so it was the *fallback erroring* that denied the request, not the
+        server refusing to guess. It passed with first-match fully intact.
+        """
+        self.assertEqual(self.org_1_admin.organizations_organization.count(), 1)
         del self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"]
 
         self._assert_denied(self.execute_graphql(self.get_teams_query()))

--- a/apps/betterangels-backend/teams/tests/test_queries.py
+++ b/apps/betterangels-backend/teams/tests/test_queries.py
@@ -111,17 +111,7 @@ class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
         self.assertEqual(returned_ids, org_2_ids)
 
     def test_requires_the_active_org_header(self) -> None:
-        """Belonging to one organization is not a licence to assume it.
-
-        The caller belongs to exactly one organization, which is the case both
-        discarded fallbacks would have served — first-match resolution, and
-        sole-organization adoption. So a denial here can only mean the server
-        requires the header.
-
-        The previous version of this test used a caller holding no Caseworker
-        group, so it was the *fallback erroring* that denied the request, not the
-        server refusing to guess. It passed with first-match fully intact.
-        """
+        """A caller who belongs to exactly one organization is still denied without the header."""
         self.assertEqual(self.org_1_admin.organizations_organization.count(), 1)
         del self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"]
 


### PR DESCRIPTION
Replaces #2345. **Breaking:** the `teams` query now requires `X-Organization-ID`.

> The branch name (`fix/teams-query-sole-org`) predates the approach — an earlier revision of this PR *adopted* the caller's sole organization. It deletes the fallback instead. See "Why deletion" below.

## The bug

With no `X-Organization-ID` header, the query resolved an organization through `resolve_permission_group(user, template=CASEWORKER)` — which is `.first()` on an **unordered** queryset. Two failures:

- A **multi-org caller** was served whichever organization the database returned first, i.e. potentially another organization's teams.
- An **Organization Admin who is not also a Caseworker** got `PermissionError: User does not hold a 'Caseworker' permission group in any organization` instead of their teams. That is exactly the persona the admin app's Teams page serves.

## Why deletion, not a better fallback

This was **the last headerless path in the API**. Verified rather than assumed:

- `get_current_organization` already raises `PermissionDenied` when the header is absent — and **all three team mutations in this same file already go through it**. The query was the odd one out.
- `teams/validators.py`'s `organization_id is None` branch is unrelated: a record with no organization, not a missing header.
- **`allow_implicit_org` does not exist on `main`.** It is #2310's unmerged compatibility mechanism, so the "remove the fallback once for the whole API" cleanup #2345's body promised is only needed *because #2310 would add it*. Deleting this now means that shim never has to exist for teams.
- `team_list` has exactly two callers, both inside this resolver. There is no internal headerless caller.

So the resolver collapses to the shape its neighbours already use, and `teams` stops importing a notes-domain role to answer a question about organizations:

```python
org = organization_get_for_member(
    user=get_current_user(info),
    organization_id=get_current_organization(info),
)
```

**5 insertions, 11 deletions.** The previous revision of this PR added ~40 lines including a new selector.

## `organization_get_sole_for_member` is deliberately not added

Adopting the caller's only organization is still the server deciding which organization a request meant. And nothing needs it:

- The active-org store's persistence is **synchronous by contract** (`ActiveOrgPersistence`, which is why the docstring rules out `AsyncStorage`), and expo backs it with MMKV. A cold start therefore reads the id *before* the first request, not after a round trip.
- `useActiveOrgState` reconciles during render rather than in an effect, so a provider has chosen an organization before any child queries.
- On web, `AuthProvider` additionally renders nothing until the user query has both settled and produced a user.

The only window with no persisted id is a genuine first sign-in, and team-picker screens mount after that resolves.

## Compatibility

Confirmed with @vecchp that no mobile build predating the header is in the field. The org header shipped to the mobile client in #2203 (2026-07-15) and was hardened in #2330 (2026-08-18). There is no minimum-version gate and no server-side logging of the header, so nothing in the repo could have answered this — hence the explicit check rather than an assumption.

## The test that was passing for the wrong reason

`test_requires_the_active_org_header` used a caller holding no Caseworker group, so the headerless request was denied by the fallback **erroring**, not by the server requiring the header. It would have gone on passing with first-match resolution fully intact.

It now asserts the caller belongs to exactly one organization *first* — the case **both** discarded fallbacks would have served — so a denial can only mean the header is required.

Mutation-tested against both discarded designs, and one test kills both:

| Mutation | Fails |
| --- | --- |
| reinstate first-match resolution | `test_requires_the_active_org_header` |
| reinstate sole-organization adoption | `test_requires_the_active_org_header` |

## Verification

- **1491 passed, 31 skipped** — full suite on a freshly created database. 51 in `teams/`.
- `mypy` clean over 387 files with the cache cleared; `ruff check` and `ruff format --check` clean.
- `export_schema` reproduces `schema.graphql` **byte-for-byte** — the SDL is unchanged, so the break is in behaviour, not in the schema, and needs no `graphql-inspector` label.

## Note

`Team.perms.VIEW` is still not enforced on this read, deliberately: `CASEWORKER` holds no `Team` permission at all, so gating the query on it would break every caseworker's team picker. Changing that means changing the template, which is its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Require an explicit active organization header when querying teams.

Bug Fixes:
- Require the teams query to use the active organization header, preventing organization selection from being guessed or resolved through an unrelated permission group.
- Update coverage to verify headerless requests are denied even when the caller belongs to exactly one organization.

Tests:
- Strengthen the teams query authorization test to distinguish mandatory-header enforcement from fallback permission errors.