### PR TITLE
fix(perm): member-list filters + role selectors union Grants (audit C-8)

### DIFF
--- a/apps/betterangels-backend/accounts/schema.py
+++ b/apps/betterangels-backend/accounts/schema.py
@@ -21,7 +21,7 @@ from accounts.extensions import HasOrgPermOrGrant, HasPermOrGrant
 from accounts.permissions import UserOrganizationPermissions, get_user_permitted_org_dual
 
 from .annotations import annotate_is_org_owner, annotate_member_role, annotate_permission_templates
-from .models import Organization, PermissionGroup, User
+from .models import Grant, Organization, PermissionGroup, User
 from .services import (
     create_organization_service,
     member_add,
@@ -123,6 +123,11 @@ class Query:
         # This allows interfaces (e.g. betterangels-admin vs shelter-operator)
         # to scope the member list to their relevant org type, even when
         # the organization has multiple types.
+        #
+        # Reads BOTH authorities: legacy PermissionGroup memberships and
+        # user-principal Grants for role-backed templates (teardown, ADR 0001
+        # §4 phase 5) — a grant-held Shelter Operator must survive the filter
+        # (audit C-8).
         if org_type is not None:
             org_config = REGISTRY.org_type(org_type.value)
             if org_config:
@@ -133,17 +138,30 @@ class Query:
                         template__name__in=template_names,
                         user=OuterRef("pk"),
                     )
+                ) | Exists(
+                    Grant.objects.filter(
+                        scope_org_id=organization_id,
+                        role__name__in=template_names,
+                        principal_user=OuterRef("pk"),
+                    )
                 )
                 queryset = queryset.filter(has_org_type_template)
 
         # When a permission_template is provided, filter to members who have
-        # that specific template (e.g. only Caseworkers).
+        # that specific template (e.g. only Caseworkers) — from either authority.
         if permission_template is not None:
+            template_name = permission_template.value
             has_template = Exists(
                 PermissionGroup.objects.filter(
                     organization_id=organization_id,
-                    template__name=permission_template.value,
+                    template__name=template_name,
                     user=OuterRef("pk"),
+                )
+            ) | Exists(
+                Grant.objects.filter(
+                    scope_org_id=organization_id,
+                    role__name=template_name,
+                    principal_user=OuterRef("pk"),
                 )
             )
             queryset = queryset.filter(has_template)

--- a/apps/betterangels-backend/accounts/selectors.py
+++ b/apps/betterangels-backend/accounts/selectors.py
@@ -131,19 +131,42 @@ def resolve_permission_group(
 
 
 def member_role_names(*, user_id: int, organization_id: int) -> list[str]:
-    """Names of the roles *user_id* holds in *organization_id*, sorted."""
-    return sorted(
-        PermissionGroup.objects.filter(organization_id=organization_id, user=user_id).values_list("label", flat=True)
+    """Names of the roles *user_id* holds in *organization_id*, sorted.
+
+    Unions the legacy ``PermissionGroup`` memberships and user-principal
+    ``Grant`` rows (role-backed templates, ADR 0001 §4 phase 5) — a grant-held
+    Shelter Operator must still appear after teardown (audit C-8).
+    """
+    from .models import Grant
+
+    legacy = PermissionGroup.objects.filter(organization_id=organization_id, user=user_id).values_list(
+        "label", flat=True
     )
+    grant_roles = Grant.objects.filter(scope_org_id=organization_id, principal_user_id=user_id).values_list(
+        "role__name", flat=True
+    )
+    return sorted(set(legacy) | set(grant_roles))
 
 
 def role_names_by_organization(*, user_id: int) -> dict[str, list[str]]:
-    """Roles *user_id* holds, grouped by organization name and sorted within each."""
+    """Roles *user_id* holds, grouped by organization name and sorted within each.
+
+    Unions legacy ``PermissionGroup`` memberships and user-principal ``Grant``
+    rows (audit C-8) so a grant-only holder still appears after teardown.
+    """
+    from .models import Grant
+
     by_organization: dict[str, list[str]] = {}
-    for organization_name, role_name in (
+    rows: list[tuple[str, str]] = list(
         PermissionGroup.objects.filter(user=user_id)
         .select_related("organization")
         .values_list("organization__name", "label")
-    ):
+    )
+    rows += list(
+        Grant.objects.filter(principal_user_id=user_id, scope_org__isnull=False)
+        .select_related("scope_org")
+        .values_list("scope_org__name", "role__name")
+    )
+    for organization_name, role_name in rows:
         by_organization.setdefault(organization_name, []).append(role_name)
     return {name: sorted(roles) for name, roles in sorted(by_organization.items())}

--- a/apps/betterangels-backend/accounts/tests/test_member_management_grants.py
+++ b/apps/betterangels-backend/accounts/tests/test_member_management_grants.py
@@ -16,11 +16,17 @@ provisioning PR, when the templates are role-backed and backfilled.
 
 from unittest.mock import patch
 
-from accounts.models import User
-from accounts.types import PermissionTemplateEnum
+from accounts.groups import ORG_ADMIN
+from accounts.models import PermissionGroup, User
+from accounts.role_manager import OrgRoleManager
+from accounts.services import sync_roles
+from accounts.types import OrgTypeEnum, PermissionTemplateEnum
 from common.tests.utils import GraphQLBaseTestCase
 from model_bakery import baker
 from organizations.models import OrganizationUser
+from shelters.groups import SHELTER_OPERATOR
+
+from .baker_recipes import organization_recipe
 
 MEMBER_PERMS = (
     "organizations.view_org_members",
@@ -195,3 +201,80 @@ class MemberManagementGrantAuthorityTestCase(GraphQLBaseTestCase):
         response = self.execute_graphql(mutation, {"data": variables})
         self.assertIsNone(response["data"])
         self.assertEqual(response["errors"][0]["message"], ACTION_DENIED)
+
+
+class MemberListGrantFilterTestCase(GraphQLBaseTestCase):
+    """C-8: the member-list orgType/permissionTemplate filters union Grants.
+
+    After teardown a role-backed Shelter Operator holds a Grant and no legacy
+    ``PermissionGroup``; the operator-portal Users page (``orgType=SHELTER``)
+    must still list them.  The filters used to read ``PermissionGroup`` only, so
+    grant-held operators vanished from the page while the display annotation
+    beside them read both authorities.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        sync_roles()
+        self.shelter_org = organization_recipe.make(preset_names=["shelter"], owner_roles=(SHELTER_OPERATOR,))
+        # A legacy ORG_ADMIN viewer at the shelter org runs the query.
+        self.viewer = baker.make(User, first_name="shelter admin")
+        self.shelter_org.add_user(self.viewer)
+        OrgRoleManager(self.shelter_org).add_roles(self.viewer, ORG_ADMIN)
+        # A role-backed Shelter Operator: Grant only, no legacy PermissionGroup.
+        self.operator = baker.make(User, first_name="shelter operator")
+        self.shelter_org.add_user(self.operator)
+        OrgRoleManager(self.shelter_org).add_roles(self.operator, SHELTER_OPERATOR)
+        self.assertFalse(PermissionGroup.objects.filter(organization=self.shelter_org, user=self.operator).exists())
+
+        self.graphql_client.force_login(self.viewer)
+        self._set_active_org(self.shelter_org)
+
+    def _list_org_members(
+        self,
+        *,
+        org_type: str | None = None,
+        permission_template: str | None = None,
+    ) -> dict:
+        query = """
+            query ($organizationId: String!, $orgType: OrgTypeEnum, $permissionTemplate: PermissionTemplateEnum) {
+                organizationMembers(organizationId: $organizationId, orgType: $orgType, permissionTemplate: $permissionTemplate) {
+                    totalCount
+                    results {
+                        id
+                    }
+                }
+            }
+        """
+        variables = {"organizationId": str(self.shelter_org.pk)}
+        if org_type is not None:
+            variables["orgType"] = org_type
+        if permission_template is not None:
+            variables["permissionTemplate"] = permission_template
+        return self.execute_graphql(query, variables)
+
+    def _member_ids(self, response: dict) -> set[str]:
+        self.assertIsNone(response.get("errors"))
+        return {m["id"] for m in response["data"]["organizationMembers"]["results"]}
+
+    def test_grant_held_operator_survives_the_org_type_filter(self) -> None:
+        response = self._list_org_members(org_type=OrgTypeEnum.SHELTER.name)
+
+        member_ids = self._member_ids(response)
+        self.assertIn(str(self.operator.pk), member_ids)
+
+    def test_grant_held_operator_survives_the_permission_template_filter(self) -> None:
+        response = self._list_org_members(permission_template=PermissionTemplateEnum.SHELTER_OPERATOR.name)
+
+        member_ids = self._member_ids(response)
+        self.assertIn(str(self.operator.pk), member_ids)
+
+    def test_member_without_the_role_still_fails_the_filter(self) -> None:
+        plain_member = baker.make(User, first_name="plain member")
+        self.shelter_org.add_user(plain_member)
+
+        response = self._list_org_members(permission_template=PermissionTemplateEnum.SHELTER_OPERATOR.name)
+
+        member_ids = self._member_ids(response)
+        self.assertNotIn(str(plain_member.pk), member_ids)
+        self.assertIn(str(self.operator.pk), member_ids)


### PR DESCRIPTION
## What & why

C-8 from the external audit: the stack's dual-authority sweep converted the
member-management *gate* but missed the read sites that filter/display members.

- **`organizationMembers`' `orgType` / `permissionTemplate` filters** read
  `PermissionGroup` only. After teardown a grant-held Shelter Operator (no
  legacy group) vanished from the operator-portal Users page
  (`orgType=SHELTER`) while the display annotation beside them read both
  authorities. The two filters now OR in a user-principal `Grant` whose role
  name matches the template (role-backed templates are name-keyed).
- **`member_role_names` / `role_names_by_organization`** (Django-admin role
  displays — the `OrganizationUser` "Roles" column and `UserAdmin`'s
  "Organizations and roles") were `PermissionGroup`-only, so a grant-only
  holder appeared in neither. Both now union user-principal Grant role names.

## TDD
3 new tests in `accounts/tests/test_member_management_grants.py` failed before
the fix, pass after:
- a grant-held Shelter Operator survives the `orgType=SHELTER` filter;
- …and the `permissionTemplate=SHELTER_OPERATOR` filter;
- a plain member without the role still fails the filter (control).

## Changes
- `accounts/schema.py` — orgType/permissionTemplate filters union Grants
- `accounts/selectors.py` — `member_role_names` / `role_names_by_organization`
  union Grants
- `accounts/tests/test_member_management_grants.py` — `MemberListGrantFilterTestCase`

## Verification
- accounts suite: 287 passed
- ruff format/check clean; mypy strict clean. No schema change (resolver-internal).

## Summary by Sourcery

Unify member filtering and role display across legacy permission groups and user-principal grants.

Bug Fixes:
- Ensure grant-only organization members remain visible when filtering member lists by organization type or permission template.
- Include user-principal grant roles in organization member role displays and organization-grouped role listings.

Tests:
- Add coverage for grant-held role members passing both member-list filters and for unprivileged members remaining excluded.