### PR TITLE
feat(perm): reports reads authorize via grant OR legacy (§5.3 slice 2)

### DIFF
--- a/apps/betterangels-backend/accounts/permissions.py
+++ b/apps/betterangels-backend/accounts/permissions.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 from common.permissions.utils import perm_filter, register_permission
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.db import models
-from django.db.models import TextChoices
+from django.db.models import Q, TextChoices
 from django.utils.translation import gettext_lazy as _
 from organizations.models import Organization
 
@@ -44,11 +44,15 @@ def get_user_permitted_org(
     """
     perm_value = permission.value if isinstance(permission, TextChoices) else permission
     app_label, codename = perm_value.split(".", 1)
+    # Both conditions MUST stay in a single ``.filter()`` call: ``permission_groups``
+    # is multi-valued, so chaining them as two ``.filter()`` calls builds two
+    # independent joins that different groups can satisfy — "user is in some group
+    # of this org, and some group of this org has the permission".  Every org is
+    # provisioned with every template, so that reads as "any member holds every
+    # permission any template in their org has" (see
+    # ``common.permissions.utils._org_perm_exists_across_fields``).
     return (
-        Organization.objects.filter(
-            pk=org_id,
-            permission_groups__user=user,
-        )
-        .filter(perm_filter(app_label, codename))
+        Organization.objects.filter(pk=org_id)
+        .filter(Q(permission_groups__user=user) & perm_filter(app_label, codename))
         .first()
     )

--- a/apps/betterangels-backend/accounts/tests/test_org_perm_check.py
+++ b/apps/betterangels-backend/accounts/tests/test_org_perm_check.py
@@ -1,0 +1,62 @@
+"""Unit tests for ``accounts.permissions.get_user_permitted_org``.
+
+Regression coverage for the multi-valued-join bypass: the helper used to chain two
+``.filter()`` calls over the multi-valued ``permission_groups`` relation, so the
+membership condition and the permission condition could be satisfied by
+*different* groups at the same org — "any member of any group holds every
+permission any template in their org has".  Every org is provisioned with every
+template, so that let a Caseworker pass a ``view_reports`` gate and download the
+org's whole note history via ``/reports/export/``.
+"""
+
+from accounts.models import PermissionGroup, User
+from accounts.permissions import get_user_permitted_org
+from accounts.role_manager import OrgRoleManager
+from django.test import TestCase
+from model_bakery import baker
+from notes.groups import CASEWORKER
+from reports.permissions import ReportPermissions
+
+from .baker_recipes import organization_recipe
+
+
+class GetUserPermittedOrgSingleJoinTestCase(TestCase):
+    """Membership in one group must not satisfy a permission held by another."""
+
+    def setUp(self) -> None:
+        # create_organization_with_presets provisions every template group the
+        # org type offers — including ORG_ADMIN, which carries view_reports — so
+        # the org has *both* a CASEWORKER group (for the user) and an ORG_ADMIN
+        # group (holding view_reports) before the test asserts anything.
+        self.org = organization_recipe.make(name="Provisioned Org")
+        self.caseworker = baker.make(User)
+        self.org.add_user(self.caseworker)
+        OrgRoleManager(self.org).add_roles(self.caseworker, CASEWORKER)
+
+        self.org_admin_group = PermissionGroup.objects.get(
+            organization=self.org,
+            template__name="Organization Admin",
+        )
+        self.assertFalse(self.caseworker.groups.filter(pk=self.org_admin_group.pk).exists())
+
+    def test_membership_in_another_group_does_not_confer_the_permission(self) -> None:
+        org = get_user_permitted_org(
+            self.caseworker,
+            org_id=str(self.org.pk),
+            permission=ReportPermissions.VIEW_REPORTS,
+        )
+
+        self.assertIsNone(org)
+
+    def test_holding_the_permission_still_returns_the_org(self) -> None:
+        self.caseworker.groups.add(self.org_admin_group)
+
+        org = get_user_permitted_org(
+            self.caseworker,
+            org_id=str(self.org.pk),
+            permission=ReportPermissions.VIEW_REPORTS,
+        )
+
+        if org is None:
+            self.fail("expected the org to be returned for a holder of the permission")
+        self.assertEqual(org.pk, self.org.pk)

--- a/apps/betterangels-backend/reports/permissions.py
+++ b/apps/betterangels-backend/reports/permissions.py
@@ -4,10 +4,12 @@ Reports app DRF permissions.
 Reference: https://github.com/HackSoftware/Django-Styleguide#apis--serializers
 """
 
+from accounts.models import User
 from accounts.permissions import get_user_permitted_org
 from common.permissions.utils import register_permission
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from organizations.models import Organization
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.views import APIView
@@ -18,10 +20,35 @@ class ReportPermissions(models.TextChoices):
     VIEW_REPORTS = "reports.view_reports", _("Can view reports")
 
 
+def report_org_for_user(user: User, org_id: str) -> Organization | None:
+    """The organization *user* may view reports for — grant arm OR legacy (§5.3).
+
+    Transitional dual-read.  ``view_reports`` rides the legacy
+    ``ORG_ADMIN``/``ORG_SUPERUSER`` templates (no scoped Role row yet, so no
+    Grants exist for it); the legacy arm (``get_user_permitted_org``) preserves
+    today's behavior while the grant arm (``can()``) is the end-state
+    authority and stays dormant until the §5.3 provisioning PR role-backs the
+    template and backfills Grants.  The legacy arm runs first — it is today's
+    authority and keeps the common path at a single query.  This helper is
+    deleted in that PR.
+    """
+    from common.permissions.selectors import can
+
+    org = get_user_permitted_org(user, org_id=org_id, permission=ReportPermissions.VIEW_REPORTS)
+    if org is not None:
+        return org
+
+    if can(user, ReportPermissions.VIEW_REPORTS, org=int(org_id)):
+        # ``can()`` never implies existence (ADR 0001 §2.6, finding F7).
+        return Organization.objects.filter(pk=org_id).first()
+    return None
+
+
 class HasReportAccess(BasePermission):
     """
     DRF permission that checks the user belongs to an organization
-    and has ``VIEW_REPORTS`` permission on it.
+    and has ``VIEW_REPORTS`` permission on it (via a Grant or, during the
+    §5.3 transition, a legacy PermissionGroup).
 
     Reads an optional ``org_id`` query-parameter to target a specific org.
     On success the permitted organization is stored on ``request.permitted_org``
@@ -40,7 +67,7 @@ class HasReportAccess(BasePermission):
         if not org_id:
             return False
 
-        org = get_user_permitted_org(user, org_id=org_id, permission=ReportPermissions.VIEW_REPORTS)
+        org = report_org_for_user(user, org_id)
         if org is None:
             return False
 

--- a/apps/betterangels-backend/reports/schema.py
+++ b/apps/betterangels-backend/reports/schema.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import strawberry
 import strawberry_django
-from accounts.extensions import HasOrgPerm
+from accounts.extensions import HasOrgPermOrGrant
 from common.permissions.utils import IsAuthenticated, get_current_organization
 from organizations.models import Organization
 from strawberry.types import Info
@@ -42,7 +42,7 @@ class ReportSummaryType:
 class Query:
     @strawberry_django.field(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(ReportPermissions.VIEW_REPORTS)],
+        extensions=[HasOrgPermOrGrant(ReportPermissions.VIEW_REPORTS)],
     )
     def report_summary(
         self,

--- a/apps/betterangels-backend/reports/schema.py
+++ b/apps/betterangels-backend/reports/schema.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import strawberry
 import strawberry_django
-from accounts.extensions import HasOrgPermOrGrant
+from accounts.extensions import HasOrgPerm
 from common.permissions.utils import IsAuthenticated, get_current_organization
 from organizations.models import Organization
 from strawberry.types import Info
@@ -42,7 +42,7 @@ class ReportSummaryType:
 class Query:
     @strawberry_django.field(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPermOrGrant(ReportPermissions.VIEW_REPORTS)],
+        extensions=[HasOrgPerm(ReportPermissions.VIEW_REPORTS, also_grant=True)],
     )
     def report_summary(
         self,

--- a/apps/betterangels-backend/reports/tests/test_views.py
+++ b/apps/betterangels-backend/reports/tests/test_views.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytest
 import time_machine
-from accounts.models import PermissionGroup, PermissionGroupTemplate, User
+from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, Role, User
 from common.tests.utils import GraphQLBaseTestCase
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -29,6 +29,23 @@ def grant_view_reports(user: User, org: Organization) -> None:
     pg, _ = PermissionGroup.objects.get_or_create(organization=org, template=template)
     pg.permissions.add(perm)
     user.groups.add(pg)
+
+
+def grant_view_reports_via_role(user: User, org: Organization) -> None:
+    """Grant view_reports via a scoped test Role + Grant (grant arm, ADR §5.3).
+
+    The §5.3 reports slice authorizes reads through the grant predicate OR the
+    legacy PermissionGroup.  A legacy-only holder exercises the legacy arm; a
+    holder with a scoped Role carrying ``view_reports`` (no PermissionGroup)
+    exercises the grant arm.
+    """
+    ct = ContentType.objects.get_for_model(ScheduledReport)
+    perm, _ = Permission.objects.get_or_create(
+        codename="view_reports", content_type=ct, defaults={"name": "Can view reports"}
+    )
+    role, _ = Role.objects.get_or_create(name="_test_report_viewer_role", is_global=False)
+    role.permissions.add(perm)
+    Grant.objects.get_or_create(principal_user=user, role=role, scope_org=org)
 
 
 @pytest.fixture
@@ -280,6 +297,33 @@ class TestExportInteractionDataView:
         response = api_client.get(f"/reports/export/?start_date=2025-01-01&end_date=2025-01-31&org_id={other_org.id}")
         assert response.status_code == 403
 
+    def test_grant_holder_without_legacy_group_can_export(self, api_client: APIClient, org: Organization) -> None:
+        """Scoped-Grant holder (no PermissionGroup) can export via the grant arm."""
+        user = baker.make(User)
+        user.set_password("testpass")
+        user.save()
+        org.add_user(user)
+        grant_view_reports_via_role(user, org)
+
+        api_client.force_authenticate(user=user)
+        response = api_client.get(f"/reports/export/?org_id={org.id}&month=1&year=2025")
+        assert response.status_code == 200
+
+    def test_grant_at_org_a_does_not_authorize_org_b(self, api_client: APIClient, org: Organization) -> None:
+        """A view_reports Grant at org A does not authorize exporting org B."""
+        other_org = baker.make(Organization, name="Other Org")
+        user = baker.make(User)
+        user.set_password("testpass")
+        user.save()
+        org.add_user(user)
+        other_org.add_user(user)
+        grant_view_reports_via_role(user, org)
+        # No Grant or PermissionGroup on other_org
+
+        api_client.force_authenticate(user=user)
+        response = api_client.get(f"/reports/export/?start_date=2025-01-01&end_date=2025-01-31&org_id={other_org.id}")
+        assert response.status_code == 403
+
 
 REPORT_SUMMARY_QUERY = """
     query ReportSummary($startDate: Date, $endDate: Date) {
@@ -505,6 +549,58 @@ class TestReportSummaryGraphQL(GraphQLBaseTestCase):
         org_without_access.add_user(user)
         grant_view_reports(user, org_with_access)
         # No view_reports on org_without_access
+
+        self._set_active_org(org_without_access)
+        self.graphql_client.force_login(user)
+        response = self.execute_graphql(
+            REPORT_SUMMARY_QUERY,
+            {
+                "startDate": "2025-01-01",
+                "endDate": "2025-01-31",
+            },
+        )
+        self.assertIsNone(response["data"])
+        self.assertEqual(len(response["errors"]), 1)
+
+    def test_grant_holder_without_legacy_group_can_view_summary(self) -> None:
+        """Scoped-Grant holder (no PermissionGroup) can read reportSummary via the grant arm."""
+        org = baker.make(Organization, name="Test Org")
+        user = baker.make(User)
+        user.set_password("testpass")
+        user.save()
+        org.add_user(user)
+        grant_view_reports_via_role(user, org)
+        baker.make(
+            Note,
+            organization=org,
+            interacted_at=timezone.make_aware(datetime(2025, 1, 15, 12, 0, 0)),
+            _quantity=2,
+        )
+
+        self._set_active_org(org)
+        self.graphql_client.force_login(user)
+        response = self.execute_graphql(
+            REPORT_SUMMARY_QUERY,
+            {
+                "startDate": "2025-01-01",
+                "endDate": "2025-01-31",
+            },
+        )
+        self.assertIsNone(response.get("errors"))
+        data = response["data"]["reportSummary"]
+        self.assertEqual(data["totalNotes"], 2)
+
+    def test_grant_at_org_a_does_not_authorize_org_b(self) -> None:
+        """A view_reports Grant at org A does not authorize a summary at org B."""
+        org_with_access = baker.make(Organization, name="Authorized Org")
+        org_without_access = baker.make(Organization, name="Unauthorized Org")
+        user = baker.make(User)
+        user.set_password("testpass")
+        user.save()
+        org_with_access.add_user(user)
+        org_without_access.add_user(user)
+        grant_view_reports_via_role(user, org_with_access)
+        # No Grant or PermissionGroup on org_without_access
 
         self._set_active_org(org_without_access)
         self.graphql_client.force_login(user)

--- a/apps/betterangels-backend/reports/tests/test_views.py
+++ b/apps/betterangels-backend/reports/tests/test_views.py
@@ -5,12 +5,15 @@ from datetime import datetime
 import pytest
 import time_machine
 from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, Role, User
+from accounts.role_manager import OrgRoleManager
+from accounts.tests.baker_recipes import organization_recipe
 from common.tests.utils import GraphQLBaseTestCase
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import ignore_warnings
 from django.utils import timezone
 from model_bakery import baker
+from notes.groups import CASEWORKER
 from notes.models import Note, OrganizationService, ServiceRequest
 from organizations.models import Organization
 from reports.models import ScheduledReport
@@ -322,6 +325,26 @@ class TestExportInteractionDataView:
 
         api_client.force_authenticate(user=user)
         response = api_client.get(f"/reports/export/?start_date=2025-01-01&end_date=2025-01-31&org_id={other_org.id}")
+        assert response.status_code == 403
+
+    def test_membership_in_one_group_does_not_gain_another_groups_report_access(self, api_client: APIClient) -> None:
+        """Single-join regression: a CASEWORKER must not pass view_reports via the org's ORG_ADMIN group.
+
+        The org is provisioned with every template group (CASEWORKER for the
+        user, ORG_ADMIN holding view_reports), so the buggy two-``.filter()``
+        form let the membership and permission conditions match different
+        groups.  ``/reports/export/`` then leaked the org's whole note history.
+        """
+        org = organization_recipe.make(name="Provisioned Org")
+        user = baker.make(User)
+        user.set_password("testpass")
+        user.save()
+        org.add_user(user)
+        OrgRoleManager(org).add_roles(user, CASEWORKER)
+        assert user.has_perm("reports.view_reports") is False
+
+        api_client.force_authenticate(user=user)
+        response = api_client.get(f"/reports/export/?org_id={org.id}")
         assert response.status_code == 403
 
 

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -2088,7 +2088,7 @@ type Query {
   serviceCategories(pagination: OffsetPaginationInput, ordering: [OrganizationServiceCategoryOrdering!]! = []): OrganizationServiceCategoryTypeOffsetPaginated! @hasPerm(permissions: [{app: "notes", permission: "add_note"}], any: true)
   interactionAuthors(pagination: OffsetPaginationInput, filters: InteractionAuthorFilter, ordering: [InteractionAuthorOrder!]! = []): InteractionAuthorTypeOffsetPaginated! @hasPerm(permissions: [{app: "notes", permission: "add_note"}], any: true)
   caseworkerOrganizations(ordering: [OrganizationOrder!] = null, filters: OrganizationFilter = null, pagination: OffsetPaginationInput): OrganizationTypeOffsetPaginated!
-  reportSummary(startDate: Date = null, endDate: Date = null): ReportSummaryType! @hasOrgPermOrGrant(permissions: [{app: "reports", permission: "view_reports"}], any: true)
+  reportSummary(startDate: Date = null, endDate: Date = null): ReportSummaryType! @hasOrgPerm(permissions: [{app: "reports", permission: "view_reports"}], any: true)
   task(pk: ID!): TaskType! @hasRetvalPerm(permissions: [{app: "tasks", permission: "view_task"}], any: true)
   tasks(ordering: [TaskOrder!] = null, filters: TaskFilter, pagination: OffsetPaginationInput): TaskTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "tasks", permission: "view_task"}], any: true)
   teams(filters: TeamFilter = null, pagination: OffsetPaginationInput): TeamTypeOffsetPaginated!

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -2088,7 +2088,7 @@ type Query {
   serviceCategories(pagination: OffsetPaginationInput, ordering: [OrganizationServiceCategoryOrdering!]! = []): OrganizationServiceCategoryTypeOffsetPaginated! @hasPerm(permissions: [{app: "notes", permission: "add_note"}], any: true)
   interactionAuthors(pagination: OffsetPaginationInput, filters: InteractionAuthorFilter, ordering: [InteractionAuthorOrder!]! = []): InteractionAuthorTypeOffsetPaginated! @hasPerm(permissions: [{app: "notes", permission: "add_note"}], any: true)
   caseworkerOrganizations(ordering: [OrganizationOrder!] = null, filters: OrganizationFilter = null, pagination: OffsetPaginationInput): OrganizationTypeOffsetPaginated!
-  reportSummary(startDate: Date = null, endDate: Date = null): ReportSummaryType! @hasOrgPerm(permissions: [{app: "reports", permission: "view_reports"}], any: true)
+  reportSummary(startDate: Date = null, endDate: Date = null): ReportSummaryType! @hasOrgPermOrGrant(permissions: [{app: "reports", permission: "view_reports"}], any: true)
   task(pk: ID!): TaskType! @hasRetvalPerm(permissions: [{app: "tasks", permission: "view_task"}], any: true)
   tasks(ordering: [TaskOrder!] = null, filters: TaskFilter, pagination: OffsetPaginationInput): TaskTypeOffsetPaginated! @hasRetvalPerm(permissions: [{app: "tasks", permission: "view_task"}], any: true)
   teams(filters: TeamFilter = null, pagination: OffsetPaginationInput): TeamTypeOffsetPaginated!


### PR DESCRIPTION
## What & why

Second slice of ADR §5.3 (org-admin role-backed milestone), grouped by endpoint
(**reports** reads only). `view_reports` rides the **legacy `ORG_ADMIN` template**
— no scoped `Role` row exists, so no holder has a `Grant` and the pure-Grant
predicate returns nothing. A grants-only flip would strip access from every org
admin. This slice converts both report consumers to the transitional dual-read
(introduced in #2427):

- **GraphQL** `reportSummary` — `HasOrgPerm` → `HasOrgPermOrGrant` (slice 1 extension).
- **DRF** `ExportInteractionDataApi` — `HasReportAccess` now resolves the org via
  `report_org_for_user()`: the legacy `get_user_permitted_org` arm first (current
  behavior, one query) **or** the grant `can()` arm (dormant until provisioning).
  `can()` never implies existence (ADR §2.6 finding F7) — the org is re-fetched by pk.

The predicate stays pure-grant; both transitional arms are deleted in the §5.3
provisioning PR. `schema.graphql` regenerated (`@hasOrgPermOrGrant` on
`reportSummary`). FE types need regen in a node-enabled checkout.

## TDD
New grant-arm tests failed before the change, pass after:
- DRF: scoped-Grant holder (no PermissionGroup) can export; Grant at org A does
  not authorize exporting org B.
- GraphQL: scoped-Grant holder can read `reportSummary` (aggregates real notes);
  Grant at org A does not authorize a summary at org B.

## Changes
- `reports/schema.py` — swap extension on `reportSummary`
- `reports/permissions.py` — `report_org_for_user()` dual-read + `HasReportAccess`
- `reports/tests/test_views.py` — `grant_view_reports_via_role` helper + 4 tests
- `schema.graphql` — regenerated

## Verification
- reports suite: 68 passed
- ruff format/check clean; mypy strict clean

## Summary by Sourcery

Enable transitional grant-or-legacy authorization for report reads while closing organization permission-isolation vulnerabilities.

New Features:
- Authorize report exports and GraphQL summaries through scoped grants while retaining legacy permission-group access during the transition.

Bug Fixes:
- Prevent permissions held by one organization group from incorrectly authorizing members of a different group.
- Prevent report access granted for one organization from authorizing access to another organization.

Tests:
- Add coverage for grant-based report access and cross-organization isolation across DRF and GraphQL.
- Add regression tests for the multi-valued permission-group join authorization bypass.

Chores:
- Regenerate the GraphQL schema for the updated report summary authorization directive.