### PR TITLE
feat(perm): teardown the GSO legacy PermissionGroup (PR 10)

### DIFF
--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -603,11 +603,15 @@ def backfill_shelter_grants() -> None:
 
 
 def backfill_global_role_members() -> None:
-    """Move Global Shelter Operator members onto the global Role group.
+    """Move Global Shelter Operator members onto the global Role group, then
+    delete the legacy GSO ``PermissionGroup`` rows (teardown, ADR 0001 §4 phase 5).
 
-    The GSO ``PermissionGroup`` was pinned to one arbitrary org; its members now
+    The GSO ``PermissionGroup`` was pinned to one arbitrary org; its members
     belong on the global Role's group, which is the global tier (ADR 0001 §2.1).
-    Idempotent (``user.groups.add``).
+    Once moved, the group row is dead weight — nothing reads it for authority
+    (the global tier is the Role group, and the Role carries the same
+    permissions, ``RoleDef.from_template(GLOBAL_SHELTER_OPERATOR)``), so it is
+    deleted the way ``reconcile_org_groups`` deletes stale groups.  Idempotent.
     """
     from accounts.models import PermissionGroup, Role
     from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE
@@ -617,6 +621,7 @@ def backfill_global_role_members() -> None:
     for group in groups.prefetch_related("user_set"):
         for user in group.user_set.all():
             user.groups.add(role)
+    groups.delete()
 
 
 # ── Grant write services (ADR 0001 §2.9) ─────────────────────────────────

--- a/apps/betterangels-backend/accounts/tests/test_roles.py
+++ b/apps/betterangels-backend/accounts/tests/test_roles.py
@@ -4,7 +4,7 @@ from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, Rol
 from accounts.services import backfill_global_role_members, backfill_shelter_grants, sync_roles
 from accounts.tests.baker_recipes import organization_recipe
 from common.permissions.checks import check_role_permissions_models_declare_org_scoping
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from model_bakery import baker
@@ -118,6 +118,10 @@ class BackfillTestCase(TestCase):
         backfill_global_role_members()
 
         self.assertTrue(member.groups.filter(role__is_global=True).exists())
+        # Teardown (ADR 0001 §4 phase 5): the legacy group row is dead weight
+        # once its members are on the Role group — nothing reads it for authority.
+        self.assertFalse(PermissionGroup.objects.filter(pk=gso_group.pk).exists())
+        self.assertFalse(Group.objects.filter(pk=gso_group.pk).exists())
 
 
 class ViewPrivateGlobalTierTestCase(TestCase):

--- a/apps/betterangels-backend/shelters/tests/test_group_permissions.py
+++ b/apps/betterangels-backend/shelters/tests/test_group_permissions.py
@@ -1,27 +1,27 @@
-from accounts.models import PermissionGroup, PermissionGroupTemplate, User
-from accounts.seed import seed_permission_templates, sync_group_permissions
-from accounts.tests.baker_recipes import organization_recipe
+"""Global Shelter Operator — the global Role tier carries the shelter permissions.
+
+Teardown (ADR 0001 §4 phase 5): GSO authority is the **global Role** held in
+``user.groups`` — not a legacy ``PermissionGroup``, which ``backfill_global_role_members``
+moves members off of and then deletes.  Every assertion here checks the Role group's
+permission set, the same ground the pre-teardown PermissionGroup suite covered.
+"""
+
+from accounts.models import Role, User
+from accounts.services import role_assign, sync_roles
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from model_bakery import baker
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE
 
 
-class ShelterGroupPermissionsTestCase(TestCase):
-    """Global Shelter Operator is granted by hand, so it has no org type.
-
-    Its permissions still have to reach the ``auth.Group`` that grants them,
-    which is what every assertion here checks — the group, not any intermediate
-    copy of the permission set.
-    """
-
+class GlobalShelterOperatorTierTestCase(TestCase):
     def setUp(self) -> None:
-        self.org = organization_recipe.make(preset_names=["shelter"], owner_roles=())
-        self.template = PermissionGroupTemplate.objects.get(name="Global Shelter Operator")
-        self.permission_group = PermissionGroup.objects.create(organization=self.org, template=self.template)
+        sync_roles()
+        self.role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
 
-    def _group_codenames(self, model: str) -> set[str]:
+    def _role_codenames(self, model: str) -> set[str]:
         return set(
-            self.permission_group.permissions.filter(
+            self.role.permissions.filter(
                 content_type__app_label="shelters",
                 content_type__model=model,
             ).values_list("codename", flat=True)
@@ -35,45 +35,22 @@ class ShelterGroupPermissionsTestCase(TestCase):
             ).values_list("codename", flat=True)
         )
 
-    def test_group_gets_every_schedule_permission(self) -> None:
-        sync_group_permissions()
-        self.assertSetEqual(self._group_codenames("schedule"), self._all_codenames("schedule"))
+    def test_role_gets_every_schedule_permission(self) -> None:
+        self.assertSetEqual(self._role_codenames("schedule"), self._all_codenames("schedule"))
 
-    def test_group_gets_every_availability_permission(self) -> None:
-        sync_group_permissions()
-        self.assertSetEqual(self._group_codenames("shelteravailability"), self._all_codenames("shelteravailability"))
+    def test_role_gets_every_availability_permission(self) -> None:
+        self.assertSetEqual(self._role_codenames("shelteravailability"), self._all_codenames("shelteravailability"))
 
-    def test_group_gets_view_private_shelter(self) -> None:
-        sync_group_permissions()
-        self.assertTrue(
-            self.permission_group.permissions.filter(
-                content_type__app_label="shelters", codename="view_private_shelter"
-            ).exists()
-        )
+    def test_role_gets_view_private_shelter(self) -> None:
+        user = baker.make(User)
+        role_assign(user=user, role=self.role)
 
-    def test_sync_populates_an_empty_group_and_is_idempotent(self) -> None:
-        self.permission_group.permissions.clear()
-
-        sync_group_permissions()
-        first_pass = set(self.permission_group.permissions.values_list("codename", flat=True))
-        self.assertIn("view_shelter", first_pass)
-        self.assertIn("change_shelter", first_pass)
-
-        sync_group_permissions()
-        self.assertSetEqual(set(self.permission_group.permissions.values_list("codename", flat=True)), first_pass)
+        self.assertIn("shelters.view_private_shelter", user.get_all_permissions())
 
     def test_member_gains_shelters_admin_access(self) -> None:
         user = baker.make(User, is_staff=True)
-        self.permission_group.user_set.add(user)
-        self.permission_group.permissions.clear()
+        role_assign(user=user, role=self.role)
 
-        self.assertNotIn("shelters.view_shelter", user.get_all_permissions())
-
-        seed_permission_templates()
-        sync_group_permissions()
-
-        # Re-fetch to bypass the cached permission set on the old instance.
-        user = User.objects.get(pk=user.pk)
         self.assertIn("shelters.view_shelter", user.get_all_permissions())
         self.assertIn("shelters.change_shelter", user.get_all_permissions())
         self.assertTrue(user.has_module_perms("shelters"))

--- a/docs/adr/0001-grant-based-authorization.md
+++ b/docs/adr/0001-grant-based-authorization.md
@@ -38,7 +38,10 @@ cannot express org→org delegation; and it is unreachable from the frontend
 (`CurrentUserOrganizationType` is membership-derived, so a non-member global holder
 gets an empty org list and every UI screen keys off `activeOrg`). Its one useful
 artifact is the 541-line `test_global_shelter_operator.py`, which we keep as the
-behavioral contract.
+behavioral contract — its assertions now live, grant-model-first, in
+`shelters/tests/test_grant_cutover.py`, `common/tests/test_permissions_selectors.py`,
+`common/tests/test_delegation.py`, `common/tests/test_object_grants.py`, and
+`shelters/tests/test_group_permissions.py` (the GSO global-Role tier).
 
 **Requirements (from the SDB-218 / outreach thread).** One model must handle: user
 grants, global group grants, org grants (org→org "view/edit managed others"), object


### PR DESCRIPTION
## Summary

Cleanup from a full audit of grant-model completeness. The shelter domain is fully moved (no `PermissionGroup` reads, no guardian, no `HasOrgPerm`, all `IsAuthenticated` + grant selectors; non-migrated apps — clients/notes/tasks/referrals/teams/reports — are intentionally still legacy). The audit found **one zombie**: the **Global Shelter Operator legacy `PermissionGroup`**.

## The zombie

GSO authority is the **global Role** in `user.groups`. The legacy GSO `PermissionGroup` was only the transition artifact:
- `backfill_global_role_members` moved members onto the Role group but **left the group rows forever** — `reconcile_org_groups` treats GSO as unscoped/hand-managed and never deletes them.
- `sync_group_permissions` kept syncing the dead rows.
- `shelters/tests/test_group_permissions.py` tested this dead path.

Deleting them is safe: the Role group carries the same permissions (`RoleDef.from_template(GLOBAL_SHELTER_OPERATOR)`), so no authority is lost.

## Changes

- **`backfill_global_role_members`** now **deletes the GSO `PermissionGroup` rows** after moving members (same queryset-delete pattern as reconcile's stale-group cleanup). Idempotent.
- **`shelters/tests/test_group_permissions.py`** rewritten from the dead legacy group to the **GSO global-Role tier contract**: schedule/availability permissions, `view_private_shelter`, and admin access all via `role_assign`.
- **`accounts/tests/test_roles.py`** backfill test now also asserts the legacy group row **and its `auth.Group`** are gone.
- **ADR 0001** — the referenced "retained" `test_global_shelter_operator.py` no longer exists; the behavioral contract now lives grant-model-first in `test_grant_cutover`, `test_permissions_selectors`, `test_delegation`, `test_object_grants`, and `test_group_permissions`.

## Validation

- Full `accounts`/`common`/`shelters` suite: **978 passed, 0 failed** · ruff format/check clean · mypy (strict) clean.

## Audit notes (no change needed)

- Shelters: zero legacy reads; all 17 `@hasOrgPerm` remaining in the schema are organizations/teams/reports (non-migrated, intentional).
- Guardian (`assign_object_permissions`) only in clients/tasks/referrals/notes — the phase-4 teardown targets.
- `resolve_permission_group` only in clients/tasks/referrals/hmis — non-migrated.
- `backfill_shelter_grants` kept as a documented idempotent safety net.

## Summary by Sourcery

Complete the Global Shelter Operator authorization teardown by removing its legacy PermissionGroup and validating the global Role as the sole authority source.

Bug Fixes:
- Remove obsolete Global Shelter Operator PermissionGroup records after transferring members to the global Role tier, preventing dead legacy authorization data from persisting.

Enhancements:
- Align Global Shelter Operator permission coverage and access tests with the global Role-based grant model.
- Update the authorization ADR to reference the grant-model-first behavioral test suites.

Documentation:
- Document the current locations of the Global Shelter Operator behavioral contract after legacy test coverage was removed.

Tests:
- Extend role backfill coverage to verify deletion of both legacy PermissionGroup and auth.Group records.
- Rewrite shelter permission tests to validate schedule, availability, private shelter, and administrative access through the global Role.