### PR TITLE
fix(perm): view_private_shelter is global-tier only (PR 13)

### DIFF
--- a/apps/betterangels-backend/shelters/groups.py
+++ b/apps/betterangels-backend/shelters/groups.py
@@ -52,7 +52,11 @@ SHELTER_OPERATOR = TemplateConfig(
         Reservation.perms.CHANGE,
         Reservation.perms.DELETE,
         Reservation.perms.VIEW,
-        Shelter.perms.VIEW_PRIVATE,
+        # view_private_shelter deliberately NOT on the scoped role: private
+        # shelters in the public directory are a global-tier gate (the only
+        # consumer reads has_perm, which Grants don't feed); a shelter operator
+        # sees their org's private shelters through the org-scoped visible()
+        # path instead (ADR 0001 §2.4).
         ClientProfile.perms.VIEW,
     ],
     invite_html="account/email/shelter_operator_invite.html",

--- a/apps/betterangels-backend/shelters/tests/test_group_permissions.py
+++ b/apps/betterangels-backend/shelters/tests/test_group_permissions.py
@@ -11,7 +11,7 @@ from accounts.services import role_assign, sync_roles
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from model_bakery import baker
-from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
 
 
 class GlobalShelterOperatorTierTestCase(TestCase):
@@ -46,6 +46,22 @@ class GlobalShelterOperatorTierTestCase(TestCase):
         role_assign(user=user, role=self.role)
 
         self.assertIn("shelters.view_private_shelter", user.get_all_permissions())
+
+    def test_view_private_is_global_tier_only(self) -> None:
+        """Private shelters in the public directory are a global-tier gate.
+
+        The scoped Shelter Operator role must NOT carry view_private_shelter
+        (its only consumer reads has_perm, which Grants don't feed) — the
+        scoped role would declare an authority it can never exercise.
+        """
+        so_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
+        so_codenames = so_role.permissions.filter(content_type__app_label="shelters").values_list("codename", flat=True)
+        self.assertNotIn("view_private_shelter", so_codenames)
+        # The global role still carries it.
+        gso_codenames = self.role.permissions.filter(content_type__app_label="shelters").values_list(
+            "codename", flat=True
+        )
+        self.assertIn("view_private_shelter", gso_codenames)
 
     def test_member_gains_shelters_admin_access(self) -> None:
         user = baker.make(User, is_staff=True)


### PR DESCRIPTION
## Summary

Audit cleanup: the **scoped** Shelter Operator role carried `view_private_shelter`, but its only consumer — the public `.approved()` directory (`shelter_list`) — reads it via legacy `has_perm`, which **Grant rows don't feed**. A grant-based shelter operator could never exercise it there (their own org's private shelters come through the org-scoped `visible()` operator path instead), so the scoped role declared an authority it can never exercise.

In the old model, the SO legacy group leaked `view_private_shelter` **globally** through `has_perm` — the exact org-bypass bug class this migration fixes. The new behavior (scoped operators don't see *other orgs'* private shelters in the public directory) is the intended correction; this PR only stops declaring the dead perm on the scoped role.

## Changes

- Remove `Shelter.perms.VIEW_PRIVATE` from the `SHELTER_OPERATOR` template (kept on `GLOBAL_SHELTER_OPERATOR`); `sync_roles` drops it from the SO Role.
- Test: `view_private_shelter` is **absent** from the scoped SO Role and **present** on the GSO Role.

## Validation
Full `accounts`/`common`/`shelters` suite: **983 passed, 0 failed** · ruff format/check clean · mypy (strict) clean.

## Summary by Sourcery

Limit private-shelter directory access to the global Shelter Operator tier and align role permissions with the scoped access model.

Bug Fixes:
- Restrict `view_private_shelter` to the global Shelter Operator role so scoped operators no longer declare an unusable global permission.

Tests:
- Add coverage verifying that the private-shelter permission is absent from the scoped role and retained by the global role.