### PR TITLE
fix(perm): cloning a bed/room requires ADD (PR 14)

### DIFF
--- a/apps/betterangels-backend/shelters/services/bed.py
+++ b/apps/betterangels-backend/shelters/services/bed.py
@@ -123,10 +123,14 @@ def bed_delete(*, user: "User", organization_id: str, bed_ids: list[int]) -> lis
 def bed_clone(*, user: "User", organization_id: str, bed_id: str) -> Bed:
     """Clone an existing bed, including all M2M relationships.
 
-    Scopes to *organization_id* where *user* is a member.
+    Scopes to *organization_id* where *user* is a member.  Cloning creates a
+    new bed, so it follows the create convention (ADR 0001 §2.6): the source
+    is resolved with view authority and create authority is checked with
+    ``can(user, Bed.perms.ADD, org)``.
 
     Raises:
         ``ObjectDoesNotExist`` when the bed is not found.
+        ``django.core.exceptions.PermissionDenied`` when the user cannot add beds.
         ``django.core.exceptions.ValidationError`` on invalid data.
     """
     qs = bed_queryset(
@@ -136,4 +140,8 @@ def bed_clone(*, user: "User", organization_id: str, bed_id: str) -> Bed:
         perms=[Bed.perms.VIEW],
     )
     source = get_by_pk_or_not_found(qs, pk=bed_id)
+
+    if not can(user, Bed.perms.ADD, org=organization_id):
+        raise PermissionDenied("You do not have permission to perform this action in this organization.")
+
     return cast(Bed, source.make_clone(attrs={"name": _clone_label(source.name)}))

--- a/apps/betterangels-backend/shelters/services/room.py
+++ b/apps/betterangels-backend/shelters/services/room.py
@@ -148,11 +148,14 @@ def room_delete(*, user: "User", organization_id: str, room_ids: list[int]) -> l
 def room_clone(*, user: "User", organization_id: str, room_id: str) -> Room:
     """Clone an existing room, including all M2M relationships.
 
-    Scopes to *organization_id* where *user* is a member.
-    Beds are not copied.
+    Scopes to *organization_id* where *user* is a member.  Beds are not copied.
+    Cloning creates a new room, so it follows the create convention (ADR 0001
+    §2.6): the source is resolved with view authority and create authority is
+    checked with ``can(user, Room.perms.ADD, org)``.
 
     Raises:
         ``ObjectDoesNotExist`` when the room is not found.
+        ``django.core.exceptions.PermissionDenied`` when the user cannot add rooms.
         ``django.core.exceptions.ValidationError`` on invalid data.
     """
     qs = room_queryset(
@@ -162,6 +165,10 @@ def room_clone(*, user: "User", organization_id: str, room_id: str) -> Room:
         perms=[Room.perms.VIEW],
     )
     source = get_by_pk_or_not_found(qs, pk=room_id)
+
+    if not can(user, Room.perms.ADD, org=organization_id):
+        raise PermissionDenied("You do not have permission to perform this action in this organization.")
+
     return cast(
         Room,
         source.make_clone(attrs={"name": _unique_clone_name(shelter_id=source.shelter.pk, name=source.name)}),

--- a/apps/betterangels-backend/shelters/tests/test_bed_mutations.py
+++ b/apps/betterangels-backend/shelters/tests/test_bed_mutations.py
@@ -408,7 +408,8 @@ class CloneBedMutationTestCase(BedMutationTestCase):
 
         variables = {"id": str(source.pk)}
 
-        expected_query_count = 34
+        # The clone now checks can(ADD) too (create convention, ADR 0001 §2.6).
+        expected_query_count = 37
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(self.mutation, variables)
 

--- a/apps/betterangels-backend/shelters/tests/test_bed_services.py
+++ b/apps/betterangels-backend/shelters/tests/test_bed_services.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timezone
 
+from accounts.models import Role
 from accounts.role_manager import OrgRoleManager
+from accounts.services import grant_create
 from accounts.tests.baker_recipes import organization_recipe
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.contrib.auth.models import Permission
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.test import TestCase
 from model_bakery import baker
 from shelters.enums import (
@@ -283,3 +286,19 @@ class BedCloneTestCase(BedServiceTestCase):
             "Bed matching ID 999999 could not be found.",
             str(ctx.exception),
         )
+
+    def test_clone_requires_add_permission(self) -> None:
+        """A viewer (Bed VIEW, no ADD) can see the source but cannot clone it —
+        cloning creates a row, so it follows the create convention (ADR 0001 §2.6)."""
+        User = get_user_model()
+        viewer = User.objects.create_user(username="bed-viewer", password="pw")
+        self.org.users.add(viewer)
+        bed = baker.make(Bed, shelter=self.shelter, name="View Only")
+        role = Role.objects.get_or_create(name="Test Bed Viewer", is_global=False)[0]
+        role.permissions.add(Permission.objects.get(codename="view_bed", content_type__app_label="shelters"))
+        grant_create(user=viewer, role=role, scope_org=self.org)
+
+        with self.assertRaises(PermissionDenied):
+            bed_clone(user=viewer, organization_id=self.org_id, bed_id=str(bed.pk))
+
+        self.assertFalse(Bed.objects.filter(name="View Only (Copy)").exists())

--- a/apps/betterangels-backend/shelters/tests/test_room_mutations.py
+++ b/apps/betterangels-backend/shelters/tests/test_room_mutations.py
@@ -321,7 +321,8 @@ class CloneRoomMutationTestCase(RoomMutationTestCase):
 
         variables = {"id": str(source.pk)}
 
-        expected_query_count = 32
+        # The clone now checks can(ADD) too (create convention, ADR 0001 §2.6).
+        expected_query_count = 35
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.execute_graphql(self.mutation, variables)
 

--- a/apps/betterangels-backend/shelters/tests/test_room_services.py
+++ b/apps/betterangels-backend/shelters/tests/test_room_services.py
@@ -1,10 +1,12 @@
 import datetime
 
-from accounts.models import OrganizationProfile, OrgTypeChoices
+from accounts.models import OrganizationProfile, OrgTypeChoices, Role
 from accounts.role_manager import OrgRoleManager
+from accounts.services import grant_create
 from accounts.tests.baker_recipes import organization_recipe
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.contrib.auth.models import Permission
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.test import TestCase
 from model_bakery import baker
 
@@ -314,3 +316,19 @@ class RoomCloneTestCase(RoomServiceTestCase):
             "Room matching ID 999999 could not be found.",
             str(ctx.exception),
         )
+
+    def test_clone_requires_add_permission(self) -> None:
+        """A viewer (Room VIEW, no ADD) can see the source but cannot clone it —
+        cloning creates a row, so it follows the create convention (ADR 0001 §2.6)."""
+        User = get_user_model()
+        viewer = User.objects.create_user(username="room-viewer", password="pw")
+        self.org.users.add(viewer)
+        room = baker.make(Room, shelter=self.shelter, name="View Only Room")
+        role = Role.objects.get_or_create(name="Test Room Viewer", is_global=False)[0]
+        role.permissions.add(Permission.objects.get(codename="view_room", content_type__app_label="shelters"))
+        grant_create(user=viewer, role=role, scope_org=self.org)
+
+        with self.assertRaises(PermissionDenied):
+            room_clone(user=viewer, organization_id=self.org_id, room_id=str(room.pk))
+
+        self.assertFalse(Room.objects.filter(name="View Only Room (Copy)").exists())


### PR DESCRIPTION
## Summary

Audit finding (audit #4): `bed_clone`/`room_clone` **created rows** while only resolving the source with **VIEW** — so a VIEW-only user (e.g. a delegated viewer) could clone (= create) beds and rooms they could never otherwise create. This was inconsistent with the migration's own create convention (ADR 0001 §2.6: creates check `can(ADD)`).

## Changes

- `bed_clone` / `room_clone` now resolve the source with VIEW **and then require** `can(user, ADD, org)` — matching `bed_create`/`room_create`.
- Tests (fail against the old code):
  - a VIEW-only viewer (scoped Role carrying `view_bed`/`view_room` only) gets `PermissionDenied` on clone, and no clone row is created
  - existing clone tests still pass (SO holders have ADD)
- Clone mutation query counts bumped by the added `can(ADD)` check (bed 34→37, room 32→35).

## Validation
Full `accounts`/`common`/`shelters` suite: **985 passed, 0 failed** · ruff format/check clean · mypy (strict) clean.

## Summary by Sourcery

Enforce create-level authorization for bed and room cloning.

Bug Fixes:
- Require ADD permission before cloning beds or rooms, preventing VIEW-only users from creating clone records.

Tests:
- Add coverage confirming VIEW-only users are denied cloning and no duplicate records are created, while updating mutation query-count expectations.