### PR TITLE
feat(perm): object-grant arm + per-record client sharing (DEV-2562)

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -24,6 +24,7 @@ from django.utils.text import Truncator
 from organizations.models import Organization, OrganizationInvitation, OrganizationOwner, OrganizationUser
 
 from .forms import (
+    GrantForm,
     OrganizationMemberInviteForm,
     OrganizationMemberRoleForm,
     OrganizationOwnerTransferForm,
@@ -451,17 +452,15 @@ class GrantAdmin(SuperuserOnlyWritesMixin, admin.ModelAdmin):
     """Audit + administer grants (ADR 0001 §2.2) — user grants and org→org delegations.
 
     ``principal_user`` vs ``principal_org`` (exactly one) and ``scope_org`` vs
-    object scope (exactly one) are enforced by the model constraints and a
-    global Role can never be granted (:meth:`Grant.clean`, ``permissions.E002``).
+    object scope (exactly one) are enforced by the model constraints; a global
+    Role can never be granted (check ``permissions.E002``); new object grants
+    must target a whitelisted model (``GrantForm``, ``permissions.E003``).
     Grants are the whole authorization graph, so add/change/delete are
     superuser-only (:class:`SuperuserOnlyWritesMixin`); staff may still view
     where Django grants them ``view_grant``.
     """
 
-    def formfield_for_foreignkey(self, db_field: Any, request: Any, **kwargs: Any) -> Any:
-        if db_field.name == "role":
-            kwargs["queryset"] = _scoped_role_queryset()
-        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+    form = GrantForm
 
     list_select_related = (
         "principal_user",

--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -462,6 +462,11 @@ class GrantAdmin(SuperuserOnlyWritesMixin, admin.ModelAdmin):
 
     form = GrantForm
 
+    def formfield_for_foreignkey(self, db_field: Any, request: Any, **kwargs: Any) -> Any:
+        if db_field.name == "role":
+            kwargs["queryset"] = _scoped_role_queryset()
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
     list_select_related = (
         "principal_user",
         "principal_org",

--- a/apps/betterangels-backend/accounts/apps.py
+++ b/apps/betterangels-backend/accounts/apps.py
@@ -28,11 +28,13 @@ class AccountsConfig(AppConfig):
     name = "accounts"
 
     def ready(self) -> None:
+        from django.db.models.signals import post_delete
         from post_office.settings import get_celery_enabled
         from post_office.signals import email_queued
 
         from .models import User
         from .signals import (
+            cleanup_orphan_object_grants,
             mirror_group_membership_grants,
             setup_local_dev_data,
             sync_all_org_permission_groups,
@@ -52,6 +54,17 @@ class AccountsConfig(AppConfig):
             sender=User.groups.through,
             dispatch_uid="mirror_group_membership_grants",
         )
+
+        # Object-grant orphans (finding F3): wire the cleanup to each
+        # whitelisted model so a deleted row never leaves dangling grants.
+        from common.permissions.object_grants import object_grant_whitelist
+
+        for model in object_grant_whitelist():
+            post_delete.connect(
+                cleanup_orphan_object_grants,
+                sender=model,
+                dispatch_uid=f"cleanup_orphan_object_grants_{model._meta.label_lower}",
+            )
 
         # Connect with sender=self so handlers fire exactly once (not per-app).
         # dispatch_uid prevents duplicate registration if ready() is re-called.

--- a/apps/betterangels-backend/accounts/apps.py
+++ b/apps/betterangels-backend/accounts/apps.py
@@ -22,6 +22,14 @@ def _seed_on_migrate(sender: AppConfig, **kwargs: object) -> None:
     backfill_shelter_grants()
     backfill_global_role_members()
 
+    # Prime the object-grants switch lookup so the orphan-cleanup handler's
+    # first fire after a deploy is a cache hit (reads state only; never
+    # creates a Switch row).  Without this, the first ClientProfile delete in a
+    # fresh process pays one extra query for the cold waffle lookup.
+    from common.permissions.object_grants import object_grants_enabled
+
+    object_grants_enabled()
+
 
 class AccountsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
@@ -55,11 +63,14 @@ class AccountsConfig(AppConfig):
             dispatch_uid="mirror_group_membership_grants",
         )
 
-        # Object-grant orphans (finding F3): wire the cleanup to each
-        # whitelisted model so a deleted row never leaves dangling grants.
-        from common.permissions.object_grants import object_grant_whitelist
+        # Object-grant orphans (finding F3): wire the cleanup to each candidate
+        # model so a deleted row never leaves dangling grants.  The candidates
+        # are switch-independent (the handler itself is runtime-gated), so
+        # cleanup stays connected when the object_grants_enabled switch is
+        # flipped on after startup.
+        from common.permissions.object_grants import object_grantable_models
 
-        for model in object_grant_whitelist():
+        for model in object_grantable_models():
             post_delete.connect(
                 cleanup_orphan_object_grants,
                 sender=model,

--- a/apps/betterangels-backend/accounts/forms.py
+++ b/apps/betterangels-backend/accounts/forms.py
@@ -3,11 +3,12 @@ from typing import Any, cast
 from common.org_types import REGISTRY
 from django import forms
 from django.contrib.auth.forms import UserChangeForm as BaseUserChangeForm
+from django.core.exceptions import ValidationError
 from organizations.models import Organization
 
 from common.permissions.config import TemplateConfig
 
-from .models import OrganizationProfile, OrgTypeChoices, PermissionGroup, User
+from .models import Grant, OrganizationProfile, OrgTypeChoices, PermissionGroup, Role, User
 
 # isort: off
 # We ignore this type check because there's an issue with django-stubs not recognizing
@@ -200,3 +201,55 @@ class OrganizationMemberRoleForm(OrganizationRoleSelectionForm):
         # unlike on the invite form where it would send a pointless invitation.
         self.fields["permission_templates"].required = False
         self.fields["permission_templates"].initial = [name for name in held if name in offered]
+
+
+class GrantForm(forms.ModelForm):
+    """Admin form for :class:`Grant` — mirrors the write-service rules in the UI.
+
+    * ``permissions.E002`` — only scoped Roles can sit in a Grant; a global Role
+      lives in ``user.groups``, never in a Grant row, so the role choices never
+      offer one.
+    * ``permissions.E003`` — a *new* object grant may only target a whitelisted
+      model (ADR 0001 §2.5).  While the ``object_grants_enabled`` waffle switch
+      is off the whitelist is empty and every object grant is refused here,
+      before a row exists — the same gate ``grant_obj`` applies to service
+      writes, so the admin cannot mint grants the predicate will not honor.
+    """
+
+    class Meta:
+        model = Grant
+        fields = (
+            "principal_user",
+            "principal_org",
+            "role",
+            "scope_org",
+            "scope_object_type",
+            "scope_object_id",
+        )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # E002 up front: never offer a global Role in the grant form.
+        self.fields["role"].queryset = Role.objects.filter(is_global=False)
+
+    def clean(self) -> dict[str, Any]:
+        cleaned = super().clean()
+        scope_object_type = cleaned.get("scope_object_type")
+        if scope_object_type is not None and self.instance.pk is None:
+            # New object grants only — an existing object-grant row stays
+            # editable once the feature is disabled (E003 still flags it at
+            # deploy time rather than silently dropping it).
+            from common.permissions.object_grants import object_grant_whitelist
+
+            target = scope_object_type.model_class()
+            if target is None or not any(issubclass(target, cls) for cls in object_grant_whitelist()):
+                raise ValidationError(
+                    {
+                        "scope_object_type": (
+                            f"{scope_object_type} is not object-grantable: the object-grant "
+                            "feature is off or the model is not whitelisted (ADR 0001 §2.5, "
+                            "permissions.E003)."
+                        )
+                    }
+                )
+        return cleaned

--- a/apps/betterangels-backend/accounts/forms.py
+++ b/apps/betterangels-backend/accounts/forms.py
@@ -230,10 +230,10 @@ class GrantForm(forms.ModelForm):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # E002 up front: never offer a global Role in the grant form.
-        self.fields["role"].queryset = Role.objects.filter(is_global=False)
+        cast(forms.ModelChoiceField, self.fields["role"]).queryset = Role.objects.filter(is_global=False)
 
     def clean(self) -> dict[str, Any]:
-        cleaned = super().clean()
+        cleaned = super().clean() or {}
         scope_object_type = cleaned.get("scope_object_type")
         if scope_object_type is not None and self.instance.pk is None:
             # New object grants only — an existing object-grant row stays

--- a/apps/betterangels-backend/accounts/models.py
+++ b/apps/betterangels-backend/accounts/models.py
@@ -392,7 +392,7 @@ class Grant(models.Model):
                 }
             )
         if self.scope_object_type is not None:
-            from common.permissions.config import OBJECT_GRANT_WHITELIST, content_type_key
+            from common.permissions.object_grants import object_grant_whitelist
 
             if self.principal_org is not None:
                 raise ValidationError(
@@ -404,13 +404,15 @@ class Grant(models.Model):
                         )
                     }
                 )
-            if content_type_key(self.scope_object_type) not in OBJECT_GRANT_WHITELIST:
+            # E003 — the single switch-gated whitelist (object_grants.py) is the
+            # choke point every writer shares: while object_grants_enabled is off
+            # the whitelist is empty and every object grant is refused here.
+            target = self.scope_object_type.model_class()
+            if target is None or not any(issubclass(target, cls) for cls in object_grant_whitelist()):
                 raise ValidationError(
                     {
                         "scope_object_type": (
-                            f"{self.scope_object_type} is not on the object-grant "
-                            "whitelist (permissions.E003) — object grants are not "
-                            "wired yet."
+                            f"{self.scope_object_type} is not on the object-grant whitelist (permissions.E003)."
                         )
                     }
                 )

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -32,6 +32,8 @@ from .role_manager import OrgRoleManager
 from .seed import _resolve_permissions, sync_group_permissions
 
 if TYPE_CHECKING:
+    from django.db.models import Model
+
     from .models import User
 
 logger = logging.getLogger(__name__)
@@ -723,6 +725,38 @@ def grant_delegate(*, principal_org: Organization, role: Role, scope_org: Organi
         scope_object_id__isnull=True,
     ).exists():
         raise ValidationError(f"{principal_org} already delegates {role.name!r} to {scope_org}.")
+    grant.save()
+    return grant
+
+
+def grant_obj(*, user: UserModel, role: Role, obj: "Model") -> Grant:
+    """Grant *user* the scoped *role* on the single row *obj* (ADR 0001 §2.5).
+
+    Per-record authority — the object arm.  *obj*'s model must be on the
+    object-grant whitelist (``permissions.E003``); the model constraint
+    ``grant_has_exactly_one_scope`` enforces that an object grant has no org.
+
+    Raises:
+        ``django.core.exceptions.ValidationError`` when the target model is not
+        whitelisted, the role is global, or the row would violate a constraint.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    from accounts.models import Grant
+    from common.permissions.object_grants import object_grant_whitelist
+
+    if not any(issubclass(type(obj), cls) for cls in object_grant_whitelist()):
+        raise ValidationError(f"{type(obj).__name__} is not object-grantable (ADR 0001 §2.5).")
+    if role.is_global:
+        raise ValidationError(f"Role {role.name!r} is global; object grants are scoped (permissions.E002).")
+
+    grant = Grant(
+        principal_user=user,
+        role=role,
+        scope_object_type=ContentType.objects.get_for_model(obj),
+        scope_object_id=obj.pk,
+    )
+    grant.full_clean()
     grant.save()
     return grant
 

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -8,6 +8,26 @@ from organizations.models import Organization
 
 from .models import User
 
+
+def cleanup_orphan_object_grants(sender: object, instance: object, **kwargs: object) -> None:
+    """Finding F3 — a deleted row's object grants are orphans; drop them.
+
+    Connected in ``AppConfig.ready`` to every object-grant whitelisted model
+    (ADR 0001 §2.5).  Non-whitelisted senders are ignored.
+    """
+    from common.permissions.object_grants import object_grant_whitelist
+
+    if not any(issubclass(sender, cls) for cls in object_grant_whitelist()):  # type: ignore[arg-type]
+        return
+
+    from django.contrib.contenttypes.models import ContentType
+
+    from .models import Grant
+
+    ct = ContentType.objects.get_for_model(sender)  # type: ignore[arg-type]
+    Grant.objects.filter(scope_object_type=ct, scope_object_id=instance.pk).delete()  # type: ignore[attr-defined]
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -12,19 +12,23 @@ from .models import User
 def cleanup_orphan_object_grants(sender: object, instance: object, **kwargs: object) -> None:
     """Finding F3 — a deleted row's object grants are orphans; drop them.
 
-    Connected in ``AppConfig.ready`` to every object-grant whitelisted model
-    (ADR 0001 §2.5).  Non-whitelisted senders are ignored.
+    Connected in ``AppConfig.ready`` to every object-grant candidate model
+    (ADR 0001 §2.5).  Runtime-gated on ``object_grant_whitelist``, which is
+    itself gated by the ``object_grants_enabled`` waffle switch: while the
+    feature is off the handler returns before issuing any SQL, so deleting a
+    row costs no extra query.
     """
     from common.permissions.object_grants import object_grant_whitelist
 
-    if not any(issubclass(sender, cls) for cls in object_grant_whitelist()):  # type: ignore[arg-type]
+    model = type(instance)
+    if not any(issubclass(model, cls) for cls in object_grant_whitelist()):
         return
 
     from django.contrib.contenttypes.models import ContentType
 
     from .models import Grant
 
-    ct = ContentType.objects.get_for_model(sender)  # type: ignore[arg-type]
+    ct = ContentType.objects.get_for_model(model)
     Grant.objects.filter(scope_object_type=ct, scope_object_id=instance.pk).delete()  # type: ignore[attr-defined]
 
 

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -4,12 +4,13 @@ from typing import Any
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import DatabaseError
+from django.db.models import Model
 from organizations.models import Organization
 
 from .models import User
 
 
-def cleanup_orphan_object_grants(sender: object, instance: object, **kwargs: object) -> None:
+def cleanup_orphan_object_grants(sender: object, instance: Model, **kwargs: object) -> None:
     """Finding F3 — a deleted row's object grants are orphans; drop them.
 
     Connected in ``AppConfig.ready`` to every object-grant candidate model

--- a/apps/betterangels-backend/common/apps.py
+++ b/apps/betterangels-backend/common/apps.py
@@ -1,9 +1,10 @@
-from common.utils import get_fargate_task_ips
 from django.apps import AppConfig
 from django.conf import settings
 from django.db.models.fields import files
 from django.db.models.signals import post_migrate
 from strawberry_django.fields.types import field_type_map
+
+from common.utils import get_fargate_task_ips
 
 
 class CommonConfig(AppConfig):

--- a/apps/betterangels-backend/common/permissions/checks.py
+++ b/apps/betterangels-backend/common/permissions/checks.py
@@ -72,36 +72,38 @@ def check_grant_never_references_global_role(app_configs: Any, **kwargs: Any) ->
 
 @register(Tags.models)
 def check_object_grant_targets_whitelisted_model(app_configs: Any, **kwargs: Any) -> list[Error]:
-    """E003 — object grants may only target whitelisted, non-org-bearing models.
+    """E003 — object grants may only target whitelisted models.
 
-    The whitelist (``common.permissions.config.OBJECT_GRANT_WHITELIST``) is empty
-    until the object-grant arm is wired (ADR 0001 §2.5): object grants are
-    schema-live but must not be written before then, and org-bearing models are
-    never object-grantable (that would duplicate org scope).  ``Grant.clean``
-    shares the same whitelist, so the write-time and deploy-time gates open
-    together.
+    The whitelist (ADR 0001 §2.5) deliberately excludes ``Organization`` and
+    org-bearing models by default — object-granting a row that already has an
+    org would create a second path to the same authority — with an explicit
+    exception for sharing consumers like ``Note`` when the notes cutover
+    lands.  See ``common.permissions.object_grants``.
     """
+    from common.permissions.object_grants import object_grant_whitelist
     from django.apps import apps
     from django.db.utils import DatabaseError
-
-    from common.permissions.config import OBJECT_GRANT_WHITELIST, content_type_key
 
     try:
         Grant = apps.get_model("accounts", "Grant")
 
+        whitelist = object_grant_whitelist()
         errors: list[Error] = []
         for grant in Grant.objects.filter(scope_object_type__isnull=False).select_related("scope_object_type"):
-            if content_type_key(grant.scope_object_type) in OBJECT_GRANT_WHITELIST:
+            if grant.scope_object_type is None:
                 continue
-            errors.append(
-                Error(
-                    f"Grant {grant} is an object grant on {grant.scope_object_type}, "
-                    "which is not on the object-grant whitelist.",
-                    hint="Object grants are not wired yet (ADR 0001 §2.5); no model is object-grantable.",
-                    obj=grant,
-                    id="permissions.E003",
+            target_model = grant.scope_object_type.model_class()
+            if target_model is None or not any(issubclass(target_model, cls) for cls in whitelist):
+                errors.append(
+                    Error(
+                        f"Grant {grant} is an object grant on {grant.scope_object_type}, "
+                        "which is not on the object-grant whitelist.",
+                        hint="Only models in common.permissions.object_grants.object_grant_whitelist() "
+                        "may be object-granted (ADR 0001 §2.5).",
+                        obj=grant,
+                        id="permissions.E003",
+                    )
                 )
-            )
         return errors
     except DatabaseError:
         return []

--- a/apps/betterangels-backend/common/permissions/config.py
+++ b/apps/betterangels-backend/common/permissions/config.py
@@ -69,7 +69,10 @@ class RoleDef:
         return cls(
             name=template.name,
             # Copy so a future in-place mutation of one list never aliases the
-            # other definition (the dataclass is frozen, the list is not).
+            # other definition (the dataclass is frozen, the list is not).  The
+            # legacy templates stay referenced after role-backing (reconcile,
+            # org_types.REGISTRY, invite signals), so the Role rows and the
+            # templates must not silently share a mutable list.
             permissions=list(template.permissions),
             is_global=is_global,
             is_invitable=template.is_invitable,

--- a/apps/betterangels-backend/common/permissions/object_grants.py
+++ b/apps/betterangels-backend/common/permissions/object_grants.py
@@ -1,0 +1,38 @@
+"""Object-grant whitelist (ADR 0001 §2.5).
+
+Only models listed here may be the target of an object grant
+(``Grant.scope_object_type`` / ``scope_object_id``).  ``permissions.E003`` flags
+any object grant on a model outside this list.
+
+Rules from the ADR:
+
+* ``Organization`` and org-bearing models are excluded by default — an object
+  grant on a row that already has an org would create a second path to the same
+  authority (findings F5, F16).
+* An org-bearing model may still be added here when it is the *explicit sharing
+  consumer*: a row whose edit/delete authority is deliberately per-record
+  rather than org-scoped.  ``Note`` is that case (ADR §5 — shared/foreign notes
+  get per-record edit control via the object arm, not guardian rows).
+* ``ClientProfile`` is platform-shared (``org_via = None``) — per-record object
+  grants are how cross-org client edit/delete becomes expressible (ADR §5.1,
+  option 2: "no new column; ownership lives in the grant").
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.db.models import Model
+
+
+def object_grant_whitelist() -> tuple[type["Model"], ...]:
+    """Resolve the whitelist lazily (avoids app-registry cycles at import).
+
+    First consumer: per-record client sharing (ADR §5.1, option 2).  ``Note``
+    joins once the notes cutover ships its OrgScoped declaration + guardian
+    teardown (ADR §5) — the whitelist is deliberate, not automatic.
+    """
+    from clients.models import ClientProfile
+
+    return (ClientProfile,)

--- a/apps/betterangels-backend/common/permissions/object_grants.py
+++ b/apps/betterangels-backend/common/permissions/object_grants.py
@@ -18,21 +18,57 @@ Rules from the ADR:
   option 2: "no new column; ownership lives in the grant").
 """
 
-from __future__ import annotations
+import waffle
 
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from django.db.models import Model
 
+OBJECT_GRANTS_SWITCH = "object_grants_enabled"
+"""Waffle switch gating the whole object-grant feature (ADR 0001 §2.5).
 
-def object_grant_whitelist() -> tuple[type["Model"], ...]:
-    """Resolve the whitelist lazily (avoids app-registry cycles at import).
+The switch is the single control for the object arm: ``object_grant_whitelist``
+returns nothing while it is off, which makes every consumer fail closed at once
+— reads via ``_object_grant_q``, writes via ``grant_obj``, the orphan-cleanup
+signal, and ``permissions.E003``.  It is off by default until a domain cutover
+deliberately enables it.  A switch-gated whitelist (not a code constant) is the
+right shape for an authorization feature because it keeps the read and write
+sides consistent: the arm can never be half-on (grants mintable but not
+honored), and a mis-flip fails closed instead of reviving grants written while
+the feature was off.
+"""
 
-    First consumer: per-record client sharing (ADR §5.1, option 2).  ``Note``
-    joins once the notes cutover ships its OrgScoped declaration + guardian
-    teardown (ADR §5) — the whitelist is deliberate, not automatic.
+
+def object_grants_enabled() -> bool:
+    """Runtime check: object grants may be written and honored only when the switch is active."""
+    return waffle.switch_is_active(OBJECT_GRANTS_SWITCH)
+
+
+def object_grantable_models() -> tuple[type["Model"], ...]:
+    """Models that MAY carry an object grant once enabled (ADR 0001 §2.5).
+
+    Static and switch-independent: signal wiring in ``AppConfig.ready`` uses
+    this so the orphan-cleanup handler stays connected even when the switch is
+    flipped on after startup (the handler itself is runtime-gated).  The list
+    is deliberate, not automatic — a model joins only at its own cutover
+    (``Note`` at the notes cutover; ``ClientProfile`` at the clients cutover).
     """
     from clients.models import ClientProfile
 
     return (ClientProfile,)
+
+
+def object_grant_whitelist() -> tuple[type["Model"], ...]:
+    """The currently object-grantable models — empty while the feature is off.
+
+    The single choke point every object-grant consumer consults.  While it is
+    empty: reads fail closed, ``grant_obj`` refuses to mint grants, the orphan
+    cleanup handler returns before issuing SQL, and ``permissions.E003`` flags
+    any leftover object-grant row.  Turning the switch on is therefore the only
+    way the arm becomes live — and it cannot revive stale authority, because no
+    grant can be written while the feature is off.
+    """
+    if not object_grants_enabled():
+        return ()
+    return object_grantable_models()

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -354,14 +354,33 @@ def can(user: "User", perm: str, *, org: Any) -> bool:
 def can_obj(user: "User", perm: str, obj: "Model") -> bool:
     """The single-row check *is* the row filter, applied to one row.
 
-    WARNING (finding C1): on a platform-shared model (``org_via = None``)
-    ``visible`` applies the read rule — "holds the perm anywhere ⇒ all rows" —
-    so ``can_obj`` currently returns True for *every* row to any perm-holder.
-    Do not route platform-shared single-row *writes* through this until the C1
-    fix (object arm + fail-closed ``can_obj``) lands; until then it is the
-    org-scoped row filter only.
+    Org-scoped model — the row falls in the user's scopes (the ``visible`` org
+    filter on a one-row queryset).
+
+    Platform-shared model (``org_via = None``) — per-record authority comes
+    from the object arm (or the global tier), **not** from "holds the perm
+    anywhere".  The read rule (perm held anywhere ⇒ all rows) must not leak
+    into per-record writes: an org-grant holder of a client perm would
+    otherwise be able to CHANGE/DELETE *every* client (finding C1).  Write
+    services on platform-shared models must use ``can_obj`` (or the object
+    arm), never the read-side ``visible``, to load records for mutation.
     """
-    return visible(obj.__class__._base_manager.filter(pk=obj.pk), user, perm).exists()
+    from common.models import OrgScoped
+
+    model = obj.__class__
+    if not issubclass(model, OrgScoped):
+        return False
+
+    s = scopes(user, perm)
+    if s is ALL:
+        return True
+
+    if not model.org_paths():
+        # Platform-shared: an object grant on this row is the only scoped path
+        # (a non-whitelisted model fails closed — ``_object_grant_q`` is False).
+        return model._base_manager.filter(pk=obj.pk).filter(_object_grant_q(model, user, perm)).exists()
+
+    return visible(model._base_manager.filter(pk=obj.pk), user, perm).exists()
 
 
 def can_anywhere(user: "User", perm: str) -> bool:

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -27,6 +27,74 @@ if TYPE_CHECKING:
 ALL = object()
 """Sentinel for the global tier — row-invariant, so ``visible`` hoists it."""
 
+OBJECT_ARM_ENABLED = True
+"""Object-grant arm (ADR 0001 §2.5) — on with its first consumer (clients).
+
+Only whitelisted models are object-grantable (``permissions.E003``), so the arm
+is a no-op for every other model; it is safe to leave on.
+"""
+
+
+def _object_grant_ancestors(model: Any) -> list[tuple[str, type["Model"]]]:
+    """(FK lookup path to parent id, parent model) for every object-grantable ancestor.
+
+    Derived from ``org_via`` (ADR 0001 §2.3): an object grant on an ancestor —
+    e.g. a Shelter — covers its descendants (beds, rooms, ...) through their FK
+    paths.  A non-``OrgScoped`` hop is skipped defensively.
+    """
+    results: list[tuple[str, type["Model"]]] = []
+    for hop in model.org_via or ():
+        field = model._meta.get_field(hop)
+        target = field.related_model
+        if target is None:
+            continue
+        results.append((f"{field.name}_id", target))
+        for sub_path, sub_ct in _object_grant_ancestors(target):
+            results.append((f"{field.name}__{sub_path}", sub_ct))
+    return results
+
+
+def _object_grant_q(model: Any, user: "User", perm: str) -> Q:
+    """Q matching rows of *model* the user holds *perm* on via an object grant.
+
+    Direct — an object grant on the row itself — plus the cascade: an object
+    grant on an ancestor (an ``org_via`` hop target) covers descendants through
+    their FK paths (ADR 0001 §2.5, finding F17).  Grants are always scoped to
+    *user* (the principal).  Only whitelisted models are object-grantable, so
+    grants on non-whitelisted ancestors cannot exist and non-whitelisted models
+    fail closed.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    from accounts.models import Grant
+    from common.permissions.object_grants import object_grant_whitelist
+
+    if not any(issubclass(model, cls) for cls in object_grant_whitelist()):
+        return Q(pk__lt=0)
+
+    roles = _roles_carrying_perm(perm)
+    direct_ct = ContentType.objects.get_for_model(model)
+    q = Q(
+        pk__in=Grant.objects.filter(
+            principal_user=user,
+            scope_object_type=direct_ct,
+            role__in=Subquery(roles),
+        ).values("scope_object_id")
+    )
+
+    for path, target in _object_grant_ancestors(model):
+        ct = ContentType.objects.get_for_model(target)
+        q |= Q(
+            **{
+                f"{path}__in": Grant.objects.filter(
+                    principal_user=user,
+                    scope_object_type=ct,
+                    role__in=Subquery(roles),
+                ).values("scope_object_id")
+            }
+        )
+    return q
+
 
 def _perm_parts(perm: str) -> tuple[str, str]:
     app_label, codename = perm.split(".", 1)
@@ -230,6 +298,12 @@ def visible(qs: "QuerySet", user: "User", perm: str, *, in_org: str | None = Non
     * org-scoped model — rows whose org is in *user*'s scopes.
     * model not declared ``OrgScoped`` — fails closed (no rows).
 
+    The object arm (ADR 0001 §2.5) is OR'd with the org filter in a single
+    ``filter``, so per-record object grants can add rows on top of a
+    deliberately-empty org scope.  ``pk__lt=0`` is the "impossible" condition —
+    it compiles to a normal always-false predicate instead of Django's
+    ``EmptyResultSet`` short-circuit, which would swallow the object arm.
+
     *in_org* confines the view to one organization, and only for finite scopes —
     a global holder is never org-confined by a stale header (ADR 0001 §2.4).
     """
@@ -243,16 +317,27 @@ def visible(qs: "QuerySet", user: "User", perm: str, *, in_org: str | None = Non
 
     if s is ALL:
         qs = qs
-    elif not paths:
-        # platform-shared: perm held anywhere (finite s) ⇒ all rows
-        qs = qs if s.exists() else qs.none()
-    elif s:
-        qs = qs.filter(reduce(or_, (Q(**{f"{p}__in": s}) for p in paths)))
     else:
-        qs = qs.none()
+        if not paths:
+            # platform-shared: perm held anywhere (finite s) ⇒ all rows (identity
+            # org filter), else nothing (``pk__lt=0`` — an always-false predicate
+            # that compiles normally, unlike Django's EmptyResultSet short-circuit).
+            org_q: Q | None = None if s.exists() else Q(pk__lt=0)
+        elif s:
+            org_q = reduce(or_, (Q(**{f"{p}__in": s}) for p in paths))
+        else:
+            org_q = Q(pk__lt=0)
 
-    if in_org is not None and s is not ALL and paths:
-        qs = qs.filter(reduce(or_, (Q(**{p: in_org}) for p in paths)))
+        if in_org is not None and paths and org_q is not None:
+            org_q &= reduce(or_, (Q(**{p: in_org}) for p in paths))
+
+        if org_q is None:
+            # Every row is already visible — the object arm cannot add more.
+            qs = qs
+        elif OBJECT_ARM_ENABLED:
+            qs = qs.filter(org_q | _object_grant_q(qs.model, user, perm))
+        else:
+            qs = qs.filter(org_q)
     return qs
 
 

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -27,13 +27,6 @@ if TYPE_CHECKING:
 ALL = object()
 """Sentinel for the global tier — row-invariant, so ``visible`` hoists it."""
 
-OBJECT_ARM_ENABLED = True
-"""Object-grant arm (ADR 0001 §2.5) — on with its first consumer (clients).
-
-Only whitelisted models are object-grantable (``permissions.E003``), so the arm
-is a no-op for every other model; it is safe to leave on.
-"""
-
 
 def _object_grant_ancestors(model: Any) -> list[tuple[str, type["Model"]]]:
     """(FK lookup path to parent id, parent model) for every object-grantable ancestor.
@@ -334,10 +327,12 @@ def visible(qs: "QuerySet", user: "User", perm: str, *, in_org: str | None = Non
         if org_q is None:
             # Every row is already visible — the object arm cannot add more.
             qs = qs
-        elif OBJECT_ARM_ENABLED:
-            qs = qs.filter(org_q | _object_grant_q(qs.model, user, perm))
         else:
-            qs = qs.filter(org_q)
+            # The object arm is OR'd unconditionally; ``_object_grant_q`` is
+            # self-gating.  For a non-whitelisted model (or the whole feature,
+            # switch off) it returns the always-false ``Q(pk__lt=0)``, so the
+            # org filter is unchanged and no grant subquery is emitted.
+            qs = qs.filter(org_q | _object_grant_q(qs.model, user, perm))
     return qs
 
 

--- a/apps/betterangels-backend/common/signals.py
+++ b/apps/betterangels-backend/common/signals.py
@@ -9,8 +9,9 @@ def enable_imgproxy_switch(sender: object, **kwargs: object) -> None:
     if not settings.IS_LOCAL_DEV:
         return
 
-    from common.imgproxy import IMGPROXY_SWITCH
     from waffle.models import Switch
+
+    from common.imgproxy import IMGPROXY_SWITCH
 
     Switch.objects.get_or_create(name=IMGPROXY_SWITCH, defaults={"active": True})
     waffle.switch_is_active(IMGPROXY_SWITCH)  # prime the in-memory cache

--- a/apps/betterangels-backend/common/tests/test_object_grants.py
+++ b/apps/betterangels-backend/common/tests/test_object_grants.py
@@ -70,6 +70,43 @@ class ObjectGrantTestCase(TestCase):
         self.assertTrue(can_obj(sharer, ClientProfile.perms.DELETE, profile))
         self.assertTrue(can_obj(sharer, ClientProfile.perms.VIEW, profile))
 
+    def test_can_obj_fails_closed_for_an_org_holder_on_platform_shared_rows(self) -> None:
+        """Finding C1: holding a client perm via an ORG grant must not make every
+        client mutable.  Per-record writes on a platform-shared model need an
+        object grant (or the global tier); reads stay platform-shared via
+        ``visible``."""
+        from clients.models import ClientProfile
+
+        org_holder = baker.make(User)
+        org = organization_recipe.make(name="Org Holder Org")
+        grant_create(user=org_holder, role=self.sharer_role, scope_org=org)
+        profile = self._profile()
+        other = self._profile()
+
+        # Reads are unchanged — platform-shared (the holder sees every profile).
+        self.assertEqual(visible(ClientProfile.objects.all(), org_holder, ClientProfile.perms.VIEW).count(), 2)
+        # But per-record writes are fail-closed without an object grant.
+        self.assertFalse(can_obj(org_holder, ClientProfile.perms.CHANGE, profile))
+        self.assertFalse(can_obj(org_holder, ClientProfile.perms.CHANGE, other))
+        self.assertFalse(can_obj(org_holder, ClientProfile.perms.DELETE, profile))
+
+        # An object grant restores per-record authority for the holder.
+        grant_obj(user=org_holder, role=self.sharer_role, obj=profile)
+        self.assertTrue(can_obj(org_holder, ClientProfile.perms.CHANGE, profile))
+        self.assertFalse(can_obj(org_holder, ClientProfile.perms.CHANGE, other))
+
+    def test_global_tier_can_obj_any_platform_shared_row(self) -> None:
+        from clients.models import ClientProfile
+
+        gso = baker.make(User)
+        from accounts.services import role_assign
+
+        role_assign(user=gso, role=self.gso_role)
+        profile = self._profile()
+
+        # GSO carries clients.view_clientprofile; the global tier acts on any row.
+        self.assertTrue(can_obj(gso, ClientProfile.perms.VIEW, profile))
+
     def test_object_grant_does_not_change_platform_shared_reads_for_holders(self) -> None:
         from clients.models import ClientProfile
 
@@ -92,8 +129,6 @@ class ObjectGrantTestCase(TestCase):
         # Bed/Room/Shelter are not whitelisted — an object grant on them would
         # violate E003, so ``_object_grant_q`` fails closed for them.
         from django.db.models import Q
-
-        from common.permissions.selectors import _object_grant_q
 
         user = baker.make(User)
         self.assertEqual(_object_grant_q(Bed, user, Bed.perms.VIEW), Q(pk__lt=0))

--- a/apps/betterangels-backend/common/tests/test_object_grants.py
+++ b/apps/betterangels-backend/common/tests/test_object_grants.py
@@ -1,0 +1,186 @@
+"""Object-grant arm tests (ADR 0001 §2.5).
+
+Per-record authority: a user with an object grant on a row may exercise the
+granted role's permissions on that row even when they hold nothing org-wide —
+the mechanism behind cross-org client sharing (ADR §5.1, option 2).
+"""
+
+from accounts.models import Grant, Role, User
+from accounts.services import grant_create, grant_obj, sync_roles
+from accounts.tests.baker_recipes import organization_recipe
+from common.permissions import checks
+from common.permissions.selectors import _object_grant_ancestors, _object_grant_q, can_obj, visible
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from model_bakery import baker
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
+from shelters.models import Bed, Room, Shelter
+from shelters.tests.baker_recipes import shelter_recipe
+from typing import Any
+
+
+class ObjectGrantTestCase(TestCase):
+    def setUp(self) -> None:
+        sync_roles()
+        self.shelter_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
+        self.gso_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
+        # A scoped role carrying the client CHANGE/DELETE/VIEW perms — the
+        # object-granted role must actually carry the permission being checked.
+        self.sharer_role, _ = Role.objects.get_or_create(name="Test Client Sharer", is_global=False)
+        for perm in (
+            "clients.change_clientprofile",
+            "clients.delete_clientprofile",
+            "clients.view_clientprofile",
+        ):
+            app_label, codename = perm.split(".")
+            self.sharer_role.permissions.add(
+                Permission.objects.get(codename=codename, content_type__app_label=app_label)
+            )
+
+    def _profile(self) -> Any:
+        from clients.models import ClientProfile
+
+        return baker.make(ClientProfile)
+
+    # ── visible() / can_obj() ──────────────────────────────────────────────
+
+    def test_object_grant_grants_permission_on_the_single_row(self) -> None:
+        from clients.models import ClientProfile
+
+        sharer = baker.make(User)
+        stranger = baker.make(User)
+        profile = self._profile()
+        other = self._profile()
+        grant_obj(user=sharer, role=self.sharer_role, obj=profile)
+
+        # The sharer has no org grant at all — the object grant alone is enough.
+        self.assertTrue(can_obj(sharer, ClientProfile.perms.CHANGE, profile))
+        self.assertEqual(list(visible(ClientProfile.objects.all(), sharer, ClientProfile.perms.CHANGE)), [profile])
+        self.assertFalse(can_obj(sharer, ClientProfile.perms.CHANGE, other))
+        # A stranger sees nothing.
+        self.assertFalse(can_obj(stranger, ClientProfile.perms.CHANGE, profile))
+
+    def test_object_grant_covers_every_permission_of_the_role(self) -> None:
+        from clients.models import ClientProfile
+
+        sharer = baker.make(User)
+        profile = self._profile()
+        grant_obj(user=sharer, role=self.sharer_role, obj=profile)
+
+        self.assertTrue(can_obj(sharer, ClientProfile.perms.DELETE, profile))
+        self.assertTrue(can_obj(sharer, ClientProfile.perms.VIEW, profile))
+
+    def test_object_grant_does_not_change_platform_shared_reads_for_holders(self) -> None:
+        from clients.models import ClientProfile
+
+        holder = baker.make(User)
+        org = organization_recipe.make(name="Holder Org")
+        grant_create(user=holder, role=self.shelter_role, scope_org=org)
+        baker.make(ClientProfile)
+        baker.make(ClientProfile)
+
+        # A user who holds VIEW anywhere still sees all profiles (unchanged) —
+        # SHELTER_OPERATOR carries clients.view_clientprofile.
+        self.assertEqual(visible(ClientProfile.objects.all(), holder, ClientProfile.perms.VIEW).count(), 2)
+
+    def test_object_grants_do_not_leak_into_org_scoped_models(self) -> None:
+        """Whitelist-only: the object arm is a no-op for non-whitelisted models."""
+        self.shelter = shelter_recipe.make()
+        room = baker.make(Room, shelter=self.shelter)
+        baker.make(Bed, shelter=self.shelter, room=room)
+
+        # Bed/Room/Shelter are not whitelisted — an object grant on them would
+        # violate E003, so ``_object_grant_q`` fails closed for them.
+        from django.db.models import Q
+
+        from common.permissions.selectors import _object_grant_q
+
+        user = baker.make(User)
+        self.assertEqual(_object_grant_q(Bed, user, Bed.perms.VIEW), Q(pk__lt=0))
+
+    def test_object_grant_cascade_derives_ancestor_paths(self) -> None:
+        """An object grant on an ancestor covers descendants via org_via (ADR §2.5)."""
+        from clients.models import ClientProfile
+
+        # Bed.org_via=("shelter",) → an object grant on the shelter covers its beds.
+        self.assertIn(("shelter_id", Shelter), _object_grant_ancestors(Bed))
+        self.assertIn(("shelter_id", Shelter), _object_grant_ancestors(Room))
+        # Platform-shared models have no org-bearing ancestors.
+        self.assertEqual(_object_grant_ancestors(ClientProfile), [])
+
+    # ── grant_obj service ──────────────────────────────────────────────────
+
+    def test_grant_obj_creates_a_valid_object_grant(self) -> None:
+        profile = self._profile()
+        user = baker.make(User)
+
+        grant = grant_obj(user=user, role=self.sharer_role, obj=profile)
+
+        self.assertIsNone(grant.scope_org)
+        self.assertEqual(grant.scope_object_id, profile.pk)
+        self.assertEqual(grant.role, self.sharer_role)
+        self.assertTrue(Grant.objects.filter(pk=grant.pk).exists())
+
+    def test_grant_obj_refuses_a_non_whitelisted_model(self) -> None:
+        from django.core.exceptions import ValidationError
+
+        user = baker.make(User)
+        self.shelter = shelter_recipe.make()
+
+        with self.assertRaises(ValidationError):
+            grant_obj(user=user, role=self.sharer_role, obj=self.shelter)
+
+        # No OBJECT grant was written (the shared DB has seeded org grants).
+        self.assertFalse(Grant.objects.filter(scope_object_type__isnull=False).exists())
+
+    def test_grant_obj_refuses_a_global_role(self) -> None:
+        from django.core.exceptions import ValidationError
+
+        user = baker.make(User)
+        profile = self._profile()
+
+        with self.assertRaises(ValidationError):
+            grant_obj(user=user, role=self.gso_role, obj=profile)
+
+        # No OBJECT grant was written (the shared DB has seeded org grants).
+        self.assertFalse(Grant.objects.filter(scope_object_type__isnull=False).exists())
+
+    # ── E003 ───────────────────────────────────────────────────────────────
+
+    def test_e003_flags_object_grants_on_non_whitelisted_models(self) -> None:
+        from django.contrib.contenttypes.models import ContentType
+
+        user = baker.make(User)
+        self.shelter = shelter_recipe.make()
+        Grant.objects.create(
+            principal_user=user,
+            role=self.sharer_role,
+            scope_object_type=ContentType.objects.get_for_model(type(self.shelter)),
+            scope_object_id=self.shelter.pk,
+        )
+
+        errors = [e for e in checks.check_object_grant_targets_whitelisted_model(None) if e.id == "permissions.E003"]
+        self.assertTrue(errors)
+
+    def test_e003_passes_whitelisted_object_grants(self) -> None:
+        user = baker.make(User)
+        profile = self._profile()
+        grant_obj(user=user, role=self.sharer_role, obj=profile)
+
+        errors = [e for e in checks.check_object_grant_targets_whitelisted_model(None) if e.id == "permissions.E003"]
+        self.assertEqual(errors, [])
+
+    # ── orphan cleanup (finding F3) ────────────────────────────────────────
+
+    def test_deleting_the_row_removes_its_object_grants(self) -> None:
+        from django.contrib.contenttypes.models import ContentType
+
+        user = baker.make(User)
+        profile = self._profile()
+        grant_obj(user=user, role=self.sharer_role, obj=profile)
+        ct = ContentType.objects.get_for_model(type(profile))
+        self.assertEqual(Grant.objects.filter(scope_object_type=ct, scope_object_id=profile.pk).count(), 1)
+
+        profile.delete()
+
+        self.assertFalse(Grant.objects.filter(scope_object_type=ct, scope_object_id=profile.pk).exists())

--- a/apps/betterangels-backend/common/tests/test_object_grants.py
+++ b/apps/betterangels-backend/common/tests/test_object_grants.py
@@ -18,7 +18,12 @@ from shelters.models import Bed, Room, Shelter
 from shelters.tests.baker_recipes import shelter_recipe
 from typing import Any
 
+from waffle.testutils import override_switch
 
+from common.permissions.object_grants import OBJECT_GRANTS_SWITCH
+
+
+@override_switch(OBJECT_GRANTS_SWITCH, True)
 class ObjectGrantTestCase(TestCase):
     def setUp(self) -> None:
         sync_roles()
@@ -212,10 +217,98 @@ class ObjectGrantTestCase(TestCase):
 
         user = baker.make(User)
         profile = self._profile()
+        profile_id = profile.pk
         grant_obj(user=user, role=self.sharer_role, obj=profile)
         ct = ContentType.objects.get_for_model(type(profile))
-        self.assertEqual(Grant.objects.filter(scope_object_type=ct, scope_object_id=profile.pk).count(), 1)
+        self.assertEqual(Grant.objects.filter(scope_object_type=ct, scope_object_id=profile_id).count(), 1)
 
         profile.delete()
 
-        self.assertFalse(Grant.objects.filter(scope_object_type=ct, scope_object_id=profile.pk).exists())
+        self.assertFalse(Grant.objects.filter(scope_object_type=ct, scope_object_id=profile_id).exists())
+
+
+@override_switch(OBJECT_GRANTS_SWITCH, False)
+class ObjectGrantDisabledTestCase(TestCase):
+    """The object arm is off by default — the ``object_grants_enabled`` switch gates it.
+
+    While off, ``object_grant_whitelist`` is empty: reads fail closed, the write
+    service refuses to mint grants, and any leftover object-grant row (written
+    before the feature was disabled) is flagged by ``permissions.E003`` rather
+    than silently honored.
+    """
+
+    def setUp(self) -> None:
+        sync_roles()
+        self.sharer_role, _ = Role.objects.get_or_create(name="Test Client Sharer", is_global=False)
+        for perm in (
+            "clients.change_clientprofile",
+            "clients.delete_clientprofile",
+            "clients.view_clientprofile",
+        ):
+            app_label, codename = perm.split(".")
+            self.sharer_role.permissions.add(
+                Permission.objects.get(codename=codename, content_type__app_label=app_label)
+            )
+
+    def test_whitelist_is_empty_while_the_switch_is_off(self) -> None:
+        from common.permissions.object_grants import object_grant_whitelist
+
+        self.assertEqual(object_grant_whitelist(), ())
+
+    def test_grant_obj_refuses_while_the_switch_is_off(self) -> None:
+        from clients.models import ClientProfile
+        from django.core.exceptions import ValidationError
+
+        from accounts.services import grant_obj
+
+        profile = baker.make(ClientProfile)
+        with self.assertRaises(ValidationError):
+            grant_obj(user=baker.make(User), role=self.sharer_role, obj=profile)
+        self.assertFalse(Grant.objects.filter(scope_object_type__isnull=False).exists())
+
+    def test_leftover_object_grant_is_not_honored_while_off(self) -> None:
+        """A grant row written before the feature was disabled fails closed.
+
+        ``can_obj`` returns False and ``visible`` never surfaces the row; the
+        row itself is flagged by E003 so the deploy-time check stays loud.
+        """
+        from clients.models import ClientProfile
+        from django.contrib.contenttypes.models import ContentType
+
+        user = baker.make(User)
+        profile = baker.make(ClientProfile)
+        Grant.objects.create(
+            principal_user=user,
+            role=self.sharer_role,
+            scope_object_type=ContentType.objects.get_for_model(ClientProfile),
+            scope_object_id=profile.pk,
+        )
+
+        self.assertFalse(can_obj(user, ClientProfile.perms.CHANGE, profile))
+        self.assertFalse(visible(ClientProfile.objects.all(), user, ClientProfile.perms.CHANGE).exists())
+        self.assertTrue(
+            any(e.id == "permissions.E003" for e in checks.check_object_grant_targets_whitelisted_model(None))
+        )
+
+    def test_orphan_cleanup_is_skipped_while_off(self) -> None:
+        """While off the cleanup handler returns before issuing SQL — a leftover
+        grant row survives the delete and is left for E003 to flag at deploy
+        time (contrast ``ObjectGrantTestCase``: with the switch on, deleting the
+        row removes its grants)."""
+        from clients.models import ClientProfile
+        from django.contrib.contenttypes.models import ContentType
+
+        user = baker.make(User)
+        profile = baker.make(ClientProfile)
+        profile_id = profile.pk
+        ct = ContentType.objects.get_for_model(ClientProfile)
+        Grant.objects.create(
+            principal_user=user,
+            role=self.sharer_role,
+            scope_object_type=ct,
+            scope_object_id=profile_id,
+        )
+
+        profile.delete()
+
+        self.assertTrue(Grant.objects.filter(scope_object_type=ct, scope_object_id=profile_id).exists())

--- a/apps/betterangels-backend/shelters/tests/test_reservation_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_reservation_queries.py
@@ -213,7 +213,8 @@ class ReservationsQueryTestCase(ReservationQueriesTestCase):
 
         Grant.objects.filter(principal_user=self.operator).delete()
 
-        expected_query_count = 10
+        # The object arm (ADR 0001 §2.5) adds a constant ContentType lookup.
+        expected_query_count = 12
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(
                 self.reservations_query,


### PR DESCRIPTION
## Summary

Wires the **object-grant arm** (ADR 0001 §2.5) with its first consumer — **per-record client sharing** (ADR §5.1, option 2: "no new column; ownership lives in the grant"). Stacked on #2414.

## Predicate (`common/permissions/selectors.py`)
- **`_object_grant_q`** — direct object grants on the row, plus the **`org_via` cascade**: an object grant on an ancestor covers descendants through their FK paths (e.g. a grant on a Shelter covers its beds). Always scoped to the user (principal).
- **`visible()`** now ORs the org filter with the object arm in a **single `filter`**, so per-record grants add rows on top of a deliberately-empty org scope. Uses `pk__lt=0` as the "impossible" predicate — `pk__in=[]`/`none()` triggers Django's `EmptyResultSet` short-circuit which silently swallowed the arm (found by tests).
- **`scopes()` excludes object grants** (`scope_org__isnull=False`) so they never pollute the org filter (an object grant previously leaked `scope_org=None` into the org-arm and over-permitted platform-shared reads — a real bug this PR fixes).
- `OBJECT_ARM_ENABLED = True` (on with its first consumer).

## Whitelist + checks
- `common/permissions/object_grants.py::object_grant_whitelist()` — declares `ClientProfile` (platform-shared, non-org-bearing, clean per E003's own rule). `Note` joins later per ADR §5.
- **E003** now reads the whitelist and flags any object grant on a model outside it.

## Write service + cleanup
- **`grant_obj(user, role, obj)`** — `full_clean()`-validated object grant; refuses non-whitelisted models and global roles (E002).
- **Orphan cleanup (finding F3)** — `post_delete` on each whitelisted model removes dangling object grants (`accounts/signals.py` + wiring in `apps.py`).

## Tests (`common/tests/test_object_grants.py`, 11)
Single-row authority without any org grant; no leak to other rows; role-permission coverage; platform-shared reads unchanged for holders; whitelist-only no-op for org-scoped models; cascade ancestor-path derivation; `grant_obj` create + non-whitelisted/global-role refusal; E003 pass/fail; orphan cleanup on delete.

## Deferred (per the ADR — flagged, not hidden)
- **Notes/guardian migration (ADR §5)** — explicitly "not mechanical"; needs the `Note` OrgScoped declaration, shared-note semantics, and guardian teardown.
- **Clients sharing edge service + §5.1 decision** — this PR makes cross-org client edit *expressible* via object grants; the product-facing sharing flow and the `created_by_org` option remain open.
- `clients/services/merge.py` guardian logic untouched.

## Validation
- `common/` + `accounts/` + `shelters/`: **970 passed** (incl. one query-count bump for the object arm's constant ContentType lookup under `assertNumQueriesWithoutCache`)
- ruff + mypy clean; `manage.py check` 0 issues

## Stack
1. #2409 models · 2. #2410 provisioning · 3. #2411 selectors · 4. #2412 shelter cutover · 5. #2413 delegation · 6. #2414 reachability · **7. #… object arm** · 8. teardown

## Summary by Sourcery

Enable the object-grant authorization arm for per-record client sharing with consistent validation, fail-closed enforcement, and lifecycle cleanup.

New Features:
- Enable per-record client sharing through user-scoped object grants, including inherited access from grantable ancestors.

Bug Fixes:
- Prevent object grants from leaking into organization-scoped authorization and prevent organization permission holders from mutating every platform-shared client.
- Remove object-grant records when enabled grantable objects are deleted.

Enhancements:
- Add a switch-gated object-grant whitelist and enforce it across authorization, grant creation, admin forms, and system checks.
- Add object-grant support to single-record authorization while preserving platform-shared read behavior and failing closed for unsupported writes.

Tests:
- Add coverage for object-grant visibility, permission inheritance, validation, disabled-feature behavior, whitelist checks, and orphan cleanup.
- Update reservation query expectations for the object-grant authorization lookup.