### PR TITLE
feat(permissions): grant authorization selectors + write services (ADR 0001 §2.4/§2.9) (DEV-2553)

### DIFF
--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -20,10 +20,12 @@ from organizations.models import Organization, OrganizationOwner, OrganizationUs
 from .emails import base_url_for
 from .groups import ORG_ADMIN
 from .models import (
+    Grant,
     OrganizationProfile,
     OrgTypeChoices,
     PermissionGroup,
     PermissionGroupTemplate,
+    Role,
 )
 from .models import User as UserModel
 from .role_manager import OrgRoleManager
@@ -609,3 +611,41 @@ def backfill_global_role_members() -> None:
     for group in groups.prefetch_related("user_set"):
         for user in group.user_set.all():
             user.groups.add(role)
+
+
+# ── Grant write services (ADR 0001 §2.10) ────────────────────────────────
+
+
+def grant_create(*, user: UserModel, role: Role, scope_org: Organization) -> Grant:
+    """Grant *user* the scoped *role* at *scope_org* (ADR 0001 §2.2).
+
+    Validates via ``full_clean`` (which checks the model constraints since
+    Django 4.1) before saving, per the repo styleguide.
+    """
+    from accounts.models import Grant
+
+    grant = Grant(principal_user=user, role=role, scope_org=scope_org)
+    grant.full_clean()
+    grant.save()
+    return grant
+
+
+def grant_delete(*, grant: Grant) -> None:
+    """Revoke a scoped grant — the audit trail is pghistory's, not a flag."""
+    grant.delete()
+
+
+def role_assign(*, user: UserModel, role: Role) -> None:
+    """Add *user* to a *global* Role's group — the global tier (ADR 0001 §2.1).
+
+    Scoped roles are never placed in ``user.groups`` (checks ``permissions.E001``);
+    they are granted through a ``Grant`` instead.
+    """
+    if not role.is_global:
+        raise ValidationError(f"Role {role.name!r} is scoped; grant it via grant_create, not user.groups.")
+    user.groups.add(role)
+
+
+def role_remove(*, user: UserModel, role: Role) -> None:
+    """Remove *user* from a global Role's group."""
+    user.groups.remove(role)

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -622,8 +622,6 @@ def grant_create(*, user: UserModel, role: Role, scope_org: Organization) -> Gra
     Validates via ``full_clean`` (which checks the model constraints since
     Django 4.1) before saving, per the repo styleguide.
     """
-    from accounts.models import Grant
-
     grant = Grant(principal_user=user, role=role, scope_org=scope_org)
     grant.full_clean()
     grant.save()

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -634,10 +634,33 @@ def grant_delete(*, grant: Grant) -> None:
 
 
 def role_assign(*, user: UserModel, role: Role) -> None:
-    """Add *user* to a *global* Role's group — the global tier (ADR 0001 §2.1).
+    """Grant *user* a *global* Role by adding it to ``user.groups``.
 
-    Scoped roles are never placed in ``user.groups`` (checks ``permissions.E001``);
-    they are granted through a ``Grant`` instead.
+    .. warning::
+       **GLOBAL AUTHORITY — read before calling.** This is the global tier
+       (ADR 0001 §2.1): once *role* is in ``user.groups``, *user* can exercise
+       every permission *role* carries **across every organization**, with no
+       org scope and no per-org audit row.  It is the highest-authority write
+       in this module — prefer an org-scoped ``Grant`` (via :func:`grant_create`)
+       unless the user genuinely needs org-wide access.
+
+       Today the only *intended* writers of the global tier are the Django
+       admin's group picker and provisioning (:func:`backfill_global_role_members`).
+       This service has **no production caller yet** — add one deliberately
+       (e.g. an admin/member-management flow), never "because it is handy".
+
+    Constraints:
+
+    * *role* **must** be a global Role (``is_global=True``).  Scoped roles are
+      exercised exclusively through ``Grant`` rows — never group membership
+      (checks ``permissions.E001``) — so a scoped *role* raises
+      ``ValidationError`` instead of silently becoming global.
+    * Granting is additive and idempotent (Django M2M); revoke with
+      :func:`role_remove`.  Membership is visible in the Django admin and in
+      ``user.groups``.
+
+    Raises:
+        ``django.core.exceptions.ValidationError`` when *role* is scoped.
     """
     if not role.is_global:
         raise ValidationError(f"Role {role.name!r} is scoped; grant it via grant_create, not user.groups.")
@@ -645,5 +668,10 @@ def role_assign(*, user: UserModel, role: Role) -> None:
 
 
 def role_remove(*, user: UserModel, role: Role) -> None:
-    """Remove *user* from a global Role's group."""
+    """Revoke a *global* Role from *user* — the mirror of :func:`role_assign`.
+
+    Removes *role* from ``user.groups``, withdrawing its global-tier authority.
+    Scoped roles are never in ``user.groups`` (they are granted via ``Grant``),
+    so removing one here is a no-op rather than an error.
+    """
     user.groups.remove(role)

--- a/apps/betterangels-backend/accounts/tests/test_grant_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_grant_services.py
@@ -1,0 +1,58 @@
+"""Tests for the grant write services (ADR 0001 §2.10)."""
+
+from accounts.models import Grant, Role, User
+from accounts.services import grant_create, grant_delete, role_assign, role_remove, sync_roles
+from accounts.tests.baker_recipes import organization_recipe
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from model_bakery import baker
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
+
+
+class GrantServiceTestCase(TestCase):
+    def setUp(self) -> None:
+        sync_roles()
+        self.org = organization_recipe.make(name="Grant Service Org")
+        self.shelter_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
+        self.gso_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
+        self.user = baker.make(User)
+
+    def test_grant_create_grants_a_scoped_role(self) -> None:
+        grant = grant_create(user=self.user, role=self.shelter_role, scope_org=self.org)
+
+        self.assertEqual(grant.principal_user, self.user)
+        self.assertEqual(grant.role, self.shelter_role)
+        self.assertEqual(grant.scope_org, self.org)
+        self.assertIsNone(grant.principal_org)
+        self.assertIsNone(grant.scope_object_type)
+
+    def test_grant_create_validates_before_saving(self) -> None:
+        with self.assertRaises(ValidationError):
+            grant_create(user=self.user, role=self.shelter_role, scope_org=None)  # type: ignore[arg-type]
+
+        self.assertFalse(Grant.objects.filter(principal_user=self.user).exists())
+
+    def test_grant_delete_revokes(self) -> None:
+        grant = grant_create(user=self.user, role=self.shelter_role, scope_org=self.org)
+
+        grant_delete(grant=grant)
+
+        self.assertFalse(Grant.objects.filter(pk=grant.pk).exists())
+
+    def test_role_assign_adds_a_global_role(self) -> None:
+        role_assign(user=self.user, role=self.gso_role)
+
+        self.assertTrue(self.user.groups.filter(role__is_global=True).exists())
+
+    def test_role_assign_refuses_a_scoped_role(self) -> None:
+        with self.assertRaises(ValidationError):
+            role_assign(user=self.user, role=self.shelter_role)
+
+        self.assertFalse(self.user.groups.exists())
+
+    def test_role_remove_removes_a_global_role(self) -> None:
+        role_assign(user=self.user, role=self.gso_role)
+
+        role_remove(user=self.user, role=self.gso_role)
+
+        self.assertFalse(self.user.groups.filter(role__is_global=True).exists())

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -1,0 +1,134 @@
+"""Read-side authorization selectors (ADR 0001 §2.4, §2.10).
+
+Pull-only: given a user, a permission, and a queryset, return the rows the user
+may exercise that permission on.  Follows the repo's service/selector pattern
+(docs/styleguides/python.md): no side effects; memoized per request on the user
+instance, mirroring ``ModelBackend._perm_cache``.
+
+The global tier is read explicitly (superuser, global Role in ``user.groups``,
+``user_permissions``) — NOT ``user.has_perm`` — until the legacy
+``PermissionGroup`` rows (which pollute ``has_perm``) are gone; it collapses to
+``has_perm`` at teardown.
+"""
+
+from __future__ import annotations
+
+from functools import reduce
+from operator import or_
+from typing import TYPE_CHECKING, Any
+
+from django.db.models import Q, Subquery
+
+if TYPE_CHECKING:
+    from accounts.models import User
+    from django.db.models import Model, QuerySet
+
+ALL = object()
+"""Sentinel for the global tier — row-invariant, so ``visible`` hoists it."""
+
+
+def _perm_parts(perm: str) -> tuple[str, str]:
+    app_label, codename = perm.split(".", 1)
+    return app_label, codename
+
+
+def _global_role_holds(user: "User", perm: str) -> bool:
+    """Whether *user* holds *perm* at the global tier through a global Role."""
+    app_label, codename = _perm_parts(perm)
+    return user.groups.filter(
+        role__is_global=True,
+        role__permissions__content_type__app_label=app_label,
+        role__permissions__codename=codename,
+    ).exists()
+
+
+def _user_permission_holds(user: "User", perm: str) -> bool:
+    """Whether *user* holds *perm* directly via ``user_permissions``."""
+    app_label, codename = _perm_parts(perm)
+    return user.user_permissions.filter(content_type__app_label=app_label, codename=codename).exists()
+
+
+def _roles_carrying_perm(perm: str) -> "QuerySet":
+    """Scoped ``Role`` ids that carry *perm* — the roles a Grant may reference."""
+    app_label, codename = _perm_parts(perm)
+    from accounts.models import Role
+
+    return Role.objects.filter(
+        is_global=False,
+        permissions__content_type__app_label=app_label,
+        permissions__codename=codename,
+    ).values("pk")
+
+
+def scopes(user: "User", perm: str) -> Any:
+    """``ALL``, or the org ids where *user* holds *perm* through a scoped Grant.
+
+    Memoized per request on the user instance.  The cached value is a lazy
+    queryset used as a subquery — caching it does not evaluate it.
+    """
+    if user.is_superuser or _global_role_holds(user, perm) or _user_permission_holds(user, perm):
+        return ALL
+
+    from accounts.models import Grant
+
+    cache = user.__dict__.setdefault("_scope_cache", {})
+    if perm not in cache:
+        roles = _roles_carrying_perm(perm)
+        cache[perm] = Grant.objects.filter(principal_user=user, role__in=Subquery(roles)).values("scope_org")
+    return cache[perm]
+
+
+def visible(qs: "QuerySet", user: "User", perm: str, *, in_org: str | None = None) -> "QuerySet":
+    """The rows of *qs* on which *user* may exercise *perm*.
+
+    * ``ALL`` (global tier) — the queryset, unconfined.
+    * platform-shared model (``org_via = None``) — all rows when *user* holds
+      *perm* anywhere, none otherwise.
+    * org-scoped model — rows whose org is in *user*'s scopes.
+    * model not declared ``OrgScoped`` — fails closed (no rows).
+
+    *in_org* confines the view to one organization, and only for finite scopes —
+    a global holder is never org-confined by a stale header (ADR 0001 §2.4).
+    """
+    from common.models import OrgScoped
+
+    if not issubclass(qs.model, OrgScoped):
+        return qs.none()
+
+    paths = qs.model.org_paths()
+    s = scopes(user, perm)
+
+    if s is ALL:
+        qs = qs
+    elif not paths:
+        # platform-shared: perm held anywhere (finite s) ⇒ all rows
+        qs = qs if s.exists() else qs.none()
+    elif s:
+        qs = qs.filter(reduce(or_, (Q(**{f"{p}__in": s}) for p in paths)))
+    else:
+        qs = qs.none()
+
+    if in_org is not None and s is not ALL and paths:
+        qs = qs.filter(reduce(or_, (Q(**{p: in_org}) for p in paths)))
+    return qs
+
+
+def can(user: "User", perm: str, *, org: Any) -> bool:
+    """Authority in an organization — the check for creates, which have no row yet."""
+    from accounts.models import Grant
+
+    s = scopes(user, perm)
+    if s is ALL:
+        return True
+    return Grant.objects.filter(scope_org=org, scope_org__in=Subquery(s)).exists()
+
+
+def can_obj(user: "User", perm: str, obj: "Model") -> bool:
+    """The single-row check *is* the row filter, applied to one row."""
+    return visible(obj.__class__._base_manager.filter(pk=obj.pk), user, perm).exists()
+
+
+def can_anywhere(user: "User", perm: str) -> bool:
+    """Authority anywhere — the check for creates on platform-shared models."""
+    s = scopes(user, perm)
+    return s is ALL or s.exists()

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -63,6 +63,11 @@ def _roles_carrying_perm(perm: str) -> "QuerySet":
 def scopes(user: "User", perm: str) -> Any:
     """``ALL``, or the org ids where *user* holds *perm* through a scoped Grant.
 
+    Direct user grants only at this stage — org→org delegation is deliberately
+    absent here and lands with the delegation PR (ADR 0001 §2.4).  Object grants
+    (``scope_org`` NULL) are excluded so they can never register as an org scope
+    or as "holds the perm somewhere" for a platform-shared model.
+
     Memoized per request on the user instance.  The cached value is a lazy
     queryset used as a subquery — caching it does not evaluate it.
     """
@@ -74,7 +79,9 @@ def scopes(user: "User", perm: str) -> Any:
     cache = user.__dict__.setdefault("_scope_cache", {})
     if perm not in cache:
         roles = _roles_carrying_perm(perm)
-        cache[perm] = Grant.objects.filter(principal_user=user, role__in=Subquery(roles)).values("scope_org")
+        cache[perm] = Grant.objects.filter(
+            principal_user=user, role__in=Subquery(roles), scope_org__isnull=False
+        ).values("scope_org")
     return cache[perm]
 
 
@@ -124,7 +131,15 @@ def can(user: "User", perm: str, *, org: Any) -> bool:
 
 
 def can_obj(user: "User", perm: str, obj: "Model") -> bool:
-    """The single-row check *is* the row filter, applied to one row."""
+    """The single-row check *is* the row filter, applied to one row.
+
+    WARNING (finding C1): on a platform-shared model (``org_via = None``)
+    ``visible`` applies the read rule — "holds the perm anywhere ⇒ all rows" —
+    so ``can_obj`` currently returns True for *every* row to any perm-holder.
+    Do not route platform-shared single-row *writes* through this until the C1
+    fix (object arm + fail-closed ``can_obj``) lands; until then it is the
+    org-scoped row filter only.
+    """
     return visible(obj.__class__._base_manager.filter(pk=obj.pk), user, perm).exists()
 
 

--- a/apps/betterangels-backend/common/tests/test_permissions_selectors.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_selectors.py
@@ -1,0 +1,125 @@
+"""Tests for the read-side authorization selectors (ADR 0001 §2.4, §2.10)."""
+
+from accounts.models import Role, User
+from accounts.services import grant_create, role_assign, sync_roles
+from accounts.tests.baker_recipes import organization_recipe
+from common.permissions.selectors import ALL, can, can_anywhere, can_obj, scopes, visible
+from django.test import TestCase
+from model_bakery import baker
+from notes.models import Note
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
+from shelters.models import Shelter
+from shelters.tests.baker_recipes import shelter_recipe
+
+
+class GrantSelectorsTestCase(TestCase):
+    def setUp(self) -> None:
+        sync_roles()
+        self.org_a = organization_recipe.make(name="Selectors Org A")
+        self.org_b = organization_recipe.make(name="Selectors Org B")
+        self.shelter_a = shelter_recipe.make(organization=self.org_a)
+        self.shelter_b = shelter_recipe.make(organization=self.org_b)
+        self.shelter_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
+        self.gso_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
+
+    def test_org_scoped_user_sees_only_their_org(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+
+        qs = visible(Shelter.objects.all(), alice, Shelter.perms.VIEW)
+
+        self.assertIn(self.shelter_a.pk, list(qs.values_list("pk", flat=True)))
+        self.assertNotIn(self.shelter_b.pk, list(qs.values_list("pk", flat=True)))
+
+    def test_global_role_holder_sees_everything(self) -> None:
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+
+        qs = visible(Shelter.objects.all(), gso, Shelter.perms.VIEW)
+
+        self.assertEqual(set(qs.values_list("pk", flat=True)), {self.shelter_a.pk, self.shelter_b.pk})
+
+    def test_superuser_sees_everything(self) -> None:
+        admin = baker.make(User, is_superuser=True)
+
+        qs = visible(Shelter.objects.all(), admin, Shelter.perms.VIEW)
+
+        self.assertEqual(set(qs.values_list("pk", flat=True)), {self.shelter_a.pk, self.shelter_b.pk})
+
+    def test_user_without_any_grant_sees_nothing(self) -> None:
+        stranger = baker.make(User)
+
+        self.assertFalse(visible(Shelter.objects.all(), stranger, Shelter.perms.VIEW).exists())
+
+    def test_in_org_confines_only_finite_scopes(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+
+        # Scoped user is confined by in_org to that org.
+        self.assertFalse(visible(Shelter.objects.all(), alice, Shelter.perms.VIEW, in_org=str(self.org_b.pk)).exists())
+        # A global holder is never confined by a stale header (ADR 0001 §2.4).
+        self.assertEqual(
+            set(
+                visible(Shelter.objects.all(), gso, Shelter.perms.VIEW, in_org=str(self.org_a.pk)).values_list(
+                    "pk", flat=True
+                )
+            ),
+            {self.shelter_a.pk, self.shelter_b.pk},
+        )
+
+    def test_platform_shared_model_is_visible_to_any_holder(self) -> None:
+        """ClientProfile (org_via=None) is platform-shared: any holder sees all."""
+        from clients.models import ClientProfile
+
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)  # carries view_clientprofile
+        baker.make(ClientProfile)
+        baker.make(ClientProfile)
+
+        self.assertEqual(visible(ClientProfile.objects.all(), alice, ClientProfile.perms.VIEW).count(), 2)
+
+    def test_unscoped_model_fails_closed(self) -> None:
+        """A model not yet declared OrgScoped is reachable by no one through visible()."""
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+
+        self.assertFalse(visible(Note.objects.all(), gso, Note.perms.VIEW).exists())
+
+    def test_scopes_is_memoized_per_request(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+
+        s = scopes(alice, Shelter.perms.VIEW)
+
+        self.assertIsNot(s, ALL)
+        self.assertIn("_scope_cache", alice.__dict__)
+        self.assertIs(scopes(alice, Shelter.perms.VIEW), s)
+
+    def test_can_checks_authority_in_an_org(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+
+        self.assertTrue(can(alice, Shelter.perms.VIEW, org=self.org_a))
+        self.assertFalse(can(alice, Shelter.perms.VIEW, org=self.org_b))
+        self.assertTrue(can(gso, Shelter.perms.VIEW, org=self.org_b))
+
+    def test_can_obj_is_the_row_filter_on_one_row(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+
+        self.assertTrue(can_obj(alice, Shelter.perms.VIEW, self.shelter_a))
+        self.assertFalse(can_obj(alice, Shelter.perms.VIEW, self.shelter_b))
+
+    def test_can_anywhere_holds_for_platform_shared_creates(self) -> None:
+        from clients.models import ClientProfile
+
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+        stranger = baker.make(User)
+
+        self.assertTrue(can_anywhere(alice, ClientProfile.perms.VIEW))
+        self.assertFalse(can_anywhere(stranger, ClientProfile.perms.VIEW))

--- a/apps/betterangels-backend/common/tests/test_permissions_selectors.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_selectors.py
@@ -4,6 +4,8 @@ from accounts.models import Role, User
 from accounts.services import grant_create, role_assign, sync_roles
 from accounts.tests.baker_recipes import organization_recipe
 from common.permissions.selectors import ALL, can, can_anywhere, can_obj, scopes, visible
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from model_bakery import baker
 from notes.models import Note
@@ -38,6 +40,29 @@ class GrantSelectorsTestCase(TestCase):
         qs = visible(Shelter.objects.all(), gso, Shelter.perms.VIEW)
 
         self.assertEqual(set(qs.values_list("pk", flat=True)), {self.shelter_a.pk, self.shelter_b.pk})
+
+    def test_narrower_global_role_composes_per_perm(self) -> None:
+        """A global Role carrying only VIEW sees everything for VIEW, nothing for CHANGE.
+
+        Global roles compose per-permission (ADR 0001 §2.2) — authority is the
+        union of the held perms, so a read-only global role is never amplified to
+        the write perms it does not carry.
+        """
+        viewer = baker.make(User)
+        role = Role.objects.create(name="Global Shelter Viewer", is_global=True)
+        view_perm, _ = Permission.objects.get_or_create(
+            content_type=ContentType.objects.get_for_model(Shelter),
+            codename=Shelter.perms.VIEW.split(".")[1],
+            defaults={"name": "Can view shelter"},
+        )
+        role.permissions.add(view_perm)
+        viewer.groups.add(role)
+
+        self.assertEqual(
+            set(visible(Shelter.objects.all(), viewer, Shelter.perms.VIEW).values_list("pk", flat=True)),
+            {self.shelter_a.pk, self.shelter_b.pk},
+        )
+        self.assertFalse(visible(Shelter.objects.all(), viewer, Shelter.perms.CHANGE).exists())
 
     def test_superuser_sees_everything(self) -> None:
         admin = baker.make(User, is_superuser=True)


### PR DESCRIPTION
## Summary

Third PR of the grant-based authorization redesign. **Stacks on #2410** (`perm/grant-roles`). Implements the predicate as **selectors** and the write side as **services**, per `docs/styleguides/python.md` (HackSoft service/selector pattern — pinned in ADR 0001 §2.9).

## What's in this PR

- **`common/permissions/selectors.py`** (read side, pull-only):
  - `scopes(user, perm)` — `ALL` sentinel or the org ids where the user holds the perm via scoped `Grant`s; memoized per request on the user instance.
  - `visible(qs, user, perm, *, in_org=None)` — the permission-aware queryset. Global tier hoists (unconfined); platform-shared models (`org_via=None`) show all rows to any holder; org-scoped models filter by `org_paths()`; models not yet declared `OrgScoped` fail closed. `in_org` confines **only finite scopes** — a global holder is never org-confined by a stale header (ADR §2.4).
  - `can(user, perm, *, org)` / `can_obj(user, perm, obj)` / `can_anywhere(user, perm)` — read-only authorization checks for services/API.
  - The global tier is read explicitly (superuser, global Role in `user.groups`, `user_permissions`) — **not** `has_perm` — until the legacy `PermissionGroup` rows that pollute it are gone (ADR §2.4).
- **`accounts/services.py`** (write side, push-only): `grant_create` (`full_clean` before save, per the styleguide), `grant_delete`, `role_assign` (global tier only — refuses scoped roles, matching check E001), `role_remove`.

**Not in this PR:** the shelter-domain cutover (flipping `shelter_queryset`/mutations to `visible()`, the `createShelter` target-org convention, and the assign-service dual-write) — it lands next so the transition stays consistent (backfill from #2410 keeps Grants in sync via `post_migrate`).

## Tests (17 new, 57 in the grant suite)

- `common/tests/test_permissions_selectors.py` — org-scoped vs global visibility on real shelters, `in_org` confinement, superuser, no-grant → nothing, platform-shared `ClientProfile` reads, fail-closed for undeclared models, `_scope_cache` memoization, `can`/`can_obj`/`can_anywhere`.
- `accounts/tests/test_grant_services.py` — `grant_create` creates + validates before save, `grant_delete` revokes, `role_assign` global vs scoped, `role_remove`.

All 57 pass; `ruff` + `mypy` clean.

## Follow-ups (per ADR 0001 §4)

- **PR 4**: shelter cutover — `shelter_queryset`/mutation surface → `visible()`/`can()`, `createShelter` explicit org input, assign-service dual-write (closes SDB-218)
- PR 5: org→org delegation + admin inline
- PR 6: frontend reachability
- PR 7: object grants + clients/notes
- PR 8: teardown

## Summary by Sourcery

Introduce the grant-based authorization read selectors and write services needed to centralize permission checks and role management.

New Features:
- Add authorization selectors for resolving global or organization-scoped permissions, filtering visible querysets, and checking organization, object, and platform-wide access.
- Add grant and global-role services for creating and revoking scoped grants and assigning or removing global roles.

Enhancements:
- Fail closed for models without organization-scope declarations and preserve global authority when applying optional organization filters.

Tests:
- Add coverage for selector visibility, scope memoization, authorization checks, platform-shared models, and grant service behavior.