### PR TITLE
feat(perm): FE capability plumbing + RFC note + merge guide (PR 16)

### DIFF
--- a/docs/adr/0002-client-writes-ownership.md
+++ b/docs/adr/0002-client-writes-ownership.md
@@ -86,3 +86,9 @@ grant) exists, no scoped role can silently mutate clients it was never granted.
   default org).
 - Whether `created_by_org` is immutable (set at create) or transferable later.
 - Who may set it: always the creating service, or also the admin.
+- **Sharing revocation on member removal (audit note):** `organization_remove_member`
+  revokes org-scoped Grants but not `principal_user` object grants — a removed member
+  would keep per-record access to shared clients. The sharing model must define
+  revocation semantics (e.g., object grants tied to membership and cleaned on removal,
+  or an explicit unshare action) before the clients cutover wires sharing; it is a
+  design decision of this RFC, not a predicate gap.

--- a/docs/grant-migration-merge-guide.md
+++ b/docs/grant-migration-merge-guide.md
@@ -1,0 +1,48 @@
+# Grant-based authorization — merge & review guide (PRs #2409–#2424)
+
+How to review and land the grant-migration stack. ADR 0001 is the design source of
+truth; this is the practical landing order and what each PR deserves scrutiny on.
+
+## Stack shape
+
+14 stacked PRs, each based on the previous branch (`#2409` bases `main`). Review and
+merge **bottom-up**; after each merge, retarget the next PR's base to `main` (or the
+merged branch) and resolve.
+
+| # | Branch / PR | Review focus |
+|---|---|---|
+| 2409 | `grant-redesign` | ADR 0001 + `Role`/`Grant` models, constraints (partial uniques, `NULLS NOT DISTINCT`), checks E001–E005, migration 0008. Schema-only — **nothing reads it yet**. |
+| 2410 | `grant-roles` | `RoleDef` provisioning (`sync_roles`), backfills, OrgScoped declarations, migration 0009. Idempotency + the `is_global` ownership rule. |
+| 2411 | `grant-predicate` | `common/permissions/selectors.py` — the whole predicate. Read `scopes`/`visible`/`can`/`can_obj`/`can_anywhere` carefully; this is the security core. |
+| 2412 | `grant-cutover` | Shelter domain flipped. Every mutation/service must check `visible`/`can` (no fail-open), `active_org` header optionality, `create_shelter` org-existence check. |
+| 2413 | `grant-delegation` | Org→org delegation: `scopes()` inherited arm, one-hop, no-amplification ("member + holds a direct grant"), `grant_delegate`, Grant admin inlines. |
+| 2414 | `grant-reachability` | FE capability contract: `currentUser.permissions` (global), grants-based org list, per-org permissions. Frontend is the harder-to-verify half — run vitest/codegen in a node-enabled checkout. |
+| 2415 | `grant-object-arm` | Object grants: whitelist, `_object_grant_q`, `grant_obj`, orphan cleanup, `pk__lt=0` vs `EmptyResultSet` fix. Note: shipped before its consumer (documented in #2418's ADR §2.5 reconciliation). |
+| 2416 | `grant-teardown` | Shelter Operator grant-only; `reconcile_org_groups` (skip role-backed create, delete stale, revoke grants for dropped roles); admin role-loss grant-awareness; **role-form fix** (union Grants into `held`). |
+| 2418 | `grant-hygiene` | Global-role write guards on `grant_create`/`grant_delegate`; Grant admin role filter; dead-code removal; ADR §2.5 `OBJECT_ARM_ENABLED` reconciliation; RFC 0002. |
+| 2419 | `grant-gso-teardown` | GSO legacy `PermissionGroup` deleted by `backfill_global_role_members`; `test_group_permissions.py` rewritten to the Role-tier contract. |
+| 2420 | `grant-query-opt` | `scopes()` full memoization (global-tier checks included); `reconcile` single role-name lookup. |
+| 2421 | `grant-canobj-failclosed` | **C1**: `can_obj` fails closed on platform-shared models (object arm / global only). Security-relevant — confirm the read/write split. |
+| 2422 | `grant-viewprivate-global` | `view_private_shelter` removed from the scoped SO role (global-tier only). |
+| 2423 | `grant-clone-perms` | `bed_clone`/`room_clone` require `ADD`. |
+| 2424 | `grant-migration-matrix` | Doc: ADR §4.1 per-domain readiness matrix. |
+
+## Verification per PR
+
+- Backend: `POSTGRES_TEST_NAME=<unique> uv run pytest -q` (shared test DB is a hazard —
+  isolate before `--create-db`).
+- `uv run ruff format --check`, `uv run ruff check`, mypy (strict).
+- Schema: `uv run python manage.py export_schema betterangels_backend.schema > schema.graphql`
+  then check no diff; FE generated types must be regenerated in a node-enabled checkout
+  (`nx codegen` / vitest) — **cannot run in the dev container** (no node_modules).
+- Pre-commit gate: `ynx-precommit` on the final head.
+
+## After the stack lands
+
+1. Decide RFC 0002 / ADR §7.6 (client ownership) with product.
+2. Mechanical cutovers in ADR §4.1 order: tasks → referrals → teams → reports (shelter
+   playbook).
+3. Clients/notes cutovers (§5/§5.1), then phase-5 teardown (`PermissionGroup` removal +
+   `has_perm` collapse).
+
+Full details: `docs/adr/0001-grant-based-authorization.md`, RFC `docs/adr/0002-client-writes-ownership.md`.

--- a/libs/react/shelter/src/lib/providers/user/UserContext.test.ts
+++ b/libs/react/shelter/src/lib/providers/user/UserContext.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasPermission, type TUser } from './UserContext';
+
+const globalUser: TUser = {
+  id: '1',
+  permissions: ['shelters.delete_shelter', 'organizations.add_org_member'],
+  organizations: [],
+};
+
+const orgScopedUser: TUser = {
+  id: '2',
+  permissions: [],
+  organization: {
+    id: 'org-1',
+    name: 'Org One',
+    permissions: ['shelters.view_shelter', 'shelters.change_shelter'],
+  },
+  organizations: [],
+};
+
+describe('hasPermission', () => {
+  it('grants a permission held at the global tier', () => {
+    expect(hasPermission(globalUser, 'shelters.delete_shelter')).toBe(true);
+    expect(hasPermission(globalUser, 'shelters.view_shelter')).toBe(false);
+  });
+
+  it('grants a permission held by the active organization', () => {
+    expect(hasPermission(orgScopedUser, 'shelters.view_shelter')).toBe(true);
+    expect(hasPermission(orgScopedUser, 'shelters.delete_shelter')).toBe(false);
+  });
+
+  it('denies everything for an undefined user', () => {
+    expect(hasPermission(undefined, 'shelters.view_shelter')).toBe(false);
+  });
+});

--- a/libs/react/shelter/src/lib/providers/user/UserContext.ts
+++ b/libs/react/shelter/src/lib/providers/user/UserContext.ts
@@ -13,8 +13,22 @@ export type TUser = {
   firstName?: string;
   lastName?: string;
   email?: string | null;
+  /** Global-tier capabilities (currentUser.permissions) — ADR 0001 §2.4. */
+  permissions?: string[];
   organizations: TOrganization[] | null;
 };
+
+/**
+ * Capability gate (ADR 0001 §5.2): a permission is held at the global tier
+ * OR by the user's active (first) organization.  Mirrors the generic
+ * useActiveOrgState.hasPermission contract so UI can gate features on
+ * capabilities rather than role names.
+ */
+export function hasPermission(user: TUser | undefined, permission: string): boolean {
+  if (!user) return false;
+  if (user.permissions?.includes(permission)) return true;
+  return user.organization?.permissions?.includes(permission) ?? false;
+}
 
 export interface IUserProviderValue {
   user: TUser | undefined;

--- a/libs/react/shelter/src/lib/providers/user/UserProvider.tsx
+++ b/libs/react/shelter/src/lib/providers/user/UserProvider.tsx
@@ -18,6 +18,7 @@ const { UserProvider, useUser } = createUserProvider({
       email: user.email,
       organization: user.organizations?.[0] ?? undefined,
       organizations: user.organizations ?? null,
+      permissions: user.permissions,
     };
   },
   isUnauthenticated: (errors) =>

--- a/libs/react/shelter/src/lib/providers/user/index.ts
+++ b/libs/react/shelter/src/lib/providers/user/index.ts
@@ -1,3 +1,4 @@
 export type { IUserProviderValue, TOrganization, TUser } from './UserContext';
+export { hasPermission } from './UserContext';
 export { UserProvider, useUser } from './UserProvider';
 export { useSignOut } from './useSignOut';


### PR DESCRIPTION
## Summary

Closes the audit finding that the **app-facing FE stack never received the grant-model capability contract** — plus the two remaining doc items.

## FE capability plumbing (the main fix)

`shelter-web` consumes providers from `@monorepo/react/shelter`, whose `UserProvider.parseUser` fetched `currentUser.permissions` (the **global tier**) but **dropped it** — so no app could gate on global capabilities, and `hasPermission` existed only in the generic `ba-platform` lib that neither app consumes.

- `react/shelter` `TUser` now carries `permissions?: string[]` (global) and `parseUser` forwards it.
- New pure `hasPermission(user, permission)` gate = **global tier OR active organization's permissions** (mirrors `useActiveOrgState.hasPermission`), exported from the public provider barrel, with unit tests.

⚠️ **Verification note:** additive + code-reviewed only — the dev container has **no node_modules**, so `vitest`/`codegen` must run in a node-enabled checkout before merge. App-level org-switching and real UI gating remain a node-enabled follow-up (the shelter-web user model is still single-org-first via `organizations[0]`).

## Doc items
- **RFC 0002**: added the object-grant-on-member-removal revocation decision (the sharing model must define revocation semantics before the clients cutover wires sharing).
- **`docs/grant-migration-merge-guide.md`**: bottom-up merge order + per-PR review focus for the 14-PR stack (#2409–#2424).

## Summary by Sourcery

Plumb grant-model capabilities through the Shelter frontend provider and document the authorization migration and remaining sharing-revocation decision.

New Features:
- Expose global user capabilities through the Shelter React provider and add a public permission gate that accepts either global or active-organization permissions.

Bug Fixes:
- Preserve `currentUser.permissions` when mapping authenticated users for app-facing frontend consumers.

Enhancements:
- Document sharing-access revocation semantics that must be resolved before client sharing cutovers.
- Add a bottom-up merge and review guide for the grant-based authorization migration stack.

Documentation:
- Document the grant migration stack’s landing order, review focus, verification requirements, and post-merge steps.
- Record the open design decision for revoking object grants when organization members are removed.

Tests:
- Add unit coverage for global, organization-scoped, and unauthenticated permission checks.