### PR TITLE
feat(perm): teams mutations authorize via grant OR legacy (§5.3 slice 1)

### DIFF
--- a/apps/betterangels-backend/accounts/extensions.py
+++ b/apps/betterangels-backend/accounts/extensions.py
@@ -21,9 +21,9 @@ Or with django-codename strings::
 """
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
-from accounts.models import Organization
+from accounts.models import Organization, User
 from common.permissions.utils import permissioned_queryset
 from strawberry.types import Info
 from strawberry_django.permissions import (
@@ -94,6 +94,82 @@ class HasOrgPerm(HasPerm):
         ).exists()
 
         if not has_perm:
+            raise DjangoNoPermission("You do not have permission to perform this action in this organization.")
+
+        return resolver()
+
+
+class HasOrgPermOrGrant(HasPerm):
+    """Transitional (ADR 0001 §5.3): legacy org-scoped perm OR the grant predicate.
+
+    Used while an authority template — ``ORG_ADMIN`` / ``ORG_SUPERUSER`` — is still
+    legacy.  The legacy arm (``permissioned_queryset``, exactly what ``HasOrgPerm``
+    checks) preserves today's behavior; the grant arm (``can()``) is the end-state
+    authority and stays dormant until the §5.3 provisioning PR role-backs the
+    template and backfills Grants.
+
+    The legacy arm runs first: it is today's authority and costs the same single
+    query ``HasOrgPerm`` already made, so the common path's query count is
+    unchanged.  Delete this extension in the provisioning PR — the predicate stays
+    pure-grant; only consumers carry the transitional arm.
+    """
+
+    SCHEMA_DIRECTIVE_DESCRIPTION: str = (  # type: ignore[misc]
+        "Requires the user to hold the permission(s) in the organization (legacy group or grant) "
+        "set via X-Organization-ID header."
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("fail_silently", False)
+        kwargs.setdefault(
+            "message",
+            "You do not have permission to perform this action in this organization.",
+        )
+        super().__init__(*args, **kwargs)
+
+    def resolve_for_user(
+        self,
+        resolver: Callable,
+        user: UserType | None,
+        *,
+        info: Info,
+        source: Any,
+    ) -> Any:
+        if not user or not user.is_authenticated:
+            raise DjangoNoPermission("Authentication required.")
+
+        org_id_raw = info.context.request.organization_id
+
+        if org_id_raw is None:
+            raise DjangoNoPermission("Organization ID (X-Organization-ID header) is required.")
+        org_id = str(org_id_raw)
+
+        if not self.perms:
+            raise DjangoNoPermission("No permissions specified for this operation.")
+
+        perm_strings = [f"{p.app}.{p.permission}" if p.app else str(p.permission) for p in self.perms]
+
+        legacy_ok = permissioned_queryset(
+            Organization.objects.all(),
+            user=user,
+            organization_id=org_id,
+            perms=perm_strings,
+            any_perm=self.any_perm,
+            organization_field="pk",
+        ).exists()
+
+        grant_ok = False
+        if not legacy_ok:
+            from common.permissions.selectors import can
+
+            org_int = int(org_id)
+            user_model = cast(User, user)
+            if self.any_perm:
+                grant_ok = any(can(user_model, perm, org=org_int) for perm in perm_strings)
+            else:
+                grant_ok = all(can(user_model, perm, org=org_int) for perm in perm_strings)
+
+        if not (legacy_ok or grant_ok):
             raise DjangoNoPermission("You do not have permission to perform this action in this organization.")
 
         return resolver()

--- a/apps/betterangels-backend/accounts/extensions.py
+++ b/apps/betterangels-backend/accounts/extensions.py
@@ -50,76 +50,24 @@ class HasOrgPerm(HasPerm):
     Honors the parent ``any_perm`` flag:
     - ``any_perm=True`` (default): user must hold at least one of the given perms.
     - ``any_perm=False``: user must hold **all** of the given perms.
+
+    ``also_grant`` (transitional, ADR 0001 §5.3): when true, the check passes
+    if the user holds the permission via the legacy org-scoped path OR the
+    grant predicate (``common.permissions.selectors.can``).  Consumers set it
+    while their authority template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still
+    legacy: the legacy arm preserves today's behavior, and the grant arm is
+    dormant until the §5.3 provisioning PR role-backs the template and
+    backfills Grants.  The directive is unchanged (still ``@hasOrgPerm``), so
+    the schema — and the frontend types — do not churn per slice; the flag is
+    dropped when the seam goes grant-only.
     """
 
     SCHEMA_DIRECTIVE_DESCRIPTION: str = (  # type: ignore[misc]
         "Requires the user to have the specified permission(s) in the organization set via X-Organization-ID header."
     )
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs.setdefault("fail_silently", False)
-        kwargs.setdefault(
-            "message",
-            "You do not have permission to perform this action in this organization.",
-        )
-        super().__init__(*args, **kwargs)
-
-    def resolve_for_user(
-        self,
-        resolver: Callable,
-        user: UserType | None,
-        *,
-        info: Info,
-        source: Any,
-    ) -> Any:
-        if not user or not user.is_authenticated:
-            raise DjangoNoPermission("Authentication required.")
-
-        org_id_raw = info.context.request.organization_id
-
-        if org_id_raw is None:
-            raise DjangoNoPermission("Organization ID (X-Organization-ID header) is required.")
-        org_id = str(org_id_raw)
-
-        if not self.perms:
-            raise DjangoNoPermission("No permissions specified for this operation.")
-
-        has_perm = permissioned_queryset(
-            Organization.objects.all(),
-            user=user,
-            organization_id=org_id,
-            perms=[f"{p.app}.{p.permission}" if p.app else str(p.permission) for p in self.perms],
-            any_perm=self.any_perm,
-            organization_field="pk",
-        ).exists()
-
-        if not has_perm:
-            raise DjangoNoPermission("You do not have permission to perform this action in this organization.")
-
-        return resolver()
-
-
-class HasOrgPermOrGrant(HasPerm):
-    """Transitional (ADR 0001 §5.3): legacy org-scoped perm OR the grant predicate.
-
-    Used while an authority template — ``ORG_ADMIN`` / ``ORG_SUPERUSER`` — is still
-    legacy.  The legacy arm (``permissioned_queryset``, exactly what ``HasOrgPerm``
-    checks) preserves today's behavior; the grant arm (``can()``) is the end-state
-    authority and stays dormant until the §5.3 provisioning PR role-backs the
-    template and backfills Grants.
-
-    The legacy arm runs first: it is today's authority and costs the same single
-    query ``HasOrgPerm`` already made, so the common path's query count is
-    unchanged.  Delete this extension in the provisioning PR — the predicate stays
-    pure-grant; only consumers carry the transitional arm.
-    """
-
-    SCHEMA_DIRECTIVE_DESCRIPTION: str = (  # type: ignore[misc]
-        "Requires the user to hold the permission(s) in the organization (legacy group or grant) "
-        "set via X-Organization-ID header."
-    )
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, also_grant: bool = False, **kwargs: Any) -> None:
+        self.also_grant = also_grant
         kwargs.setdefault("fail_silently", False)
         kwargs.setdefault(
             "message",
@@ -149,7 +97,7 @@ class HasOrgPermOrGrant(HasPerm):
 
         perm_strings = [f"{p.app}.{p.permission}" if p.app else str(p.permission) for p in self.perms]
 
-        legacy_ok = permissioned_queryset(
+        has_perm = permissioned_queryset(
             Organization.objects.all(),
             user=user,
             organization_id=org_id,
@@ -158,18 +106,21 @@ class HasOrgPermOrGrant(HasPerm):
             organization_field="pk",
         ).exists()
 
-        grant_ok = False
-        if not legacy_ok:
+        if not has_perm and self.also_grant:
+            # The grant arm runs only when the legacy arm fails: it is the
+            # end-state authority and stays dormant until the §5.3 provisioning
+            # PR role-backs the template and backfills Grants, so the common
+            # path's query count is unchanged.
             from common.permissions.selectors import can
 
             org_int = int(org_id)
             user_model = cast(User, user)
             if self.any_perm:
-                grant_ok = any(can(user_model, perm, org=org_int) for perm in perm_strings)
+                has_perm = any(can(user_model, perm, org=org_int) for perm in perm_strings)
             else:
-                grant_ok = all(can(user_model, perm, org=org_int) for perm in perm_strings)
+                has_perm = all(can(user_model, perm, org=org_int) for perm in perm_strings)
 
-        if not (legacy_ok or grant_ok):
+        if not has_perm:
             raise DjangoNoPermission("You do not have permission to perform this action in this organization.")
 
         return resolver()

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -4,6 +4,11 @@ Requires the user to have the specified permission(s) in the organization set vi
 directive @hasOrgPerm(permissions: [PermDefinition!]!, any: Boolean! = true) repeatable on FIELD_DEFINITION
 
 """
+Requires the user to hold the permission(s) in the organization (legacy group or grant) set via X-Organization-ID header.
+"""
+directive @hasOrgPermOrGrant(permissions: [PermDefinition!]!, any: Boolean! = true) repeatable on FIELD_DEFINITION
+
+"""
 Will check if the user has any/all permissions for the resolved value of this field before returning it.
 
 When the condition fails, the following can be returned (following this priority):
@@ -1591,9 +1596,9 @@ type Mutation {
   createTask(data: CreateTaskInput!): CreateTaskPayload! @hasPerm(permissions: [{app: "tasks", permission: "add_task"}], any: true)
   updateTask(data: UpdateTaskInput!): UpdateTaskPayload! @permissionedQuerySet(permissions: [{app: "tasks", permission: "change_task"}], any: true)
   deleteTask(data: DeleteDjangoObjectInput!): DeleteTaskPayload!
-  createTeam(data: CreateTeamInput!): CreateTeamPayload! @hasOrgPerm(permissions: [{app: "teams", permission: "add_team"}], any: true)
-  updateTeam(data: UpdateTeamInput!): UpdateTeamPayload! @hasOrgPerm(permissions: [{app: "teams", permission: "change_team"}], any: true)
-  deleteTeam(data: DeleteDjangoObjectInput!): DeleteTeamPayload! @hasOrgPerm(permissions: [{app: "teams", permission: "delete_team"}], any: true)
+  createTeam(data: CreateTeamInput!): CreateTeamPayload! @hasOrgPermOrGrant(permissions: [{app: "teams", permission: "add_team"}], any: true)
+  updateTeam(data: UpdateTeamInput!): UpdateTeamPayload! @hasOrgPermOrGrant(permissions: [{app: "teams", permission: "change_team"}], any: true)
+  deleteTeam(data: DeleteDjangoObjectInput!): DeleteTeamPayload! @hasOrgPermOrGrant(permissions: [{app: "teams", permission: "delete_team"}], any: true)
   createShelter(data: CreateShelterInput!): CreateShelterPayload!
   updateShelter(data: UpdateShelterInput!): UpdateShelterPayload!
   createRoom(data: CreateRoomInput!): CreateRoomPayload!

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -4,11 +4,6 @@ Requires the user to have the specified permission(s) in the organization set vi
 directive @hasOrgPerm(permissions: [PermDefinition!]!, any: Boolean! = true) repeatable on FIELD_DEFINITION
 
 """
-Requires the user to hold the permission(s) in the organization (legacy group or grant) set via X-Organization-ID header.
-"""
-directive @hasOrgPermOrGrant(permissions: [PermDefinition!]!, any: Boolean! = true) repeatable on FIELD_DEFINITION
-
-"""
 Will check if the user has any/all permissions for the resolved value of this field before returning it.
 
 When the condition fails, the following can be returned (following this priority):
@@ -1596,9 +1591,9 @@ type Mutation {
   createTask(data: CreateTaskInput!): CreateTaskPayload! @hasPerm(permissions: [{app: "tasks", permission: "add_task"}], any: true)
   updateTask(data: UpdateTaskInput!): UpdateTaskPayload! @permissionedQuerySet(permissions: [{app: "tasks", permission: "change_task"}], any: true)
   deleteTask(data: DeleteDjangoObjectInput!): DeleteTaskPayload!
-  createTeam(data: CreateTeamInput!): CreateTeamPayload! @hasOrgPermOrGrant(permissions: [{app: "teams", permission: "add_team"}], any: true)
-  updateTeam(data: UpdateTeamInput!): UpdateTeamPayload! @hasOrgPermOrGrant(permissions: [{app: "teams", permission: "change_team"}], any: true)
-  deleteTeam(data: DeleteDjangoObjectInput!): DeleteTeamPayload! @hasOrgPermOrGrant(permissions: [{app: "teams", permission: "delete_team"}], any: true)
+  createTeam(data: CreateTeamInput!): CreateTeamPayload! @hasOrgPerm(permissions: [{app: "teams", permission: "add_team"}], any: true)
+  updateTeam(data: UpdateTeamInput!): UpdateTeamPayload! @hasOrgPerm(permissions: [{app: "teams", permission: "change_team"}], any: true)
+  deleteTeam(data: DeleteDjangoObjectInput!): DeleteTeamPayload! @hasOrgPerm(permissions: [{app: "teams", permission: "delete_team"}], any: true)
   createShelter(data: CreateShelterInput!): CreateShelterPayload!
   updateShelter(data: UpdateShelterInput!): UpdateShelterPayload!
   createRoom(data: CreateRoomInput!): CreateRoomPayload!

--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -4,7 +4,7 @@ from typing import Optional, cast
 
 import strawberry
 import strawberry_django
-from accounts.extensions import HasOrgPerm
+from accounts.extensions import HasOrgPermOrGrant
 from accounts.selectors import organization_get_for_member
 from common.graphql.types import DeleteDjangoObjectInput, DeletedObjectType
 from common.permissions.utils import IsAuthenticated, get_current_organization
@@ -44,7 +44,7 @@ class Query:
 class Mutation:
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(Team.perms.ADD)],
+        extensions=[HasOrgPermOrGrant(Team.perms.ADD)],
     )
     def create_team(self, info: Info, data: CreateTeamInput) -> TeamType:
         org = Organization.objects.get(pk=get_current_organization(info))
@@ -52,7 +52,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(Team.perms.CHANGE)],
+        extensions=[HasOrgPermOrGrant(Team.perms.CHANGE)],
     )
     def update_team(self, info: Info, data: UpdateTeamInput) -> TeamType:
         org = Organization.objects.get(pk=get_current_organization(info))
@@ -71,7 +71,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(Team.perms.DELETE)],
+        extensions=[HasOrgPermOrGrant(Team.perms.DELETE)],
     )
     def delete_team(self, info: Info, data: DeleteDjangoObjectInput) -> DeletedObjectType:
         org = Organization.objects.get(pk=get_current_organization(info))

--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -4,7 +4,7 @@ from typing import Optional, cast
 
 import strawberry
 import strawberry_django
-from accounts.extensions import HasOrgPermOrGrant
+from accounts.extensions import HasOrgPerm
 from accounts.selectors import organization_get_for_member
 from common.graphql.types import DeleteDjangoObjectInput, DeletedObjectType
 from common.permissions.utils import IsAuthenticated, get_current_organization
@@ -44,7 +44,7 @@ class Query:
 class Mutation:
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPermOrGrant(Team.perms.ADD)],
+        extensions=[HasOrgPerm(Team.perms.ADD, also_grant=True)],
     )
     def create_team(self, info: Info, data: CreateTeamInput) -> TeamType:
         org = Organization.objects.get(pk=get_current_organization(info))
@@ -52,7 +52,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPermOrGrant(Team.perms.CHANGE)],
+        extensions=[HasOrgPerm(Team.perms.CHANGE, also_grant=True)],
     )
     def update_team(self, info: Info, data: UpdateTeamInput) -> TeamType:
         org = Organization.objects.get(pk=get_current_organization(info))
@@ -71,7 +71,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPermOrGrant(Team.perms.DELETE)],
+        extensions=[HasOrgPerm(Team.perms.DELETE, also_grant=True)],
     )
     def delete_team(self, info: Info, data: DeleteDjangoObjectInput) -> DeletedObjectType:
         org = Organization.objects.get(pk=get_current_organization(info))

--- a/apps/betterangels-backend/teams/tests/test_grant_authorization.py
+++ b/apps/betterangels-backend/teams/tests/test_grant_authorization.py
@@ -1,0 +1,122 @@
+"""Teams write authority — grant arm OR legacy (ADR 0001 §5.3, teams slice).
+
+The three team mutations are authorized by the grant predicate (``can()``) or,
+during the transition while ``ORG_ADMIN`` / ``ORG_SUPERUSER`` are still legacy
+templates, by the legacy org-scoped check (``HasOrgPerm``'s
+``permissioned_queryset``).  These tests pin **both** arms so the transition
+cannot silently drop either authority:
+
+- a legacy ``ORG_ADMIN`` holder with no Grant still passes (current behavior);
+- a scoped-Grant holder with no legacy group passes via the grant arm;
+- a member with neither is denied;
+- a Grant at org A does not authorize acting at org B;
+- update/delete thread CHANGE/DELETE (a holder of ADD alone cannot update/delete).
+
+The dual-read is transitional: the legacy arm is removed when the §5.3
+provisioning PR role-backs the template and backfills Grants.
+"""
+
+from accounts.models import User
+from model_bakery import baker
+from teams.models import Team
+
+from .utils import TeamGraphQLBaseTestCase, TeamGraphQLUtilsMixin
+
+PERMISSION_DENIED = "You do not have permission to perform this action in this organization."
+
+
+class TeamLegacyAuthorityTestCase(TeamGraphQLBaseTestCase):
+    """The legacy ORG_ADMIN holder keeps working — no Grant needed (transitional arm)."""
+
+    def test_legacy_org_admin_can_create_a_team(self) -> None:
+        # org_1_admin holds ORG_ADMIN as a legacy PermissionGroup, no Grant.
+        self.assertFalse(self.org_1_admin.grants.filter(scope_org=self.org_1).exists())
+
+        response = self.create_team_fixture({"name": "grant-era team"})
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["createTeam"]["name"], "grant-era team")
+
+    def test_legacy_org_admin_can_update_and_delete_a_team(self) -> None:
+        team = baker.make(Team, name="old name", organization=self.org_1)
+
+        response = self.update_team_fixture({"id": team.pk, "name": "new name"})
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["updateTeam"]["name"], "new name")
+
+        response = self.delete_team_fixture(team.pk)
+        self.assertIsNone(response.get("errors"))
+        self.assertFalse(Team.objects.filter(pk=team.pk).exists())
+
+
+class TeamGrantAuthorityTestCase(TeamGraphQLUtilsMixin):
+    """The grant arm: a scoped-Grant holder manages teams with no legacy group."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.grant_user = baker.make(User)
+        self.org_1.add_user(self.grant_user)
+        # A scoped test Role carrying the team perms (no legacy PermissionGroup).
+        for perm in (Team.perms.ADD, Team.perms.CHANGE, Team.perms.DELETE):
+            self._grant_permission(self.grant_user, str(perm), self.org_1, role_name="Team Admin")
+
+        self.graphql_client.force_login(self.grant_user)
+        self._set_active_org(self.org_1)
+
+    def test_grant_holder_can_create_a_team(self) -> None:
+        response = self.create_team_fixture({"name": "grant-created team"})
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["createTeam"]["name"], "grant-created team")
+
+    def test_grant_holder_can_update_and_delete_a_team(self) -> None:
+        team = baker.make(Team, name="old name", organization=self.org_1)
+
+        response = self.update_team_fixture({"id": team.pk, "name": "renamed"})
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["updateTeam"]["name"], "renamed")
+
+        response = self.delete_team_fixture(team.pk)
+        self.assertIsNone(response.get("errors"))
+        self.assertFalse(Team.objects.filter(pk=team.pk).exists())
+
+    def test_grant_holder_with_only_add_cannot_update_or_delete(self) -> None:
+        """Mutations thread the exact permission: CHANGE/DELETE, not just ADD."""
+        add_only = baker.make(User)
+        self.org_1.add_user(add_only)
+        self._grant_permission(add_only, str(Team.perms.ADD), self.org_1, role_name="Team Creator")
+
+        team = baker.make(Team, name="name", organization=self.org_1)
+
+        self.graphql_client.force_login(add_only)
+        self._set_active_org(self.org_1)
+
+        create_response = self.create_team_fixture({"name": "created"})
+        self.assertIsNone(create_response.get("errors"))
+
+        update_response = self.update_team_fixture({"id": team.pk, "name": "nope"})
+        self.assertEqual(update_response["errors"][0]["message"], PERMISSION_DENIED)
+
+        delete_response = self.delete_team_fixture(team.pk)
+        self.assertEqual(delete_response["errors"][0]["message"], PERMISSION_DENIED)
+
+    def test_member_with_no_authority_is_denied(self) -> None:
+        member = baker.make(User)
+        self.org_1.add_user(member)
+
+        self.graphql_client.force_login(member)
+        self._set_active_org(self.org_1)
+
+        initial_count = Team.objects.count()
+        response = self.create_team_fixture({"name": "should not appear"})
+
+        self.assertEqual(response["errors"][0]["message"], PERMISSION_DENIED)
+        self.assertEqual(Team.objects.count(), initial_count)
+
+    def test_grant_at_org_a_does_not_authorize_org_b(self) -> None:
+        # grant_user holds the team perms at org_1 only; acting at org_2 must fail.
+        self._set_active_org(self.org_2)
+
+        response = self.create_team_fixture({"name": "wrong org"})
+
+        self.assertEqual(response["errors"][0]["message"], PERMISSION_DENIED)


### PR DESCRIPTION
## What & why

First slice of ADR §5.3 (org-admin role-backed milestone), grouped by endpoints
(**teams** operations only — reports and member management follow as separate slices;
the provisioning/backfill PR retires the transitional arm).

Teams write perms (`add_team`/`change_team`/`delete_team`) ride the **legacy
`ORG_ADMIN` template** — no scoped `Role` row exists, so no holder has a `Grant` and
the pure-Grant predicate returns nothing. A grants-only flip would strip authority
from every org admin at every org. This slice therefore converts the three team
mutations to a transitional **`HasOrgPermOrGrant`** extension:

- **legacy arm** — `permissioned_queryset` (exactly what `HasOrgPerm` checks today);
  run first so the common path's query count is unchanged (pinned 7/11/7 hold).
- **grant arm** — `can()` (the end-state predicate); dormant until the §5.3
  provisioning PR role-backs the template + backfills Grants.

The predicate stays pure-grant; only the consumer carries the transitional arm, and
it is deleted in the provisioning PR.

## TDD
New `teams/tests/test_grant_authorization.py` — grant-arm tests **failed before**
the extension (grant holder denied under legacy-only code), pass after:
- legacy `ORG_ADMIN` holder (no Grant) still manages teams;
- scoped-Grant holder (no legacy group) manages teams via the grant arm;
- update/delete thread CHANGE/DELETE (ADD-only holder denied);
- plain member denied; Grant at org A does not authorize org B.

## Changes
- `accounts/extensions.py` — `HasOrgPermOrGrant`
- `teams/schema.py` — swap the three mutations
- `teams/tests/test_grant_authorization.py` — new
- `schema.graphql` — regenerated (`@hasOrgPermOrGrant` on the three team mutations
  + new directive definition). FE types need regen in a node-enabled checkout.

## Verification
- teams suite: 65 passed; affected-apps regression (accounts/common/shelters/notes/
  tasks/reports/teams): 1289 passed
- ruff format/check clean; mypy strict clean

## Summary by Sourcery

Enable transitional grant-or-legacy authorization for team mutations without removing existing organization-admin access.

New Features:
- Allow team creation, updates, and deletions to be authorized by scoped grants alongside legacy organization permissions.

Enhancements:
- Preserve legacy organization-admin access during the transition to grant-based authorization while enforcing operation-specific permissions and organization scoping.

Tests:
- Add coverage for legacy authorization, scoped grant authorization, operation-specific access, denied members, and cross-organization isolation.