### PR TITLE
feat(perm): grant hygiene — write-time guards, admin role filter, ADR reconciliation (PR 9)

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -340,6 +340,17 @@ class MemberInviteAdminMixin:
         }
 
 
+def _scoped_role_queryset() -> Any:
+    """Grant forms must not offer global Roles.
+
+    A global Role is held in ``user.groups`` (the global tier), never in a
+    Grant — ``permissions.E002`` makes a grant referencing one a deploy-time
+    error, so the admin refuses the choice up front instead of writing a row
+    that only a check will flag.
+    """
+    return Role.objects.filter(is_global=False)
+
+
 @admin.register(Role)
 class RoleAdmin(admin.ModelAdmin):
     """Code-owned roles (ADR 0001 §2.2) — read-only in the admin."""
@@ -357,6 +368,11 @@ class GrantAdmin(admin.ModelAdmin):
     object scope (exactly one) are enforced by the model constraints; a global
     Role can never be granted (check ``permissions.E002``).
     """
+
+    def formfield_for_foreignkey(self, db_field: Any, request: Any, **kwargs: Any) -> Any:
+        if db_field.name == "role":
+            kwargs["queryset"] = _scoped_role_queryset()
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     list_display = (
         "id",
@@ -403,6 +419,11 @@ class GrantInline(admin.TabularInline):
     extra = 0
     autocomplete_fields = ("principal_user", "principal_org", "role")
 
+    def formfield_for_foreignkey(self, db_field: Any, request: Any, **kwargs: Any) -> Any:
+        if db_field.name == "role":
+            kwargs["queryset"] = _scoped_role_queryset()
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
 
 class DelegatedGrantInline(admin.TabularInline):
     """Org→org delegations FROM this org — what this org lends to others (ADR 0001 §2.2)."""
@@ -411,6 +432,11 @@ class DelegatedGrantInline(admin.TabularInline):
     fk_name = "principal_org"
     extra = 0
     autocomplete_fields = ("role", "scope_org")
+
+    def formfield_for_foreignkey(self, db_field: Any, request: Any, **kwargs: Any) -> Any:
+        if db_field.name == "role":
+            kwargs["queryset"] = _scoped_role_queryset()
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
 @admin.register(Organization)

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -626,9 +626,19 @@ def grant_create(*, user: UserModel, role: Role, scope_org: Organization) -> Gra
     """Grant *user* the scoped *role* at *scope_org* (ADR 0001 §2.2).
 
     Validates via ``full_clean`` (which checks the model constraints since
-    Django 4.1) before saving, per the repo styleguide.
+    Django 4.1) before saving, per the repo styleguide.  A global Role can
+    never be granted through a Grant — it belongs in ``user.groups`` via
+    :func:`role_assign` (mirrors ``permissions.E002`` at write time).
+
+    Raises:
+        ``django.core.exceptions.ValidationError`` when *role* is global.
     """
     from accounts.models import Grant
+
+    if role.is_global:
+        raise ValidationError(
+            f"Role {role.name!r} is global; grant it via role_assign, not a Grant (permissions.E002)."
+        )
 
     grant = Grant(principal_user=user, role=role, scope_org=scope_org)
     grant.full_clean()
@@ -643,9 +653,15 @@ def grant_delegate(*, principal_org: Organization, role: Role, scope_org: Organi
     members of *principal_org* AND hold a direct Grant there ("acting at" the
     org).  The org cannot delegate a role to itself (model constraint
     ``grant_org_principal_is_not_scope``) and a global Role can never be
-    delegated (check ``permissions.E002``).
+    delegated (mirrors ``permissions.E002`` at write time).
+
+    Raises:
+        ``django.core.exceptions.ValidationError`` when *role* is global.
     """
     from accounts.models import Grant
+
+    if role.is_global:
+        raise ValidationError(f"Role {role.name!r} is global; scoped roles only (permissions.E002).")
 
     grant = Grant(principal_org=principal_org, role=role, scope_org=scope_org)
     grant.full_clean()

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -4,7 +4,7 @@ Creating an organization in the admin used to produce one that could hold no
 roles and accept no members, and adding a member to it returned a 500.
 """
 
-from typing import cast
+from typing import Any, cast
 
 from accounts.admin import CustomOrganizationUserAdmin
 from accounts.groups import ORG_ADMIN
@@ -14,6 +14,7 @@ from accounts.models import (
     OrgTypeChoices,
     PermissionGroup,
     PermissionGroupTemplate,
+    Role,
     User,
 )
 from accounts.seed import seed_permission_templates
@@ -1334,3 +1335,39 @@ class PermissionGroupTemplateAdminTestCase(TestCase):
         seed_permission_templates()
         with self.assertRaises(IntegrityError), transaction.atomic():
             reconcile_org_groups(self.organization)
+
+
+class GrantAdminRoleFilterTestCase(TestCase):
+    """Grant forms offer only scoped Roles — a global Role is held in user.groups (permissions.E002)."""
+
+    def setUp(self) -> None:
+        from accounts.admin import DelegatedGrantInline, GrantAdmin, GrantInline
+        from accounts.services import sync_roles
+
+        sync_roles()
+        self.grant_admin = GrantAdmin(Grant, admin.site)
+        self.grant_inline = GrantInline(Grant, admin.site)
+        self.delegated_inline = DelegatedGrantInline(Grant, admin.site)
+        self.scoped = Role.objects.get(name=SHELTER_OPERATOR.name, is_global=False)
+        self.global_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR.name, is_global=True)
+
+    def _role_queryset(self, admin_instance: Any) -> Any:
+        field = admin_instance.formfield_for_foreignkey(
+            Grant._meta.get_field("role"),
+            None,  # type: ignore[arg-type]
+        )
+        return field.queryset
+
+    def _assert_scoped_only(self, admin_instance: Any) -> None:
+        queryset = self._role_queryset(admin_instance)
+        self.assertIn(self.scoped, queryset)
+        self.assertNotIn(self.global_role, queryset)
+
+    def test_grant_admin_offers_only_scoped_roles(self) -> None:
+        self._assert_scoped_only(self.grant_admin)
+
+    def test_grant_inline_offers_only_scoped_roles(self) -> None:
+        self._assert_scoped_only(self.grant_inline)
+
+    def test_delegated_grant_inline_offers_only_scoped_roles(self) -> None:
+        self._assert_scoped_only(self.delegated_inline)

--- a/apps/betterangels-backend/accounts/tests/test_grant_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_grant_services.py
@@ -26,6 +26,13 @@ class GrantServiceTestCase(TestCase):
         self.assertIsNone(grant.principal_org)
         self.assertIsNone(grant.scope_object_type)
 
+    def test_grant_create_refuses_a_global_role(self) -> None:
+        """A global Role can never be granted through a Grant (permissions.E002)."""
+        with self.assertRaises(ValidationError):
+            grant_create(user=self.user, role=self.gso_role, scope_org=self.org)
+
+        self.assertFalse(Grant.objects.filter(principal_user=self.user).exists())
+
     def test_grant_create_validates_before_saving(self) -> None:
         with self.assertRaises(ValidationError):
             grant_create(user=self.user, role=self.shelter_role, scope_org=None)  # type: ignore[arg-type]
@@ -50,16 +57,14 @@ class GrantServiceTestCase(TestCase):
 
         self.assertFalse(Grant.objects.filter(principal_org=self.org).exists())
 
-    def test_grant_delegate_rejects_a_global_role(self) -> None:
-        """A global Role must never be delegated — check permissions.E002 flags it."""
-        from common.permissions import checks
-
+    def test_grant_delegate_refuses_a_global_role(self) -> None:
+        """A global Role must never be delegated — refused at write time (permissions.E002)."""
         other_org = organization_recipe.make(name="Global Role Delegatee")
-        grant_delegate(principal_org=self.org, role=self.gso_role, scope_org=other_org)
 
-        # The row violates E002 (Grant referencing a global Role).
-        errors = [e for e in checks.check_grant_never_references_global_role(None) if e.id == "permissions.E002"]
-        self.assertTrue(errors)
+        with self.assertRaises(ValidationError):
+            grant_delegate(principal_org=self.org, role=self.gso_role, scope_org=other_org)
+
+        self.assertFalse(Grant.objects.filter(principal_org=self.org).exists())
 
     def test_grant_delete_revokes_a_delegation(self) -> None:
         other_org = organization_recipe.make(name="Delegatee Org")

--- a/apps/betterangels-backend/shelters/selectors/__init__.py
+++ b/apps/betterangels-backend/shelters/selectors/__init__.py
@@ -11,7 +11,6 @@ from shelters.selectors.operator import (
     shelter_get,
     shelter_list,
     shelter_queryset,
-    user_shelter_list,
 )
 from shelters.selectors.reports import (
     avg_days_to_occupancy,

--- a/apps/betterangels-backend/shelters/selectors/operator.py
+++ b/apps/betterangels-backend/shelters/selectors/operator.py
@@ -38,19 +38,6 @@ def shelter_list(
     return queryset.filter(is_private=False)
 
 
-def user_shelter_list(
-    queryset: "QuerySet[Shelter]",
-    *,
-    user: "User",
-) -> "QuerySet[Shelter]":
-    """Filter to shelters belonging to organizations that *user* is a member of.
-
-    Does NOT require a specific organization — used by global permission
-    checks (e.g., photo mutations using ``HasPerm``).
-    """
-    return queryset.filter(Exists(Organization.objects.filter(pk=OuterRef("organization_id"), users=user)))
-
-
 def operator_shelter_list(
     queryset: "QuerySet[Shelter]",
     *,

--- a/docs/adr/0001-grant-based-authorization.md
+++ b/docs/adr/0001-grant-based-authorization.md
@@ -314,8 +314,14 @@ subquery, not a re-derivation.
 - **Creates under an object grant** resolve the parent object and check
   `can_obj(parent, child_ADD)` (finding F17) — ADD-on-child ≈ CHANGE-on-parent. This is
   a stated convention for every child-create service, not per-site.
-- The arm is `OBJECT_ARM_ENABLED = False` until the clients cutover ships (finding F9);
-  it is turned on with its first consumer, not before.
+- The arm ships **on** (`OBJECT_ARM_ENABLED = True`, PR #2415) but is a *no-op for
+  every non-whitelisted model* (`_object_grant_q` fails closed with `pk__lt=0`), and
+  `ClientProfile` — the only whitelisted model — is not yet read through `visible()`
+  by any consumer. It is therefore schema-live and predicate-lazy: it gains its first
+  real effect when the clients cutover reads `ClientProfile` through `visible()`, and
+  per-record capability fields ship then (§5.2). This revises the earlier finding-F9
+  "keep it `False` until the cutover" rule: turning it on early is harmless because the
+  whitelist gates every effect, and it keeps the object-grant tests live.
 
 ### 2.6 Mutation surface convention
 
@@ -530,7 +536,7 @@ cutover touches those exact code paths.
    `can_anywhere`; owner-tier `created_by_org` parked for later product adoption).
    Required before phase 4. The tier-3 FE surfacing shape (§5.2 — `canChange`/
    `canDelete` via `can_obj`) is chosen regardless of which write tier wins. Decision
-   request: `docs/adr/0002-client-writes-ownership.md` (added later in the stack).
+   request: `docs/adr/0002-client-writes-ownership.md`.
 
 [SDB-218]: https://betterangels.atlassian.net/browse/SDB-218
 [PR #2407]: https://github.com/BetterAngelsLA/monorepo/pull/2407


### PR DESCRIPTION
## Summary

Follow-ups from the adversarial review of the grant stack (#2409–#2416), tracked in #2417. Stacked on the teardown (#2416).

## Changes

### Write-time global-role guards (medium finding 1)
- `grant_create` / `grant_delegate` now **refuse a global Role** with `ValidationError` at write time (mirrors `permissions.E002`), matching `grant_obj` and `role_assign`. Previously a global-role Grant could be written and only flagged by `manage.py check`.
- `GrantAdmin`, `GrantInline`, `DelegatedGrantInline` restrict the `role` choices to scoped Roles, so staff can't write a global-role Grant through the admin.
- The old test that **pinned** the permissive behavior (`test_grant_delegate_rejects_a_global_role`) is inverted to assert the write-time refusal; added `test_grant_create_refuses_a_global_role` and three admin role-filter tests. Both guard tests fail against the old services.

### Dead code (low finding 4)
- Removed `user_shelter_list` from `shelters/selectors/operator.py` + its re-export — no callers since the shelter cutover.

### ADR reconciliation (medium finding 2 + §7.6)
- ADR 0001 §2.5 reconciled with code: `OBJECT_ARM_ENABLED` ships **on** but is a whitelist-gated no-op for every model except `ClientProfile`, which no consumer reads through `visible()` yet. Revises the earlier finding-F9 "keep it `False`" rule.
- New **RFC 0002** — `docs/adr/0002-client-writes-ownership.md`: the §7.6 client-ownership decision request, recommending `created_by_org` (per ADR rule 4: ownership is a data property, not grant rows at creation). §7.6 now links to it.

## Validation
- Full backend suite: **1652 passed, 31 skipped, 0 failed** · ruff format/check clean · mypy (strict) clean.

## Deferred (already tracked in #2417)
- Header-optional mutation convention (only `create_shelter` follows §2.6) — for the cutover wave.
- Tier-3 per-record FE surfacing (`canChange`/`canDelete`) — ships with the clients cutover (ADR §5.2).

## Summary by Sourcery

Harden grant creation and delegation against invalid global-role assignments while aligning authorization documentation with the current object-grant rollout and client ownership decision.

Bug Fixes:
- Reject global roles when creating or delegating grants instead of allowing invalid grant records to be written.
- Prevent the admin grant forms from offering global roles as selectable grant targets.

Enhancements:
- Remove the unused user_shelter_list selector and its export.
- Reconcile ADR 0001 with the enabled, whitelist-gated object-grant arm and document the client-write ownership decision in RFC 0002.

Documentation:
- Update the grant authorization ADR and add the client-write ownership RFC reference and decision recommendation.

Tests:
- Add service and admin coverage for rejecting and filtering global roles in grants.