### PR TITLE
fix(permissions): org-scope every write PermissionedQuerySet guards (DEV-2567)

### DIFF
--- a/apps/betterangels-backend/accounts/extensions.py
+++ b/apps/betterangels-backend/accounts/extensions.py
@@ -24,7 +24,7 @@ from collections.abc import Callable
 from typing import Any
 
 from accounts.models import Organization
-from common.permissions.utils import permissioned_queryset
+from common.permissions.utils import permissioned_queryset, require_organization_id
 from strawberry.types import Info
 from strawberry_django.permissions import (
     DjangoNoPermission,
@@ -75,11 +75,7 @@ class HasOrgPerm(HasPerm):
         if not user or not user.is_authenticated:
             raise DjangoNoPermission("Authentication required.")
 
-        org_id_raw = info.context.request.organization_id
-
-        if org_id_raw is None:
-            raise DjangoNoPermission("Organization ID (X-Organization-ID header) is required.")
-        org_id = str(org_id_raw)
+        org_id = require_organization_id(info)
 
         if not self.perms:
             raise DjangoNoPermission("No permissions specified for this operation.")

--- a/apps/betterangels-backend/common/graphql/extensions.py
+++ b/apps/betterangels-backend/common/graphql/extensions.py
@@ -1,7 +1,10 @@
-import inspect
-from typing import Any, Callable, Optional, Type, Union
+from functools import reduce
+from operator import or_
+from typing import Any, Callable, Optional, Sequence, Type, Union
 
-from django.db.models import Model, QuerySet
+from common.permissions.utils import require_organization_id
+from django.db.models import Model, Q, QuerySet
+from django.db.models.constants import LOOKUP_SEP
 from strawberry.types.info import Info
 from strawberry_django.auth.utils import get_current_user
 from strawberry_django.permissions import (
@@ -15,18 +18,23 @@ from strawberry_django.utils.query import filter_for_user
 
 
 class PermissionedQuerySet(HasRetvalPerm):
-    """
-    Injects a permission-filtered QuerySet into info.context.qs.
+    """Injects an org-scoped, permission-filtered QuerySet into ``info.context.qs``.
 
-    The queryset is pre-filtered via ``filter_for_user`` so that only
-    objects the user has the required permissions on are accessible.
+    Object permissions and the active organization are both applied; see
+    "Org-owned vs platform-shared" in ``docs/permissions.md`` for why one
+    without the other does not confine a write.
 
-    The parent ``HasRetvalPerm`` return-value permission check is skipped
-    because some mutations return a different type than the queryset model
-    (e.g. ``create_note_service_request`` checks Note CHANGE but returns a
-    ``ServiceRequestType``).  Mutations that need cross-org protection
-    must catch ``DoesNotExist`` from ``qs.get()`` and raise a
-    ``PermissionDenied`` explicitly.
+    Because ``resolve_for_user_with_perms`` never calls ``super()``, the
+    parent's ``target`` dispatch never runs; the argument is accepted only to
+    keep the signature compatible with the base class.
+
+    Parameters
+    ----------
+    organization_field : str | Sequence[str] | None
+        Field path(s) from *model* to the owning organization —
+        ``"organization_id"`` for a direct FK, ``"note__organization_id"``
+        for an indirect one.  Several paths are OR'd together.  ``None``
+        opts out, and means the records are shared across organizations.
     """
 
     def __init__(
@@ -34,6 +42,7 @@ class PermissionedQuerySet(HasRetvalPerm):
         perms: Union[list[str], str],
         *,
         model: Type[Model],
+        organization_field: Union[str, Sequence[str], None],
         message: Optional[str] = None,
         use_directives: bool = True,
         target: Optional[PermTarget] = None,
@@ -45,7 +54,10 @@ class PermissionedQuerySet(HasRetvalPerm):
     ) -> None:
         super().__init__(
             perms=perms,
-            message=message,
+            # Strawberry's default ("You don't have permission to access this
+            # app.") names neither the record nor the organization.  Match
+            # HasOrgPerm so a client gets the same denial either way.
+            message=message or "You do not have permission to perform this action in this organization.",
             use_directives=use_directives,
             fail_silently=False,
             target=target,
@@ -57,9 +69,33 @@ class PermissionedQuerySet(HasRetvalPerm):
         )
         self.model = model
 
+        if organization_field is None:
+            self.organization_fields: Optional[list[str]] = None
+        elif isinstance(organization_field, str):
+            self.organization_fields = [organization_field]
+        else:
+            self.organization_fields = list(organization_field)
+            if not self.organization_fields:
+                raise ValueError("organization_field must name at least one path, or be None to opt out.")
+
     def _prepare_qs(self, info: Info) -> QuerySet[Model]:
         user = get_current_user(info)
-        qs: QuerySet[Model] = filter_for_user(self.model.objects.all(), user, self.permissions)  # type: ignore
+        qs: QuerySet[Model] = filter_for_user(self.model._default_manager.all(), user, self.permissions)
+
+        if self.organization_fields is None:
+            return qs
+
+        org_id = require_organization_id(info)
+
+        org_q = reduce(or_, (Q(**{f: org_id}) for f in self.organization_fields))
+
+        if any(LOOKUP_SEP in f for f in self.organization_fields):
+            # A traversal may be multi-valued, so join duplicates have to stay
+            # inside the subquery or a later .get() raises MultipleObjectsReturned.
+            qs = qs.filter(pk__in=self.model._default_manager.filter(org_q).values("pk"))
+        else:
+            qs = qs.filter(org_q)
+
         return qs
 
     def resolve_for_user_with_perms(
@@ -70,41 +106,16 @@ class PermissionedQuerySet(HasRetvalPerm):
         info: Info,
         source: Any,
     ) -> Any:
-        """Skip the return-value permission check.
+        """Prepare the queryset, then skip the return-value permission check.
 
-        Some mutations return a different type than ``self.model`` (e.g.
-        ``ServiceRequestType`` while checking ``NotePermissions.CHANGE``).
-        The standard ``HasRetvalPerm`` check would always fail on the
-        mismatched type.  Instead, mutations enforce access control via
-        ``qs.get()`` with an explicit ``DoesNotExist → PermissionDenied``.
+        The queryset is built here rather than in a ``resolve`` override so a
+        denial raises inside the frame strawberry-django catches it in.
         """
         if user is None:
             # DjangoNoPermission is the strawberry-django internal signal;
             # PermissionDenied would bypass the framework's error handling.
             raise DjangoNoPermission
+
+        info.context.qs = self._prepare_qs(info)
+
         return resolver()
-
-    def resolve(
-        self,
-        next_: Callable[..., Any],
-        source: Any,
-        info: Info,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
-        info.context.qs = self._prepare_qs(info)
-        return super().resolve(next_, source, info, *args, **kwargs)
-
-    async def resolve_async(
-        self,
-        next_: Callable[..., Any],
-        source: Any,
-        info: Info,
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
-        info.context.qs = self._prepare_qs(info)
-        result = super().resolve_async(next_, source, info, *args, **kwargs)
-        if inspect.isawaitable(result):
-            result = await result  # type: ignore
-        return result

--- a/apps/betterangels-backend/common/graphql/utils.py
+++ b/apps/betterangels-backend/common/graphql/utils.py
@@ -1,11 +1,24 @@
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from strawberry import ID, Maybe
+from strawberry.types import Info
 
-from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist, PermissionDenied
 from django.db.models import Model, QuerySet
 
 T = TypeVar("T", bound=Model)
+
+
+def permissioned_qs(info: Info, model: type[T]) -> QuerySet[T]:
+    """Return the queryset ``PermissionedQuerySet`` prepared for this resolver."""
+    qs = info.context.qs
+
+    if qs.model is not model:
+        raise ImproperlyConfigured(
+            f"PermissionedQuerySet is configured for {qs.model.__name__}, but the resolver expects {model.__name__}."
+        )
+
+    return cast(QuerySet[T], qs)
 
 
 def get_object_or_permission_error(

--- a/apps/betterangels-backend/common/permissions/utils.py
+++ b/apps/betterangels-backend/common/permissions/utils.py
@@ -6,13 +6,14 @@ from typing import Any, Sequence, Tuple, Type, TypeVar
 
 import strawberry
 from django.contrib.auth.models import AbstractBaseUser, Group
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import Exists, Model, OuterRef, Q, QuerySet, TextChoices
 from django.utils.encoding import force_str
 from guardian.shortcuts import assign_perm
 from organizations.models import Organization
 from strawberry.types import Info
 from strawberry_django.auth.utils import get_current_user
+from strawberry_django.permissions import DjangoNoPermission
 
 from common.errors import UnauthenticatedGQLError
 
@@ -233,6 +234,26 @@ def get_current_organization(info: Info) -> str:
 
     if org_id is None:
         raise PermissionDenied("Organization ID (X-Organization-ID header) is required.")
+
+    return str(org_id)
+
+
+def require_organization_id(info: Info) -> str:
+    """Return the active organization ID, for use *inside a permission extension*.
+
+    Raises ``DjangoNoPermission``, which strawberry-django only catches around
+    ``resolve_for_user``.  Resolver *bodies* want ``get_current_organization``.
+    """
+    org_id = info.context.request.organization_id
+    if org_id is None:
+        raise DjangoNoPermission("Organization ID (X-Organization-ID header) is required.")
+
+    # A client-supplied header need not be a usable primary key; unvalidated it
+    # raises ValueError from inside the query rather than reading as a denial.
+    try:
+        Organization._meta.pk.to_python(org_id)
+    except ValidationError:
+        raise DjangoNoPermission("Organization ID (X-Organization-ID header) is not a valid organization ID.")
 
     return str(org_id)
 

--- a/apps/betterangels-backend/common/tests/permission_fixtures.py
+++ b/apps/betterangels-backend/common/tests/permission_fixtures.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for the organization-scoping tests."""
+
+from types import SimpleNamespace
+from typing import Any, Optional
+
+from accounts.models import User
+from django.contrib.auth.models import Permission
+from model_bakery import baker
+
+
+def stub_info(user: Optional[User] = None, organization_id: Any = None) -> Any:
+    """Minimum shape the org-scoping code reads: ``info.context.request``."""
+    return SimpleNamespace(
+        context=SimpleNamespace(
+            request=SimpleNamespace(user=user, organization_id=organization_id),
+        )
+    )
+
+
+def user_with_global_perm(perm: str) -> User:
+    """A user holding *perm* model-wide, the way the guardian fallback grants it."""
+    app_label, codename = perm.split(".", 1)
+    user = baker.make(User, is_active=True)
+    user.user_permissions.add(
+        Permission.objects.get(content_type__app_label=app_label, codename=codename),
+    )
+    return user

--- a/apps/betterangels-backend/common/tests/test_graphql_extensions.py
+++ b/apps/betterangels-backend/common/tests/test_graphql_extensions.py
@@ -1,0 +1,155 @@
+"""Organization scoping in ``PermissionedQuerySet`` (``common/graphql/extensions.py``).
+
+These exercise ``_prepare_qs`` directly rather than through GraphQL so the
+organization filter can be isolated from the object-permission filter that
+runs alongside it.
+
+Each user here is granted the permission **globally** — no guardian object
+permissions at all.  That is not a contrivance: it is the shape that makes
+the org filter necessary.  ``filter_for_user`` OR's in
+``Exists(user.user_permissions ...)``, so a global grant matches every row in
+the table regardless of who owns it.  Object permissions alone therefore do
+not confine a write to one organization, and whatever narrowing these tests
+observe is the organization filter's doing and nothing else.
+
+End-to-end coverage of the same behaviour, including the denial a client
+actually sees, lives with the mutations in ``notes`` and ``referrals``.
+"""
+
+from typing import Any
+
+from accounts.tests.baker_recipes import organization_recipe
+from common.graphql.extensions import PermissionedQuerySet
+from common.tests.permission_fixtures import stub_info, user_with_global_perm
+from django.test import TestCase
+from model_bakery import baker
+from notes.models import Note, ServiceRequest
+from notes.permissions import NotePermissions, ServiceRequestPermissions
+from strawberry_django.permissions import DjangoNoPermission
+
+
+class PermissionedQuerySetOrgScopingTestCase(TestCase):
+    def setUp(self) -> None:
+        self.org_1 = organization_recipe.make(name="pqs_org_1")
+        self.org_2 = organization_recipe.make(name="pqs_org_2")
+
+        self.user = user_with_global_perm(NotePermissions.CHANGE)
+
+        self.note_1 = baker.make(Note, organization=self.org_1)
+        self.note_2 = baker.make(Note, organization=self.org_2)
+
+    def _prepare(self, extension: PermissionedQuerySet, organization_id: Any) -> Any:
+        return extension._prepare_qs(stub_info(self.user, organization_id))
+
+    def test_scopes_to_the_active_organization(self) -> None:
+        extension = PermissionedQuerySet(
+            model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id"
+        )
+
+        qs = self._prepare(extension, self.org_1.pk)
+
+        self.assertEqual(list(qs), [self.note_1])
+
+    def test_opting_out_leaves_every_organization_visible(self) -> None:
+        """``organization_field=None`` is the deliberate shared-layer escape hatch."""
+        extension = PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field=None)
+
+        qs = self._prepare(extension, self.org_1.pk)
+
+        self.assertCountEqual(qs, [self.note_1, self.note_2])
+
+    def test_opting_out_does_not_require_the_header(self) -> None:
+        extension = PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field=None)
+
+        qs = self._prepare(extension, None)
+
+        self.assertCountEqual(qs, [self.note_1, self.note_2])
+
+    def test_missing_header_denies_when_scoped(self) -> None:
+        extension = PermissionedQuerySet(
+            model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id"
+        )
+
+        with self.assertRaises(DjangoNoPermission):
+            self._prepare(extension, None)
+
+    def test_malformed_header_denies_when_scoped(self) -> None:
+        """A header that is not a usable primary key must deny, not explode.
+
+        Left unvalidated it reaches the ORM inside the filter and raises
+        ``ValueError: Field 'id' expected a number but got 'not-an-id'`` from
+        within the query, which escapes as an unhandled error rather than the
+        extension's denial.
+        """
+        extension = PermissionedQuerySet(
+            model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id"
+        )
+
+        with self.assertRaises(DjangoNoPermission):
+            list(self._prepare(extension, "not-an-id"))
+
+    def test_rejects_an_empty_field_list(self) -> None:
+        """An empty list would silently scope to nothing; ``None`` is the way to opt out."""
+        with self.assertRaises(ValueError):
+            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field=[])
+
+
+class PermissionedQuerySetMultiPathTestCase(TestCase):
+    """ServiceRequest reaches its organization through two reverse m2m paths."""
+
+    ORG_FIELDS = ["provided_notes__organization_id", "requested_notes__organization_id"]
+
+    def setUp(self) -> None:
+        self.org_1 = organization_recipe.make(name="pqs_multi_org_1")
+        self.org_2 = organization_recipe.make(name="pqs_multi_org_2")
+        self.user = user_with_global_perm(ServiceRequestPermissions.DELETE)
+
+        self.note_1 = baker.make(Note, organization=self.org_1)
+        self.note_2 = baker.make(Note, organization=self.org_2)
+
+        self.provided = baker.make(ServiceRequest)
+        self.note_1.provided_services.add(self.provided)
+
+        self.requested = baker.make(ServiceRequest)
+        self.note_1.requested_services.add(self.requested)
+
+        self.other_org = baker.make(ServiceRequest)
+        self.note_2.provided_services.add(self.other_org)
+
+    def _prepare(self, organization_id: Any) -> Any:
+        extension = PermissionedQuerySet(
+            model=ServiceRequest,
+            perms=[ServiceRequestPermissions.DELETE],
+            organization_field=self.ORG_FIELDS,
+        )
+        return extension._prepare_qs(stub_info(self.user, organization_id))
+
+    def test_matches_on_either_path(self) -> None:
+        qs = self._prepare(self.org_1.pk)
+
+        self.assertCountEqual(qs, [self.provided, self.requested])
+
+    def test_excludes_another_organizations_service_request(self) -> None:
+        self.assertNotIn(self.other_org, self._prepare(self.org_1.pk))
+
+    def test_a_service_request_on_several_notes_appears_once(self) -> None:
+        """The org filter LEFT JOINs both m2m tables, so a service request
+        reachable through more than one note comes back once per matching
+        join row.  Without ``.distinct()`` a later ``.get()`` raises
+        ``MultipleObjectsReturned`` — a 500 on a request that should succeed.
+
+        One note on each *side* is not enough to trigger it (1 x 1 = 1 row);
+        it takes two matches on the same side.  ``note_service_request_create``
+        makes one service request per note today, so this is not reachable
+        through the API yet — but the m2m permits it and
+        ``ServiceRequest.get_note_id`` is written in anticipation of it.
+        """
+        shared = baker.make(ServiceRequest)
+        other_note = baker.make(Note, organization=self.org_1)
+        self.note_1.provided_services.add(shared)
+        other_note.provided_services.add(shared)
+
+        qs = self._prepare(self.org_1.pk)
+
+        self.assertEqual(list(qs).count(shared), 1)
+        self.assertEqual(qs.get(pk=shared.pk), shared)

--- a/apps/betterangels-backend/common/tests/test_graphql_utils.py
+++ b/apps/betterangels-backend/common/tests/test_graphql_utils.py
@@ -1,0 +1,33 @@
+"""Tests for ``common.graphql.utils``."""
+
+from types import SimpleNamespace
+from typing import Any
+
+from common.graphql.utils import permissioned_qs
+from django.core.exceptions import ImproperlyConfigured
+from django.test import SimpleTestCase
+from notes.models import Note
+from tasks.models import Task
+
+
+class PermissionedQsTestCase(SimpleTestCase):
+    """``permissioned_qs`` is the only reader of the queryset the extension injects."""
+
+    @staticmethod
+    def _info(**context: Any) -> Any:
+        return SimpleNamespace(context=SimpleNamespace(**context))
+
+    def test_returns_the_queryset_the_extension_prepared(self) -> None:
+        qs = Note.objects.all()
+
+        self.assertIs(permissioned_qs(self._info(qs=qs), Note), qs)
+
+    def test_rejects_a_queryset_for_another_model(self) -> None:
+        """The mismatch an annotation cannot catch: the extension names Note,
+        the resolver expects Task, and every lookup silently misses."""
+        with self.assertRaises(ImproperlyConfigured):
+            permissioned_qs(self._info(qs=Note.objects.all()), Task)
+
+    def test_a_missing_extension_raises_attribute_error(self) -> None:
+        with self.assertRaises(AttributeError):
+            permissioned_qs(self._info(), Note)

--- a/apps/betterangels-backend/common/tests/test_permissions_utils.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_utils.py
@@ -1,0 +1,31 @@
+"""Organization context helpers in ``common/permissions/utils.py``."""
+
+from common.permissions.utils import require_organization_id
+from common.tests.permission_fixtures import stub_info
+from django.test import TestCase
+from strawberry_django.permissions import DjangoNoPermission
+
+
+class RequireOrganizationIdTestCase(TestCase):
+    def test_returns_a_string_id(self) -> None:
+        self.assertEqual(require_organization_id(stub_info(organization_id="42")), "42")
+
+    def test_coerces_a_non_string_id(self) -> None:
+        """The middleware reads a header, but tests and other callers pass ints."""
+        self.assertEqual(require_organization_id(stub_info(organization_id=42)), "42")
+
+    def test_raises_when_the_header_is_absent(self) -> None:
+        with self.assertRaises(DjangoNoPermission) as ctx:
+            require_organization_id(stub_info(organization_id=None))
+
+        self.assertIn("X-Organization-ID", str(ctx.exception))
+
+    def test_never_returns_the_string_none(self) -> None:
+        """Regression: ``str(None)`` used to reach queryset filters as ``"None"``.
+
+        That is not a valid organization id, so the request failed anyway —
+        but as ``ValueError: Field 'id' expected a number but got 'None'``,
+        an unhandled 500 rather than a denial.
+        """
+        with self.assertRaises(DjangoNoPermission):
+            require_organization_id(stub_info(organization_id=None))

--- a/apps/betterangels-backend/docs/permissions.md
+++ b/apps/betterangels-backend/docs/permissions.md
@@ -193,3 +193,91 @@ The frontend `hasPermission()` helper checks across all domains with O(1) lookup
 - `shelters/permissions.py` is a 3-line bridge that delegates to `Shelter.perms.as_text_choices()` for GraphQL schema generation — `model.perms` is the single source of truth.
 - The old `AdminShelterManager`/`AdminShelterQuerySet` and `Shelter.admin_objects` manager were removed — they've been replaced by `permissioned_queryset()` + selectors + `HasOrgPerm`, which provide the same org-scoping in a single, shared function.
 - The `adminShelters`/`adminShelter` GraphQL queries have been renamed to `operatorShelters`/`operatorShelter` and `AdminShelterType` → `OperatorShelterType` to reflect their role as operator-facing endpoints.
+
+## Org-owned vs platform-shared
+
+- **Org-owned**: teams, members, reports, shelter operations, and
+  note/task **writes** (header-driven via `HasOrgPerm`).
+- **Platform-shared by design**: client profiles, note/task **reads**
+  (orgs coordinate on shared clients and see cross-org interactions).
+
+### Where a mutation declares which one it is
+
+Every `PermissionedQuerySet` takes a **required** `organization_field`:
+
+```python
+extensions=[
+    PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE],
+                         organization_field="organization_id"),   # org-owned
+]
+```
+
+`None` opts out and means the records are deliberately shared. Because the
+argument is required, adding a mutation forces an answer, and reviewing one
+means reading the decorator rather than hunting for a filter in the body.
+
+This replaced a hand-written `.filter(organization_id=...)` in each resolver.
+Four of eleven call sites did not have it — `generateNoteFileUploads`,
+`resolveNoteFileUploads`, `deleteServiceRequest` and `updateReferral` — so
+those records could be written while the caller's active organization was a
+different one than the record's owner. Guardian grants object permissions to
+the permission group that *created* the record, and that grant says nothing
+about the header, so nothing else was confining them.
+
+### Why the org filter is load-bearing, and what it is not
+
+It is **not** compensating for guardian's global fallback in the usual case:
+in practice `CASEWORKER` does not hold `notes.change_note` globally, so
+`filter_for_user` already refuses a stranger's note.
+
+What it does confine is the **multi-org caller**. Object permissions follow
+the record's creating group, so a user who legitimately reaches a record
+through org A can act on it while their active organization header says org
+B. Without the filter, the action is accepted and attributed to the wrong
+organization.
+
+The global fallback is still a real hazard wherever a template *does* grant a
+model-level permission — it makes `filter_for_user` match every row in the
+table. Retiring it means auditing which templates grant model-level
+permissions, deciding per model whether it is shared or org-owned, and dropping
+the fallback so `filter_for_user` cannot match rows the caller holds no object
+grant on. The required `organization_field` is what makes that mechanical, since
+every call site's intended layer is now written down. Until it lands, that
+filter is the only thing standing between a model-level grant and every row in
+its table.
+
+### Outstanding: mutations that still resolve the org by first match
+
+`resolve_permission_group(user, template=...)` called without an organization id
+picks whichever `PermissionGroup` the database returns first, so for a multi-org
+caller it can pick the wrong organization. Still doing that:
+
+| Call site | Consequence |
+| --- | --- |
+| `notes/schema.py` — four sites, including `create_note` and `import_note` | a note, or the object permissions granted for it, can be attributed to the wrong organization |
+| `tasks/schema.py` `create_task` | same, for tasks |
+| `referrals/schema.py` `create_referral` | a referral can be attributed to the wrong organization |
+| `clients/schema.py` `create_client_document`, and `clients/services/client_document.py` | document *ownership* on upload is first-match, so "shared read, org-owned write" is not guaranteed for client documents |
+| `hmis/schema.py` `create_hmis_note_service_request` | same |
+
+The org filter this document describes confines which records a write may
+*reach*; it does not decide which organization the write is *attributed* to.
+That is what these nine call sites still get wrong, and it is a separate change:
+make `organization_id` required on `resolve_permission_group` so the guessing
+branch cannot be reached, and pass `get_current_organization(info)` at each site.
+
+### Accepted risk: cross-org delete of a client profile
+
+`delete_client_profile` filters on `ClientProfile.perms.DELETE`, which
+`CASEWORKER` holds globally, and `Note.client_profile` is `on_delete=CASCADE`.
+So a caseworker in any organization can delete a shared client profile, and
+doing so **also deletes every other organization's notes** for that client —
+note rows are org-owned, so this destroys data outside the deleting
+organization's own layer. (`Task.client_profile` is `SET_NULL`, so tasks survive
+with no client, which is its own inconsistency.)
+
+Left as-is deliberately: clients are shared and there is no ownership concept,
+and changing delete rights now would change app behaviour. Recorded here so it
+is a known risk rather than a surprise. The cheapest mitigations that preserve
+today's rights are soft-deleting the profile, or `PROTECT`ing the cascade when
+another organization holds notes.

--- a/apps/betterangels-backend/notes/schema.py
+++ b/apps/betterangels-backend/notes/schema.py
@@ -167,7 +167,9 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE])],
+        extensions=[
+            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id")
+        ],
     )
     def update_note(self, info: Info, data: UpdateNoteInput) -> NoteType:
         user = cast(User, get_current_user(info))
@@ -194,7 +196,9 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE])],
+        extensions=[
+            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id")
+        ],
     )
     def update_note_location(self, info: Info, data: UpdateNoteLocationInput) -> NoteType:
         qs: QuerySet[Note] = info.context.qs
@@ -207,7 +211,9 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE])],
+        extensions=[
+            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id")
+        ],
     )
     def revert_note(self, info: Info, data: RevertNoteInput) -> NoteType:
         qs: QuerySet[Note] = info.context.qs
@@ -232,7 +238,7 @@ class Mutation:
         permission_classes=[IsAuthenticated],
         extensions=[
             HasPerm(ServiceRequestPermissions.ADD),
-            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE]),
+            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id"),
         ],
     )
     def create_note_service_request(self, info: Info, data: CreateNoteServiceRequestInput) -> ServiceRequestType:
@@ -259,7 +265,13 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[PermissionedQuerySet(model=ServiceRequest, perms=[ServiceRequestPermissions.DELETE])],
+        extensions=[
+            PermissionedQuerySet(
+                model=ServiceRequest,
+                perms=[ServiceRequestPermissions.DELETE],
+                organization_field=["provided_notes__organization_id", "requested_notes__organization_id"],
+            )
+        ],
     )
     def delete_service_request(self, info: Info, data: DeleteDjangoObjectInput) -> DeletedObjectType:
         """
@@ -376,7 +388,7 @@ class Mutation:
         permission_classes=[IsAuthenticated],
         extensions=[
             HasPerm(Attachment.perms.ADD),
-            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE]),
+            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id"),
         ],
     )
     def generate_note_file_uploads(
@@ -405,7 +417,7 @@ class Mutation:
         permission_classes=[IsAuthenticated],
         extensions=[
             HasPerm(Attachment.perms.ADD),
-            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE]),
+            PermissionedQuerySet(model=Note, perms=[NotePermissions.CHANGE], organization_field="organization_id"),
         ],
     )
     def resolve_note_file_uploads(

--- a/apps/betterangels-backend/referrals/schema.py
+++ b/apps/betterangels-backend/referrals/schema.py
@@ -80,7 +80,9 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[PermissionedQuerySet(model=Referral, perms=[Referral.perms.CHANGE])],
+        extensions=[
+            PermissionedQuerySet(model=Referral, perms=[Referral.perms.CHANGE], organization_field="organization_id")
+        ],
     )
     def update_referral(self, info: Info, data: UpdateReferralInput) -> ReferralType:
         qs: QuerySet[Referral] = info.context.qs

--- a/apps/betterangels-backend/tasks/schema.py
+++ b/apps/betterangels-backend/tasks/schema.py
@@ -86,7 +86,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[PermissionedQuerySet(model=Task, perms=[Task.perms.CHANGE])],
+        extensions=[PermissionedQuerySet(model=Task, perms=[Task.perms.CHANGE], organization_field="organization_id")],
     )
     def update_task(self, info: Info, data: UpdateTaskInput) -> TaskType:
         qs: QuerySet[Task] = info.context.qs

--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -5,12 +5,11 @@ from typing import Optional, cast
 import strawberry
 import strawberry_django
 from accounts.extensions import HasOrgPerm
-from accounts.selectors import organization_get_for_member, resolve_permission_group
+from accounts.selectors import organization_get_for_member
 from common.graphql.types import DeleteDjangoObjectInput, DeletedObjectType
 from common.permissions.utils import IsAuthenticated, get_current_organization
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
-from notes.groups import CASEWORKER
 from organizations.models import Organization
 from strawberry.types import Info
 from strawberry_django.auth.utils import get_current_user
@@ -30,15 +29,10 @@ class Query:
     )
     def teams(self, info: Info, filters: Optional[TeamFilter] = None) -> QuerySet[Team]:
         """List the active organization's teams, if the user is a member of it."""
-        org_id = info.context.request.organization_id
-
-        if org_id is None:
-            # App builds older than #2330 send no header; #2345 denies them
-            # once those builds have rolled over.
-            permission_group = resolve_permission_group(info.context.request.user, template=CASEWORKER)
-            return team_list(organization=permission_group.organization)
-
-        org = organization_get_for_member(user=get_current_user(info), organization_id=org_id)
+        org = organization_get_for_member(
+            user=get_current_user(info),
+            organization_id=get_current_organization(info),
+        )
 
         if org is None:
             raise PermissionDenied("You do not have access to this organization.")

--- a/apps/betterangels-backend/teams/tests/test_queries.py
+++ b/apps/betterangels-backend/teams/tests/test_queries.py
@@ -111,7 +111,18 @@ class TeamQueryOrgScopingTestCase(TeamGraphQLBaseTestCase):
         self.assertEqual(returned_ids, org_2_ids)
 
     def test_requires_the_active_org_header(self) -> None:
-        """The server must not guess — first-match is how other orgs leaked."""
+        """Belonging to one organization is not a licence to assume it.
+
+        The caller belongs to exactly one organization, which is the case both
+        discarded fallbacks would have served — first-match resolution, and
+        sole-organization adoption. So a denial here can only mean the server
+        requires the header.
+
+        The previous version of this test used a caller holding no Caseworker
+        group, so it was the *fallback erroring* that denied the request, not the
+        server refusing to guess. It passed with first-match fully intact.
+        """
+        self.assertEqual(self.org_1_admin.organizations_organization.count(), 1)
         del self.graphql_client.defaults["HTTP_X_ORGANIZATION_ID"]
 
         self._assert_denied(self.execute_graphql(self.get_teams_query()))


### PR DESCRIPTION
> Stacked on #2390. Base retargets to `main` when that lands.

Rebuilt replacement for #2310. **No longer breaking**, and 12 files instead of 29.

## The hole

`PermissionedQuerySet` filtered by object permissions only. Guardian grants those to the permission group that *created* a record, and that grant says nothing about which organization the caller is currently acting as. So a multi-org user who legitimately reached a record through org A could act on it while their header said org B — and **four of the nine call sites had no compensating `.filter(organization_id=...)` in the resolver body at all**: `generateNoteFileUploads`, `resolveNoteFileUploads`, `deleteServiceRequest`, `updateReferral`.

## What this does

`organization_field` becomes a **required** argument on `PermissionedQuerySet` — a field path for an org-owned endpoint, or `None` to declare it deliberately platform-shared.

Making it required is what makes this reviewable: adding a mutation forces an answer, and mypy rejects a call site that omits one. Nine sites declare it. `ServiceRequest` has no organization foreign key, so it names the two paths it reaches one through:

```python
organization_field=["provided_notes__organization_id", "requested_notes__organization_id"]
```

A multi-valued traversal is filtered via `pk__in` on a subquery, so join duplicates stay inside it and a later `.get()` cannot raise `MultipleObjectsReturned`.

`require_organization_id` raises `DjangoNoPermission`, which strawberry-django catches around `resolve_for_user` — resolver *bodies* keep `get_current_organization`. It also validates that a client-supplied header is a usable primary key; unvalidated, a junk header raised `ValueError` from inside the query rather than reading as a denial.

`docs/permissions.md` gains the org-owned vs platform-shared model.

## Why this is a rebuild, not a rebase

#2310 carried 36 commits that are largely earlier forms of work since merged — `git rebase --onto` conflicts on commit 1 of 36. So this compares **trees, not histories**, the same way #2312 was rebuilt. An in-memory `git merge-tree` against #2390 showed 14 of 29 files conflicting, all clustered where the four teams PRs already changed things.

Comparing trees showed what was actually left, and two things dropped out:

- **`allow_implicit_org` — 30 mentions.** The entire compatibility shim. Pointless now: no pre-header builds are live, and #2390 made the last headerless fallback strict. #2310's own body called `grep -rn allow_implicit_org` "the removal list" — so this deletes deliberately temporary code before it ever shipped. **Dropping it is why this PR is no longer breaking.**
- **`active_organization` and `permission_group_for_request`** — both would have shipped unused here. The latter belongs with the de-guessing change below.

Verified that taking whole files reverted nothing: `git diff 9e1ea0ced origin/main` is empty for every file taken wholesale, so `main` has not touched them since #2310 forked.

## Deliberately not included

**The nine call sites that still resolve the *attributed* organization by first match.** The org filter here confines which records a write may *reach*; it does not decide which organization the write is *recorded against*. `docs/permissions.md` now names all nine — #2310's version listed only three, because it assumed its own notes/tasks fix had landed. The follow-up makes `organization_id` required on `resolve_permission_group` so the guessing branch cannot be reached at all.

**Moving `createNote` / `createTask` / `importNote` to `HasOrgPerm`.** Tried, then backed out: `HasOrgPerm` denies with a **raw GraphQL error** where `HasPerm` returned a structured `OperationInfo` with a `PERMISSION` message. The outcome is right either way (denied, nothing created), but that is an error-surface regression on three mutations and deserves its own decision rather than riding along in a rebuild. It cost 10 test updates when attempted.

## Verification

- **1507 passed, 31 skipped** (#2390's branch is at 1491, so +16 — this PR's own new tests). `mypy` clean over 391 files with the cache cleared; `ruff check` and `ruff format --check` clean.
- No schema change.

Mutation-tested:

| Mutation | Fails |
| --- | --- |
| the extension ignores its declared `organization_field` | **5** |
| `organization_field=[]` instead of `None` | the empty-list test — an empty list would silently scope to nothing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce active-organization boundaries across permissioned mutation querysets while preserving deliberate platform-shared access.

Bug Fixes:
- Scope permission-filtered mutation querysets to the caller’s active organization, preventing cross-organization writes through object-permission access.
- Treat missing or invalid organization headers as structured permission denials instead of unhandled query errors.

Enhancements:
- Require every PermissionedQuerySet to explicitly declare an organization field or opt into platform-shared behavior, including support for indirect multi-path organization ownership.
- Add queryset/model validation and document the organization-owned versus platform-shared permission model.

Documentation:
- Document org-scoped mutation behavior, remaining organization-attribution risks, and known cross-organization client deletion risk.

Tests:
- Add coverage for organization scoping, shared-resource opt-out, invalid headers, multi-path relationships, duplicate prevention, and queryset/model mismatches.