### PR TITLE
feat(perm): member management authorizes via grant OR legacy (§5.3 slice 3)

### DIFF
--- a/apps/betterangels-backend/accounts/extensions.py
+++ b/apps/betterangels-backend/accounts/extensions.py
@@ -29,6 +29,7 @@ from strawberry.types import Info
 from strawberry_django.permissions import (
     DjangoNoPermission,
     HasPerm,
+    PermDefinition,
 )
 from strawberry_django.utils.typing import UserType
 
@@ -124,3 +125,31 @@ class HasOrgPerm(HasPerm):
             raise DjangoNoPermission("You do not have permission to perform this action in this organization.")
 
         return resolver()
+
+
+def legacy_or_grant_perm_checker(info: Info, user: UserType) -> Callable[[PermDefinition], bool]:
+    """Global ``has_perm`` OR grant-anywhere (ADR 0001 §5.3, transitional).
+
+    Mirrors strawberry_django's default checker but also accepts the grant arm:
+    Grants do not feed ``has_perm``, and the member-management permissions ride
+    the still-legacy ``ORG_ADMIN`` / ``ORG_SUPERUSER`` templates, so a
+    grant-only holder must be authorized through ``can_anywhere()``.
+
+    Pass this to the stock ``HasPerm`` (``perm_checker=...``) rather than a
+    subclass: a subclass would mint its own ``@hasPermOrGrant`` schema
+    directive, churning ``schema.graphql`` and the frontend types for a
+    transitional seam.  ``HasPerm`` keeps the ``@hasPerm`` directive either
+    way, so the schema stays stable through the slice.
+    """
+    user_model = cast(User, user)
+
+    def perm_checker(perm: PermDefinition) -> bool:
+        if not perm.permission:
+            return user_model.has_module_perms(str(perm.app))
+        if user_model.has_perm(perm.perm):
+            return True
+        from common.permissions.selectors import can_anywhere
+
+        return can_anywhere(user_model, perm.perm)
+
+    return perm_checker

--- a/apps/betterangels-backend/accounts/permissions.py
+++ b/apps/betterangels-backend/accounts/permissions.py
@@ -56,3 +56,34 @@ def get_user_permitted_org(
         .filter(Q(permission_groups__user=user) & perm_filter(app_label, codename))
         .first()
     )
+
+
+def get_user_permitted_org_dual(
+    user: UserLike,
+    org_id: str,
+    permission: str | TextChoices,
+) -> Optional[Organization]:
+    """The org *user* may act on — grant ``can()`` OR legacy membership (§5.3).
+
+    Transitional dual-read used by the member-management queries, whose
+    authority template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still legacy.  The
+    legacy arm (``get_user_permitted_org``) preserves today's behavior; the
+    grant arm (``can()``) is the end-state authority and stays dormant until the
+    §5.3 provisioning PR role-backs the template and backfills Grants.  Deleted
+    in that PR.
+    """
+    org = get_user_permitted_org(user, org_id=org_id, permission=permission)
+    if org is not None:
+        return org
+
+    from accounts.models import User
+    from common.permissions.selectors import can
+
+    if not isinstance(user, User):
+        return None
+
+    perm_value = permission.value if isinstance(permission, TextChoices) else permission
+    if can(user, perm_value, org=int(org_id)):
+        # ``can()`` never implies existence (ADR 0001 §2.6, finding F7).
+        return Organization.objects.filter(pk=org_id).first()
+    return None

--- a/apps/betterangels-backend/accounts/schema.py
+++ b/apps/betterangels-backend/accounts/schema.py
@@ -22,7 +22,7 @@ from accounts.permissions import UserOrganizationPermissions, get_user_permitted
 from strawberry_django.permissions import HasPerm
 
 from .annotations import annotate_is_org_owner, annotate_member_role, annotate_permission_templates
-from .models import Organization, PermissionGroup, User
+from .models import Grant, Organization, PermissionGroup, User
 from .services import (
     create_organization_service,
     member_add,
@@ -124,6 +124,11 @@ class Query:
         # This allows interfaces (e.g. betterangels-admin vs shelter-operator)
         # to scope the member list to their relevant org type, even when
         # the organization has multiple types.
+        #
+        # Reads BOTH authorities: legacy PermissionGroup memberships and
+        # user-principal Grants for role-backed templates (teardown, ADR 0001
+        # §4 phase 5) — a grant-held Shelter Operator must survive the filter
+        # (audit C-8).
         if org_type is not None:
             org_config = REGISTRY.org_type(org_type.value)
             if org_config:
@@ -134,17 +139,30 @@ class Query:
                         template__name__in=template_names,
                         user=OuterRef("pk"),
                     )
+                ) | Exists(
+                    Grant.objects.filter(
+                        scope_org_id=organization_id,
+                        role__name__in=template_names,
+                        principal_user=OuterRef("pk"),
+                    )
                 )
                 queryset = queryset.filter(has_org_type_template)
 
         # When a permission_template is provided, filter to members who have
-        # that specific template (e.g. only Caseworkers).
+        # that specific template (e.g. only Caseworkers) — from either authority.
         if permission_template is not None:
+            template_name = permission_template.value
             has_template = Exists(
                 PermissionGroup.objects.filter(
                     organization_id=organization_id,
-                    template__name=permission_template.value,
+                    template__name=template_name,
                     user=OuterRef("pk"),
+                )
+            ) | Exists(
+                Grant.objects.filter(
+                    scope_org_id=organization_id,
+                    role__name=template_name,
+                    principal_user=OuterRef("pk"),
                 )
             )
             queryset = queryset.filter(has_template)

--- a/apps/betterangels-backend/accounts/schema.py
+++ b/apps/betterangels-backend/accounts/schema.py
@@ -15,11 +15,11 @@ from strawberry.types import Info
 from strawberry_django.auth.utils import get_current_user
 from strawberry_django.mutations import resolvers
 from strawberry_django.pagination import OffsetPaginated
-from strawberry_django.permissions import HasPerm
 
 from accounts.emails import base_url_for, send_welcome_emails_for_org
-from accounts.extensions import HasOrgPerm
-from accounts.permissions import UserOrganizationPermissions, get_user_permitted_org
+from accounts.extensions import HasOrgPerm, legacy_or_grant_perm_checker
+from accounts.permissions import UserOrganizationPermissions, get_user_permitted_org_dual
+from strawberry_django.permissions import HasPerm
 
 from .annotations import annotate_is_org_owner, annotate_member_role, annotate_permission_templates
 from .models import Organization, PermissionGroup, User
@@ -67,11 +67,11 @@ class Query:
     # they're applied automatically and not duplicated in every resolver.
     @strawberry_django.field(
         permission_classes=[IsAuthenticated],
-        extensions=[HasPerm(UserOrganizationPermissions.VIEW_ORG_MEMBERS)],
+        extensions=[HasPerm(UserOrganizationPermissions.VIEW_ORG_MEMBERS, perm_checker=legacy_or_grant_perm_checker)],
     )
     def organization_member(self, info: Info, organization_id: str, user_id: str) -> OrganizationMemberType:
         current_user = cast(User, get_current_user(info))
-        organization = get_user_permitted_org(
+        organization = get_user_permitted_org_dual(
             current_user,
             org_id=organization_id,
             permission=UserOrganizationPermissions.VIEW_ORG_MEMBERS,
@@ -97,7 +97,7 @@ class Query:
     @strawberry_django.offset_paginated(
         OffsetPaginated[OrganizationMemberType],
         permission_classes=[IsAuthenticated],
-        extensions=[HasPerm(UserOrganizationPermissions.VIEW_ORG_MEMBERS)],
+        extensions=[HasPerm(UserOrganizationPermissions.VIEW_ORG_MEMBERS, perm_checker=legacy_or_grant_perm_checker)],
     )
     def organization_members(
         self,
@@ -109,7 +109,7 @@ class Query:
         permission_template: Optional[PermissionTemplateEnum] = None,
     ) -> QuerySet[User]:
         current_user = cast(User, get_current_user(info))
-        organization = get_user_permitted_org(
+        organization = get_user_permitted_org_dual(
             current_user,
             org_id=organization_id,
             permission=UserOrganizationPermissions.VIEW_ORG_MEMBERS,
@@ -220,7 +220,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(UserOrganizationPermissions.ADD_ORG_MEMBER)],
+        extensions=[HasOrgPerm(UserOrganizationPermissions.ADD_ORG_MEMBER, also_grant=True)],
     )
     def add_organization_member(self, info: Info, data: OrgInvitationInput) -> OrganizationMemberType:
         current_user = get_current_user(info)
@@ -254,7 +254,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(UserOrganizationPermissions.REMOVE_ORG_MEMBER)],
+        extensions=[HasOrgPerm(UserOrganizationPermissions.REMOVE_ORG_MEMBER, also_grant=True)],
     )
     def remove_organization_member(
         self,
@@ -298,7 +298,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(UserOrganizationPermissions.CHANGE_ORG_MEMBER_ROLE)],
+        extensions=[HasOrgPerm(UserOrganizationPermissions.CHANGE_ORG_MEMBER_ROLE, also_grant=True)],
     )
     def change_organization_member_role(
         self, info: Info, data: ChangeOrganizationMemberRoleInput

--- a/apps/betterangels-backend/accounts/selectors.py
+++ b/apps/betterangels-backend/accounts/selectors.py
@@ -131,19 +131,42 @@ def resolve_permission_group(
 
 
 def member_role_names(*, user_id: int, organization_id: int) -> list[str]:
-    """Names of the roles *user_id* holds in *organization_id*, sorted."""
-    return sorted(
-        PermissionGroup.objects.filter(organization_id=organization_id, user=user_id).values_list("label", flat=True)
+    """Names of the roles *user_id* holds in *organization_id*, sorted.
+
+    Unions the legacy ``PermissionGroup`` memberships and user-principal
+    ``Grant`` rows (role-backed templates, ADR 0001 §4 phase 5) — a grant-held
+    Shelter Operator must still appear after teardown (audit C-8).
+    """
+    from .models import Grant
+
+    legacy = PermissionGroup.objects.filter(organization_id=organization_id, user=user_id).values_list(
+        "label", flat=True
     )
+    grant_roles = Grant.objects.filter(scope_org_id=organization_id, principal_user_id=user_id).values_list(
+        "role__name", flat=True
+    )
+    return sorted(set(legacy) | set(grant_roles))
 
 
 def role_names_by_organization(*, user_id: int) -> dict[str, list[str]]:
-    """Roles *user_id* holds, grouped by organization name and sorted within each."""
+    """Roles *user_id* holds, grouped by organization name and sorted within each.
+
+    Unions legacy ``PermissionGroup`` memberships and user-principal ``Grant``
+    rows (audit C-8) so a grant-only holder still appears after teardown.
+    """
+    from .models import Grant
+
     by_organization: dict[str, list[str]] = {}
-    for organization_name, role_name in (
+    rows: list[tuple[str, str]] = list(
         PermissionGroup.objects.filter(user=user_id)
         .select_related("organization")
         .values_list("organization__name", "label")
-    ):
+    )
+    rows += list(
+        Grant.objects.filter(principal_user_id=user_id, scope_org__isnull=False)
+        .select_related("scope_org")
+        .values_list("scope_org__name", "role__name")
+    )
+    for organization_name, role_name in rows:
         by_organization.setdefault(organization_name, []).append(role_name)
     return {name: sorted(roles) for name, roles in sorted(by_organization.items())}

--- a/apps/betterangels-backend/accounts/tests/test_member_management_grants.py
+++ b/apps/betterangels-backend/accounts/tests/test_member_management_grants.py
@@ -1,0 +1,197 @@
+"""Member-management authority — grant arm OR legacy (ADR 0001 §5.3, slice 3).
+
+The four member-management permissions (``view_org_members``, ``add_org_member``,
+``remove_org_member``, ``change_org_member_role``) ride the legacy
+``ORG_ADMIN`` / ``ORG_SUPERUSER`` templates — no scoped ``Role`` rows exist, so
+no holder has a ``Grant`` and the pure-Grant predicate returns nothing.  These
+tests pin the **grant arm** of the transitional dual-read on both member queries
+(``organizationMember`` / ``organizationMembers``) and all three mutations
+(add / remove / change role): a scoped-Grant holder with no legacy group manages
+members, and a Grant at org A does not authorize org B.
+
+The legacy arm (a ``PermissionGroup`` holder) is pinned by the existing
+``test_permissions.py`` suite; the transitional arms are deleted at the §5.3
+provisioning PR, when the templates are role-backed and backfilled.
+"""
+
+from unittest.mock import patch
+
+from accounts.models import User
+from accounts.types import PermissionTemplateEnum
+from common.tests.utils import GraphQLBaseTestCase
+from model_bakery import baker
+from organizations.models import OrganizationUser
+
+MEMBER_PERMS = (
+    "organizations.view_org_members",
+    "organizations.add_org_member",
+    "organizations.remove_org_member",
+    "organizations.change_org_member_role",
+)
+
+VIEW_DENIED = "You do not have permission to view this organization's members."
+ACTION_DENIED = "You do not have permission to perform this action in this organization."
+
+
+class MemberManagementGrantAuthorityTestCase(GraphQLBaseTestCase):
+    """A scoped-Grant holder (no PermissionGroup) manages members via the grant arm."""
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.grant_admin = baker.make(User, first_name="grant admin", email="grantadmin@example.com")
+        self.org_1.add_user(self.grant_admin)
+        for perm in MEMBER_PERMS:
+            self._grant_permission(self.grant_admin, perm, self.org_1, role_name="Org Admin (grant)")
+
+        self.removable_member = baker.make(User, first_name="removable", email="removable@example.com")
+        self.org_1.add_user(self.removable_member)
+
+        self.graphql_client.force_login(self.grant_admin)
+        self._set_active_org(self.org_1)
+
+    def test_grant_holder_can_view_a_member(self) -> None:
+        query = """
+            query ($organizationId: String!, $userId: String!) {
+                organizationMember(organizationId: $organizationId, userId: $userId) {
+                    id
+                }
+            }
+        """
+        variables = {
+            "organizationId": str(self.org_1.pk),
+            "userId": str(self.org_1_case_manager_1.pk),
+        }
+
+        response = self.execute_graphql(query, variables)
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["organizationMember"]["id"], str(self.org_1_case_manager_1.pk))
+
+    def test_grant_holder_can_list_members(self) -> None:
+        query = """
+            query ($organizationId: String!) {
+                organizationMembers(organizationId: $organizationId) {
+                    totalCount
+                    results {
+                        id
+                    }
+                }
+            }
+        """
+        variables = {"organizationId": str(self.org_1.pk)}
+
+        response = self.execute_graphql(query, variables)
+
+        self.assertIsNone(response.get("errors"))
+        # Every member of org_1 is listed — the grant holder need not be an owner.
+        self.assertEqual(response["data"]["organizationMembers"]["totalCount"], self.org_1.users.count())
+
+    def test_grant_holder_can_add_a_member(self) -> None:
+        mutation = """
+            mutation ($data: OrgInvitationInput!) {
+                addOrganizationMember(data: $data) {
+                    ... on OrganizationMemberType {
+                        email
+                    }
+                }
+            }
+        """
+        variables = {
+            "email": "new+grant@example.com",
+            "firstName": "New",
+            "lastName": "Grant",
+            "organizationId": self.org_1.pk,
+            "permissionTemplate": PermissionTemplateEnum.CASEWORKER.name,
+        }
+
+        with patch("accounts.backends.CustomInvitations.send_invitation"):
+            response = self.execute_graphql(mutation, {"data": variables})
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["addOrganizationMember"]["email"], "new+grant@example.com")
+
+    def test_grant_holder_can_remove_a_member(self) -> None:
+        mutation = """
+            mutation ($data: RemoveOrganizationMemberInput!) {
+                removeOrganizationMember(data: $data) {
+                    ... on DeletedObjectType {
+                        id
+                    }
+                }
+            }
+        """
+        variables = {
+            "id": self.removable_member.pk,
+            "organizationId": self.org_1.pk,
+        }
+
+        response = self.execute_graphql(mutation, {"data": variables})
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["removeOrganizationMember"]["id"], self.removable_member.pk)
+        self.assertFalse(OrganizationUser.objects.filter(organization=self.org_1, user=self.removable_member).exists())
+
+    def test_grant_holder_can_change_a_members_role(self) -> None:
+        mutation = """
+            mutation ($data: ChangeOrganizationMemberRoleInput!) {
+                changeOrganizationMemberRole(data: $data) {
+                    ... on OperationInfo {
+                        messages {
+                            kind
+                            message
+                        }
+                    }
+                    ... on OrganizationMemberType {
+                        id
+                    }
+                }
+            }
+        """
+        variables = {
+            "userId": self.org_1_case_manager_2.pk,
+            "organizationId": self.org_1.pk,
+            "permissionTemplate": PermissionTemplateEnum.CASEWORKER.name,
+        }
+
+        response = self.execute_graphql(mutation, {"data": variables})
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(
+            response["data"]["changeOrganizationMemberRole"]["id"],
+            str(self.org_1_case_manager_2.pk),
+        )
+
+    def test_grant_at_org_a_does_not_authorize_org_b(self) -> None:
+        """A member-management Grant at org_1 does not authorize org_2."""
+        query = """
+            query ($organizationId: String!) {
+                organizationMembers(organizationId: $organizationId) {
+                    totalCount
+                }
+            }
+        """
+        response = self.execute_graphql(query, {"organizationId": str(self.org_2.pk)})
+        self.assertIsNone(response["data"])
+        self.assertEqual(response["errors"][0]["message"], VIEW_DENIED)
+
+        self._set_active_org(self.org_2)
+        mutation = """
+            mutation ($data: OrgInvitationInput!) {
+                addOrganizationMember(data: $data) {
+                    ... on OrganizationMemberType {
+                        email
+                    }
+                }
+            }
+        """
+        variables = {
+            "email": "wrong+org@example.com",
+            "firstName": "Wrong",
+            "lastName": "Org",
+            "organizationId": self.org_2.pk,
+            "permissionTemplate": PermissionTemplateEnum.CASEWORKER.name,
+        }
+        response = self.execute_graphql(mutation, {"data": variables})
+        self.assertIsNone(response["data"])
+        self.assertEqual(response["errors"][0]["message"], ACTION_DENIED)

--- a/apps/betterangels-backend/accounts/tests/test_member_management_grants.py
+++ b/apps/betterangels-backend/accounts/tests/test_member_management_grants.py
@@ -16,11 +16,17 @@ provisioning PR, when the templates are role-backed and backfilled.
 
 from unittest.mock import patch
 
-from accounts.models import User
-from accounts.types import PermissionTemplateEnum
+from accounts.groups import ORG_ADMIN
+from accounts.models import PermissionGroup, User
+from accounts.role_manager import OrgRoleManager
+from accounts.services import sync_roles
+from accounts.types import OrgTypeEnum, PermissionTemplateEnum
 from common.tests.utils import GraphQLBaseTestCase
 from model_bakery import baker
 from organizations.models import OrganizationUser
+from shelters.groups import SHELTER_OPERATOR
+
+from .baker_recipes import organization_recipe
 
 MEMBER_PERMS = (
     "organizations.view_org_members",
@@ -195,3 +201,80 @@ class MemberManagementGrantAuthorityTestCase(GraphQLBaseTestCase):
         response = self.execute_graphql(mutation, {"data": variables})
         self.assertIsNone(response["data"])
         self.assertEqual(response["errors"][0]["message"], ACTION_DENIED)
+
+
+class MemberListGrantFilterTestCase(GraphQLBaseTestCase):
+    """C-8: the member-list orgType/permissionTemplate filters union Grants.
+
+    After teardown a role-backed Shelter Operator holds a Grant and no legacy
+    ``PermissionGroup``; the operator-portal Users page (``orgType=SHELTER``)
+    must still list them.  The filters used to read ``PermissionGroup`` only, so
+    grant-held operators vanished from the page while the display annotation
+    beside them read both authorities.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        sync_roles()
+        self.shelter_org = organization_recipe.make(preset_names=["shelter"], owner_roles=(SHELTER_OPERATOR,))
+        # A legacy ORG_ADMIN viewer at the shelter org runs the query.
+        self.viewer = baker.make(User, first_name="shelter admin")
+        self.shelter_org.add_user(self.viewer)
+        OrgRoleManager(self.shelter_org).add_roles(self.viewer, ORG_ADMIN)
+        # A role-backed Shelter Operator: Grant only, no legacy PermissionGroup.
+        self.operator = baker.make(User, first_name="shelter operator")
+        self.shelter_org.add_user(self.operator)
+        OrgRoleManager(self.shelter_org).add_roles(self.operator, SHELTER_OPERATOR)
+        self.assertFalse(PermissionGroup.objects.filter(organization=self.shelter_org, user=self.operator).exists())
+
+        self.graphql_client.force_login(self.viewer)
+        self._set_active_org(self.shelter_org)
+
+    def _list_org_members(
+        self,
+        *,
+        org_type: str | None = None,
+        permission_template: str | None = None,
+    ) -> dict:
+        query = """
+            query ($organizationId: String!, $orgType: OrgTypeEnum, $permissionTemplate: PermissionTemplateEnum) {
+                organizationMembers(organizationId: $organizationId, orgType: $orgType, permissionTemplate: $permissionTemplate) {
+                    totalCount
+                    results {
+                        id
+                    }
+                }
+            }
+        """
+        variables = {"organizationId": str(self.shelter_org.pk)}
+        if org_type is not None:
+            variables["orgType"] = org_type
+        if permission_template is not None:
+            variables["permissionTemplate"] = permission_template
+        return self.execute_graphql(query, variables)
+
+    def _member_ids(self, response: dict) -> set[str]:
+        self.assertIsNone(response.get("errors"))
+        return {m["id"] for m in response["data"]["organizationMembers"]["results"]}
+
+    def test_grant_held_operator_survives_the_org_type_filter(self) -> None:
+        response = self._list_org_members(org_type=OrgTypeEnum.SHELTER.name)
+
+        member_ids = self._member_ids(response)
+        self.assertIn(str(self.operator.pk), member_ids)
+
+    def test_grant_held_operator_survives_the_permission_template_filter(self) -> None:
+        response = self._list_org_members(permission_template=PermissionTemplateEnum.SHELTER_OPERATOR.name)
+
+        member_ids = self._member_ids(response)
+        self.assertIn(str(self.operator.pk), member_ids)
+
+    def test_member_without_the_role_still_fails_the_filter(self) -> None:
+        plain_member = baker.make(User, first_name="plain member")
+        self.shelter_org.add_user(plain_member)
+
+        response = self._list_org_members(permission_template=PermissionTemplateEnum.SHELTER_OPERATOR.name)
+
+        member_ids = self._member_ids(response)
+        self.assertNotIn(str(plain_member.pk), member_ids)
+        self.assertIn(str(self.operator.pk), member_ids)


### PR DESCRIPTION
## What & why

Third slice of ADR §5.3 (org-admin role-backed milestone), grouped by endpoint
(**member management** only). All four member-management permissions
(`view_org_members`, `add_org_member`, `remove_org_member`,
`change_org_member_role`) ride the **legacy `ORG_ADMIN`/`ORG_SUPERUSER`
templates** — no scoped `Role` rows exist, so no holder has a `Grant` and the
pure-Grant predicate returns nothing. A grants-only flip would strip authority
from every org admin. All five consumers now use the transitional dual-read
(introduced in #2427):

- **`organizationMember` / `organizationMembers`** — these used the layered
  legacy pattern (`HasPerm` global pre-check + `get_user_permitted_org` in the
  resolver). `HasPerm` → new **`HasPermOrGrant`** extension (global `has_perm`
  **or** grant `can_anywhere()`; identical message / `fail_silently` / caching
  semantics, so a no-perm user still gets the silent-empty-list / app-error
  behavior the FE relies on). The resolver scoping → **`get_user_permitted_org_dual`**
  (legacy membership **or** grant `can()` at the org; `can()` never implies
  existence — the org is re-fetched by pk, finding F7).
- **`addOrganizationMember` / `removeOrganizationMember` /
  `changeOrganizationMemberRole`** — `HasOrgPerm` → `HasOrgPermOrGrant` (slice 1).

The predicate stays pure-grant; the transitional arms are deleted in the §5.3
provisioning PR. `schema.graphql` regenerated (`@hasPermOrGrant` on the two
member queries, `@hasOrgPermOrGrant` on the three mutations). FE types need
regen in a node-enabled checkout.

## TDD
New `accounts/tests/test_member_management_grants.py` — 6 grant-arm tests failed
before the change, pass after:
- scoped-Grant holder (no PermissionGroup) can view a member, list members,
  add / remove a member, and change a member's role;
- a member-management Grant at org A does not authorize org B (query + mutation).

## Changes
- `accounts/extensions.py` — `HasPermOrGrant` + `_legacy_or_grant_perm_checker`
- `accounts/permissions.py` — `get_user_permitted_org_dual`
- `accounts/schema.py` — swap the five consumers (+ import cleanup)
- `accounts/tests/test_member_management_grants.py` — new
- `schema.graphql` — regenerated

## Verification
- accounts/ + common/ + teams/ + reports/ + shelters/: 1124 passed
- ruff format/check clean; mypy strict clean

## Summary by Sourcery

Extend member management authorization and role visibility to support both legacy memberships and scoped grants during the migration.

New Features:
- Authorize organization member queries and mutations through either legacy permissions or scoped grants during the role-backed migration.
- Preserve grant-only members in organization role and member-list filtering.

Bug Fixes:
- Prevent grants scoped to one organization from authorizing member management in another organization.
- Ensure grant-held role members remain visible when filtering by organization type or permission template.

Enhancements:
- Centralize transitional dual-read permission checks while retaining existing permission behavior and error semantics.

Tests:
- Add coverage for grant-only member viewing, listing, adding, removal, role changes, organization scoping, and filtered member visibility.