### PR TITLE
chore(deps): upgrade date-fns to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@vis.gl/react-google-maps": "^1.7.1",
     "antd": "^6.3.1",
     "clsx": "^2.1.1",
-    "date-fns": "^3.6.0",
+    "date-fns": "^4.4.0",
     "dotenv": "^17.4.2",
     "embla-carousel-react": "^8.6.0",
     "expo": "~57.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5292,7 +5292,7 @@ __metadata:
     babel-preset-vite: "npm:^1.1.3"
     clsx: "npm:^2.1.1"
     core-js: "npm:3.36.1"
-    date-fns: "npm:^3.6.0"
+    date-fns: "npm:^4.4.0"
     dotenv: "npm:^17.4.2"
     dotenv-cli: "npm:^11.0.0"
     embla-carousel-react: "npm:^8.6.0"
@@ -15087,14 +15087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "date-fns@npm:3.6.0"
-  checksum: 10/cac35c58926a3b5d577082ff2b253612ec1c79eb6754fddef46b6a8e826501ea2cb346ecbd211205f1ba382ddd1f9d8c3f00bf433ad63cc3063454d294e3a6b8
-  languageName: node
-  linkType: hard
-
-"date-fns@npm:^4.1.0":
+"date-fns@npm:^4.1.0, date-fns@npm:^4.4.0":
   version: 4.4.0
   resolution: "date-fns@npm:4.4.0"
   checksum: 10/ae702acea42fb8452abe74f6d133c2360de9a14f00985645684b0df9c12280276649e95b52298a4fd7dabcc3b38799eb111107da99320d1cd94ba1d8a3d1c174


### PR DESCRIPTION
react-day-picker 9, which #2191 introduces, depends on `date-fns@^4.1.0`. On `^3.6.0` the lockfile resolves both majors and the bundle carries two copies of the same library. Moving the root to `^4.4.0` dedupes them to one.

Worth doing on its own — it removes the duplicate whether or not #2191 lands. Kept separate from #2191 because it touches a dependency shared by 20 files and the Expo app.

## Why this is a small upgrade

date-fns v4's breaking changes are type-only. From the release notes:

> a bunch of types changes that should not affect the library's expected usage. The changes are primarily internal and nuanced, so rather than listing them here, I recommend you running the type checker after the upgrade.

The other change is ESM-first packaging. Beyond that:

- Every function this repo imports still exists in v4 — `addDays`, `format`, `formatDistanceToNow`, `hoursToMilliseconds`, `isSameDay`, `isToday`, `isValid`, `minutesToMilliseconds`, `parse`, `parseISO`, `setHours`, `setMinutes`, `startOfDay`, `startOfMonth`, `startOfWeek`, `startOfYear`, `subDays`, `differenceInCalendarDays`, `addMonths`, `subMonths`.
- Nothing imports `date-fns/esm` or `date-fns-tz`; every call site is a plain `from 'date-fns'`.
- Running v3 and v4 side by side over the format strings actually used here — `yyyy-MM-dd`, `EEEE`, `MMM d`, `h:mmaaa`, `MM/dd/yyyy`, `h:mm a`, `hh:mm a`, `M/d/yy` — plus `parse`, `parseISO` and `formatDistanceToNow`, produced identical output in every case.

## Verification

Typechecked and tested every project that imports date-fns, against a v4 install:

| project | result |
|---|---|
| `libs/shared/scalars` | tsc clean · 98 tests |
| `libs/expo/betterangels` | tsc clean · 153 tests |
| `libs/react/shelter-operator` | tsc clean · 65 tests |
| `libs/react/shelter` | 64 tests |
| `libs/react/betterangels-admin` | no test files |

`libs/react/shelter` and `libs/react/betterangels-admin` report a pre-existing `TS6307` project-reference error about `libs/apollo` under both v3 and v4 — unrelated to this change.

The lockfile ends with a single `date-fns` entry (`4.4.0`); the diff is 10 lines.

## Note for reviewers

The Expo app is the place to watch, since v4 is ESM-first and Metro `exports`-map resolution is where RN projects usually trip. Its library suite passes; a device/simulator bundle would be worth a sanity check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Upgrade date-fns to v4 and deduplicate the dependency across the projects.

Enhancements:
- Upgrade the root date-fns dependency to v4 to consolidate the dependency tree and eliminate duplicate bundled copies.

Chores:
- Refresh the lockfile to resolve a single date-fns 4.4.0 entry.