### PR TITLE
perf(perm): memoize scopes() decision + reconcile role lookup (PR 11)

### DIFF
--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -321,6 +321,15 @@ def reconcile_org_groups(org: Organization) -> None:
     org_types = OrganizationProfile.objects.values_list("org_types", flat=True).filter(organization=org).first()
 
     if org_types is not None:
+        # One query for the whole reconcile, not one per template: the set of
+        # scoped Role names (role-backed templates are Grant-authoritative).
+        role_backed_names = set(Role.objects.filter(is_global=False).values_list("name", flat=True))
+        unscoped = {template_config.name for template_config in REGISTRY.unscoped}
+        # ``expected`` excludes role-backed templates, so ``derived - expected``
+        # deletes any stale legacy row a pre-teardown org still carries — the
+        # Grant is authoritative now, and the row is dead weight.
+        derived = {name for name in REGISTRY.template_names() if name not in unscoped}
+
         expected: set[str] = set()
         expected_role_backed: set[str] = set()
         for org_type_value in org_types:
@@ -331,7 +340,7 @@ def reconcile_org_groups(org: Organization) -> None:
                 # Post-teardown (ADR 0001 §4 phase 5): role-backed templates
                 # (migrated domains) have no legacy PermissionGroup — the Grant
                 # is authoritative.  Skip them here and delete any stale rows.
-                if Role.objects.filter(name=template_config.name, is_global=False).exists():
+                if template_config.name in role_backed_names:
                     expected_role_backed.add(template_config.name)
                     continue
                 expected.add(template_config.name)
@@ -345,12 +354,6 @@ def reconcile_org_groups(org: Organization) -> None:
                 template=permission_group_template,
             )
 
-        unscoped = {template_config.name for template_config in REGISTRY.unscoped}
-        # ``expected`` excludes role-backed templates, so ``derived - expected``
-        # deletes any stale legacy row a pre-teardown org still carries — the
-        # Grant is authoritative now, and the row is dead weight.
-        derived = {name for name in REGISTRY.template_names() if name not in unscoped}
-
         PermissionGroup.objects.filter(
             organization=org,
             template__name__in=derived - expected,
@@ -359,14 +362,9 @@ def reconcile_org_groups(org: Organization) -> None:
         # Role-backed templates the org no longer offers are revoked the same
         # way their legacy groups were: the role is not derivable from any org
         # type the org still holds, so every scoped Grant for it is deleted.
-        role_backed = {
-            name
-            for name in REGISTRY.template_names()
-            if name not in unscoped and Role.objects.filter(name=name, is_global=False).exists()
-        }
         Grant.objects.filter(
             scope_org=org,
-            role__name__in=role_backed - expected_role_backed,
+            role__name__in=(derived & role_backed_names) - expected_role_backed,
         ).delete()
 
     _refresh_group_names(org)

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -163,46 +163,50 @@ def scopes(user: "User", perm: str) -> Any:
       role at B without membership does NOT inherit — no amplification (ADR 0001
       §2.4, findings F1/F19).  One hop only.
 
-    Memoized per request on the user instance.  The cached value is a lazy
-    queryset used as a subquery — caching it does not evaluate it.
+    Memoized per request on the user instance — the **whole** decision, global
+    tier included: the superuser / global-Role / ``user_permissions`` checks are
+    EXISTS queries, and a shelter page checks the same permission on several
+    fields, so they must not re-run per call.  The cached value is either the
+    ``ALL`` sentinel or a lazy queryset used as a subquery — caching it does not
+    evaluate it.
     """
-    if user.is_superuser or _global_role_holds(user, perm) or _user_permission_holds(user, perm):
-        return ALL
-
     from accounts.models import Grant, Organization
 
     cache = user.__dict__.setdefault("_scope_cache", {})
     if perm not in cache:
-        roles = _roles_carrying_perm(perm)
-        # Org-scope arm only: object grants (scope_org IS NULL) never feed the
-        # org filter — they are per-record and handled by the object arm.
-        mine = Grant.objects.filter(principal_user=user, role__in=Subquery(roles), scope_org__isnull=False).values(
-            "scope_org"
-        )
-
-        # Delegation: orgs where the user acts (member + holds a direct Grant
-        # at that org) inherit that org's org→org delegations.  "Acts at B" is
-        # role-keyed: the grant at B must carry *this* permission's role, or a
-        # member holding only a weak role at B would inherit everything B
-        # delegated at C — more authority at C than at B (audit C-1).
-        acting_at = (
-            Organization.objects.filter(
-                users=user,
-                grants__principal_user=user,
-                grants__role__in=Subquery(roles),
+        if user.is_superuser or _global_role_holds(user, perm) or _user_permission_holds(user, perm):
+            cache[perm] = ALL
+        else:
+            roles = _roles_carrying_perm(perm)
+            # Org-scope arm only: object grants (scope_org IS NULL) never feed the
+            # org filter — they are per-record and handled by the object arm.
+            mine = Grant.objects.filter(principal_user=user, role__in=Subquery(roles), scope_org__isnull=False).values(
+                "scope_org"
             )
-            .values("pk")
-            .distinct()
-        )
-        # Org-scope arm only on inherited delegations too: object grants
-        # (scope_org IS NULL) never feed the org filter.
-        inherited = Grant.objects.filter(
-            principal_org__in=Subquery(acting_at),
-            role__in=Subquery(roles),
-            scope_org__isnull=False,
-        ).values("scope_org")
 
-        cache[perm] = mine.union(inherited)
+            # Delegation: orgs where the user acts (member + holds a direct Grant
+            # at that org) inherit that org's org→org delegations.  "Acts at B" is
+            # role-keyed: the grant at B must carry *this* permission's role, or a
+            # member holding only a weak role at B would inherit everything B
+            # delegated at C — more authority at C than at B (audit C-1).
+            acting_at = (
+                Organization.objects.filter(
+                    users=user,
+                    grants__principal_user=user,
+                    grants__role__in=Subquery(roles),
+                )
+                .values("pk")
+                .distinct()
+            )
+            # Org-scope arm only on inherited delegations too: object grants
+            # (scope_org IS NULL) never feed the org filter.
+            inherited = Grant.objects.filter(
+                principal_org__in=Subquery(acting_at),
+                role__in=Subquery(roles),
+                scope_org__isnull=False,
+            ).values("scope_org")
+
+            cache[perm] = mine.union(inherited)
     return cache[perm]
 
 

--- a/apps/betterangels-backend/common/tests/test_permissions_selectors.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_selectors.py
@@ -123,3 +123,45 @@ class GrantSelectorsTestCase(TestCase):
 
         self.assertTrue(can_anywhere(alice, ClientProfile.perms.VIEW))
         self.assertFalse(can_anywhere(stranger, ClientProfile.perms.VIEW))
+
+
+class ScopesMemoizationTestCase(TestCase):
+    """scopes() caches the whole decision — global tier included.
+
+    A shelter page checks the same permission on several fields; the
+    superuser/global-Role/user_permissions EXISTS checks must not re-run
+    per call (they used to, costing 2 queries per visible()).
+    """
+
+    def setUp(self) -> None:
+        sync_roles()
+        self.org = organization_recipe.make(name="Memo Org")
+        self.user = baker.make(User)
+        grant_create(user=self.user, role=Role.objects.get(name=SHELTER_OPERATOR_ROLE.name), scope_org=self.org)
+
+    def test_repeated_scopes_calls_execute_no_extra_queries(self) -> None:
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            scopes(self.user, Shelter.perms.VIEW)
+        first = len(ctx.captured_queries)
+        self.assertGreater(first, 0)
+
+        with CaptureQueriesContext(connection) as ctx:
+            scopes(self.user, Shelter.perms.VIEW)
+            scopes(self.user, Shelter.perms.VIEW)
+        self.assertEqual(len(ctx.captured_queries), 0, "memoized scopes() must not re-query")
+
+    def test_the_all_sentinel_is_cached_too(self) -> None:
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        gso = baker.make(User)
+        role_assign(user=gso, role=Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name))
+        self.assertIs(scopes(gso, Shelter.perms.VIEW), ALL)
+
+        with CaptureQueriesContext(connection) as ctx:
+            self.assertIs(scopes(gso, Shelter.perms.VIEW), ALL)
+            self.assertIs(scopes(gso, Shelter.perms.VIEW), ALL)
+        self.assertEqual(len(ctx.captured_queries), 0, "the cached ALL sentinel must not re-query")

--- a/apps/betterangels-backend/shelters/tests/test_room_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_room_queries.py
@@ -97,7 +97,9 @@ class RoomQueryTestCase(RoomQueriesTestCase):
                 }
             }
         """
-        expected_query_count = 12
+        # scopes() now memoizes the whole decision (global-tier checks included),
+        # so the repeated view_room check costs 0 — 2 queries fewer than before.
+        expected_query_count = 10
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(query, variables={"id": str(self.room.pk)})
 


### PR DESCRIPTION
## Summary

Query-optimization pass over the grant predicate and provisioning, from a performance-focused review.

## Changes

### 1. `scopes()` now memoizes the **whole** decision, global tier included
`scopes()` cached the lazy org-scope union, but ran the global-tier checks (superuser / global-Role / `user_permissions` — **2 EXISTS**) **before** the cache lookup — so every `visible()` call on a page re-paid them. The whole decision — the `ALL` sentinel included — is now memoized per `(user, perm)`.

Measured on a real shelter-operator scenario:
- 3 `visible()` calls on the same perm: **10 → 6 queries**
- 3 `scopes()` calls: **6 → 2 queries**

### 2. `reconcile_org_groups` loads the scoped-Role name set once
It issued a `Role.objects.filter(is_global=False).exists()` per template per org; the role-backed name set is now loaded in a single query per reconcile (migrate-time path).

### 3. Regression tests
- `ScopesMemoizationTestCase`: repeated `scopes()` calls execute **0** extra queries; the cached `ALL` sentinel too.
- `test_room_query_with_beds_status` query count 12 → 10 — it had pinned the redundant per-call global EXISTS.

## Validation
Full `accounts`/`common`/`shelters` suite: **978 passed, 0 failed** · ruff format/check clean · mypy (strict) clean.

## Notes (reviewed, not changed)
- `can()` rebuilds the memoized scope union for a one-org membership test — kept, because the memoized union is reused and a targeted rewrite would duplicate delegation logic and risk drift.
- Per-field subquery overhead in `visible()` (~2–3 subqueries per permission) is the documented fail-closed tradeoff; the object arm is whitelist-gated so non-whitelisted models pay only an always-false predicate.

## Summary by Sourcery

Reduce permission query overhead by memoizing complete scope decisions and batching role lookups during organization reconciliation.

Enhancements:
- Memoize complete permission scope decisions, including global permission checks, to avoid repeated queries within a request.
- Optimize organization group reconciliation by loading scoped role names in a single query per reconciliation.

Tests:
- Add regression coverage confirming repeated scoped permission checks, including cached global access, execute no additional queries.
- Update room query expectations to reflect reduced permission-check query overhead.