### PR TITLE
fix(clients): scope client document deletes to ClientProfile attachments

### DIFF
--- a/apps/betterangels-backend/clients/admin.py
+++ b/apps/betterangels-backend/clients/admin.py
@@ -366,9 +366,6 @@ class ClientDocumentAdmin(ExportActionMixin, admin.ModelAdmin):
     def get_export_formats(self) -> list:
         return [CSV]
 
-    def get_queryset(self, request: HttpRequest) -> QuerySet[ClientDocument]:
-        return super().get_queryset(request).filter(content_type__model="clientprofile")
-
     def get_search_results(self, request: HttpRequest, queryset: QuerySet, search_term: str) -> tuple[QuerySet, bool]:
         queryset, use_distinct = super().get_search_results(request, queryset, search_term)
 

--- a/apps/betterangels-backend/clients/models.py
+++ b/apps/betterangels-backend/clients/models.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from typing import Any, List, Optional, cast
+from typing import Any, ClassVar, List, Optional, cast
 
 import pghistory
 from betterangels_backend import settings
@@ -254,8 +254,15 @@ class ClientProfile(OrgScoped, AbstractClientProfile):
         ordering = ["first_name"]
 
 
+class ClientDocumentManager(models.Manager["ClientDocument"]):
+    def get_queryset(self) -> QuerySet["ClientDocument"]:
+        return super().get_queryset().filter(content_type__app_label="clients", content_type__model="clientprofile")
+
+
 class ClientDocument(Attachment):
-    """This is here to allow for a separate admin interface for Client Documents"""
+    """An Attachment hanging off a ClientProfile. Note attachments share the table and are excluded."""
+
+    objects: ClassVar[ClientDocumentManager] = ClientDocumentManager()
 
     class Meta:
         proxy = True

--- a/apps/betterangels-backend/clients/schema.py
+++ b/apps/betterangels-backend/clients/schema.py
@@ -7,6 +7,7 @@ from accounts.models import User
 from clients.enums import ErrorCodeEnum
 from clients.models import (
     ClientContact,
+    ClientDocument,
     ClientHouseholdMember,
     ClientProfile,
     ClientProfileDataImport,
@@ -594,11 +595,11 @@ class Mutation:
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
         extensions=[
-            PermissionedQuerySet(model=Attachment, perms=[Attachment.perms.DELETE]),
+            PermissionedQuerySet(model=ClientDocument, perms=[Attachment.perms.DELETE]),
         ],
     )
     def delete_client_document(self, info: Info, data: DeleteDjangoObjectInput) -> ClientDocumentType:
-        qs: QuerySet[Attachment] = info.context.qs
+        qs: QuerySet[ClientDocument] = info.context.qs
         client_document = get_object_or_permission_error(
             qs, data.id, error_message="You do not have permission to delete this document."
         )

--- a/apps/betterangels-backend/clients/tests/test_permissions.py
+++ b/apps/betterangels-backend/clients/tests/test_permissions.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from unittest.mock import patch
 
+from accounts.selectors import resolve_permission_group
 from clients.enums import ClientDocumentNamespaceEnum, GenderEnum, HmisAgencyEnum, LanguageEnum
 from clients.models import ClientContact, ClientHouseholdMember, ClientProfile, HmisProfile, SocialMediaProfile
 from clients.tests.utils import (
@@ -10,8 +11,15 @@ from clients.tests.utils import (
     HmisProfileBaseTestCase,
     SocialMediaProfileBaseTestCase,
 )
+from common.enums import AttachmentType
 from common.models import Attachment
+from common.permissions.utils import assign_object_permissions
 from common.services.s3 import PresignedS3UploadBatchResult, PresignedS3UploadResult
+from django.contrib.contenttypes.models import ContentType
+from django.core.files.uploadedfile import SimpleUploadedFile
+from model_bakery import baker
+from notes.groups import CASEWORKER
+from notes.models import Note
 from unittest_parametrize import parametrize
 
 
@@ -269,6 +277,34 @@ class ClientDocumentPermissionTestCase(ClientProfileGraphQLBaseTestCase):
 
         self.assertGraphQLUnauthenticated(response)
         self.assertTrue(Attachment.objects.filter(id=client_document_id).exists())
+
+    def test_delete_client_document_refuses_a_note_attachment(self) -> None:
+        """Note attachments share the Attachment table and grant the same group DELETE."""
+        note = baker.make(Note, organization=self.org_1)
+        note_attachment = Attachment.objects.create(
+            file=SimpleUploadedFile(name="note.txt", content=b"note attachment"),
+            attachment_type=AttachmentType.DOCUMENT,
+            content_type=ContentType.objects.get_for_model(Note),
+            object_id=note.pk,
+            uploaded_by=self.org_1_case_manager_1,
+        )
+        assign_object_permissions(
+            resolve_permission_group(self.org_1_case_manager_1, template=CASEWORKER),
+            note_attachment,
+            [Attachment.perms.DELETE],
+        )
+
+        self._handle_user_login("org_1_case_manager_1")
+        response = self._delete_client_document_fixture(str(note_attachment.pk))
+
+        self.assertGraphQLOperationInfo(
+            response,
+            "deleteClientDocument",
+            "You do not have permission to delete this document.",
+            kind="PERMISSION",
+            exact=True,
+        )
+        self.assertTrue(Attachment.objects.filter(id=note_attachment.pk).exists())
 
     @parametrize(
         "user_label, should_succeed",


### PR DESCRIPTION
> Stacked on #2387, which is where the mutation gets its `PermissionedQuerySet`. Base retargets to `main` when that lands.

## Why

`deleteClientDocument` resolves its target from **every `Attachment` the caller holds DELETE on**, with nothing tying it to client documents.

Note attachments are rows in the same table, and `resolve_note_file_uploads` assigns `Attachment.perms.DELETE` on each one to the organization's CASEWORKER group. So a caseworker can pass a note attachment's id to `deleteClientDocument` and it is deleted — through an endpoint named, typed (`ClientDocumentType`) and documented for client documents.

Not a permission bypass: the caller genuinely holds DELETE on that row. It is the domain boundary that is missing. Worth noting there is no `deleteNoteAttachment` mutation at all, so this is currently the only attachment-delete path in the schema.

This is not a regression from #2387 — `main` uses `mutations.delete(...) + HasRetvalPerm(perms=Attachment.perms.DELETE)`, which resolves the `Attachment` by pk with the same absent scoping. Identical reach before and after. Found by @tglaz reviewing #2387.

## The fix scopes the model, not the resolver

`clients/models.py` already has a `ClientDocument` proxy of `Attachment`, added so the admin could have its own page. It carried no scoping, which is why `ClientDocumentAdmin` filtered `content_type__model="clientprofile"` by hand.

Its manager now applies that filter, so the proxy means *an `Attachment` hanging off a `ClientProfile`*:

```python
class ClientDocumentManager(models.Manager["ClientDocument"]):
    def get_queryset(self) -> QuerySet["ClientDocument"]:
        return super().get_queryset().filter(content_type__app_label="clients", content_type__model="clientprofile")
```

The mutation then only changes which model the extension is given — the resolver body is untouched apart from a narrower annotation:

```diff
-            PermissionedQuerySet(model=Attachment, perms=[Attachment.perms.DELETE]),
+            PermissionedQuerySet(model=ClientDocument, perms=[Attachment.perms.DELETE]),
```

and **`ClientDocumentAdmin.get_queryset` is deleted**, because the scoping it duplicated now lives on the model. Every future caller inherits it rather than needing its own filter.

The lookup form rather than `ContentType.objects.get_for_model(ClientProfile)` keeps `get_queryset` free of a database call and matches what the admin was already doing; `app_label` is included so it cannot match another app's `clientprofile`.

### Two things that look risky and are not

**Object permissions still resolve.** The proxy's own `app_label`/`model_name` are `clients`/`clientdocument`, while the permission is `common.delete_attachment` — but `strawberry_django.utils.query.filter_for_user_q` reassigns `model = model._meta.concrete_model` before resolving the ContentType. Checked by generating both querysets and comparing: the permission subquery is byte-identical (`content_type_id = 1`, `codename = delete_attachment`).

**Related-object fetching is untouched.** A filtered default manager would be a problem if it were also the base manager. `Meta.base_manager_name` is unset, so Django builds `_base_manager` from a plain `Manager`:

```
Attachment.objects           WHERE: <no WHERE>
ClientDocument.objects       WHERE: (app_label = clients AND model = clientprofile)
ClientDocument._base_manager WHERE: <no WHERE>
```

## Scope

- The only caller is `DocumentModal.tsx` on the Client screen, which passes client document ids. No client uses this field for note attachments.
- Nothing is stranded: `Note.attachments` is a `GenericRelation`, so note attachments still cascade with their note. They simply stop being individually deletable, which matches the fact that no endpoint or UI offers that today.
- `ClientDocumentResource` and the admin export now inherit the scoping, which is the intent.

## Testing

`test_delete_client_document_refuses_a_note_attachment` builds a note attachment, grants the caseworker group DELETE on it exactly as `resolve_note_file_uploads` does, and asserts the mutation refuses it and the row survives.

Mutation-tested: dropping the filter from the manager fails that test and nothing else.

- **474 passed** across `clients` and `notes` on an isolated database, `mypy` clean over 387 files with the cache cleared, `ruff` clean.
- `makemigrations --check` — no changes detected. A manager is not schema.
- `export_schema` reproduces `schema.graphql` exactly — this changes which rows resolve, not the field signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Scope client document attachment operations to ClientProfile records so shared note attachments cannot be targeted by the client document deletion endpoint.

Bug Fixes:
- Restrict client document deletion to attachments associated with ClientProfile records, preventing note attachments from being deleted through the client document mutation.

Enhancements:
- Centralize ClientDocument attachment scoping in its model manager and reuse it across the mutation, admin, and export queries.

Tests:
- Add coverage verifying that users with DELETE permission on note attachments cannot delete them through the client document mutation.