### PR TITLE
fix(permissions): Global Shelter Operator regains Django-admin org add/edit (DEV-2553)

### DIFF
--- a/apps/betterangels-backend/accounts/permissions.py
+++ b/apps/betterangels-backend/accounts/permissions.py
@@ -24,6 +24,22 @@ class UserOrganizationPermissions(models.TextChoices):
     VIEW_ORG_MEMBERS = "organizations.view_org_members", _("Can view organization members")
 
 
+class OrganizationAdminPermissions(models.TextChoices):
+    """Django default perms on the django-organizations models.
+
+    Consumed only by the Django admin via ``ModelBackend.has_perm``, so this is
+    deliberately NOT ``@register_permission``-ed — these must not leak into the
+    generated frontend permission consts.  The models come from the third-party
+    ``django-organizations`` package and declare no ``perms`` PermissionSet,
+    which is why these are constants rather than ``Model.perms.*``.
+    """
+
+    ADD_ORGANIZATION = "organizations.add_organization", _("Can add organization")
+    CHANGE_ORGANIZATION = "organizations.change_organization", _("Can change organization")
+    VIEW_ORGANIZATION = "organizations.view_organization", _("Can view organization")
+    VIEW_ORGANIZATION_USER = "organizations.view_organizationuser", _("Can view organization user")
+
+
 # ── Organization permission check ─────────────────────────────────────────────
 
 

--- a/apps/betterangels-backend/accounts/tests/test_gso_org_admin_permissions.py
+++ b/apps/betterangels-backend/accounts/tests/test_gso_org_admin_permissions.py
@@ -1,0 +1,94 @@
+"""Regression: GSO holders (successors to the legacy 'Shelter Data Entry' /
+'Shelter Administration' groups) must be able to add/edit Organizations in the
+Django admin.
+
+Migration 0003_consolidate_shelter_operator deleted those global groups and
+moved their staff into org-scoped ``Global Shelter Operator`` PermissionGroups.
+Because a PermissionGroup *is* an ``auth.Group``, ``ModelBackend`` reads its
+permissions globally — but the GSO template originally carried only
+``shelters.*``/lookup perms, so those staff lost Django-admin org management
+(403 on /admin/organizations/organization/).
+"""
+
+from accounts.models import PermissionGroup, PermissionGroupTemplate, User
+from accounts.seed import sync_group_permissions
+from accounts.tests.baker_recipes import organization_recipe
+from django.test import TestCase
+from django.urls import reverse
+from model_bakery import baker
+from organizations.models import Organization
+from shelters.groups import GLOBAL_SHELTER_OPERATOR
+
+ORG_ADMIN_PERMS = {
+    "organizations.add_organization",
+    "organizations.change_organization",
+    "organizations.view_organization",
+    "organizations.view_organizationuser",
+    "accounts.add_organizationprofile",
+    "accounts.change_organizationprofile",
+    "accounts.view_organizationprofile",
+}
+
+
+class GSOCanManageOrgsTestCase(TestCase):
+    def setUp(self) -> None:
+        self.org = organization_recipe.make(preset_names=["shelter"], owner_roles=())
+        template = PermissionGroupTemplate.objects.get(name="Global Shelter Operator")
+        self.gso_group = PermissionGroup.objects.create(organization=self.org, template=template)
+        sync_group_permissions()
+
+        self.staff = baker.make(User, is_staff=True)
+        self.gso_group.user_set.add(self.staff)
+        self.client.force_login(self.staff)
+
+    def test_template_carries_the_org_admin_perms(self) -> None:
+        """GSO is the code-owned successor role — the org perms live in config."""
+        self.assertIn("organizations.add_organization", GLOBAL_SHELTER_OPERATOR.permissions)
+        self.assertIn("accounts.change_organizationprofile", GLOBAL_SHELTER_OPERATOR.permissions)
+
+    def test_gso_holder_gains_the_org_admin_perms(self) -> None:
+        user = User.objects.get(pk=self.staff.pk)  # bypass cached perms
+        perms = set(user.get_all_permissions())
+        # Sanity: the org-scoped group still grants shelter admin globally.
+        self.assertIn("shelters.add_shelter", perms)
+        self.assertTrue(ORG_ADMIN_PERMS <= perms)
+
+    def test_gso_holder_can_open_and_save_org_add_page(self) -> None:
+        add_url = reverse("admin:organizations_organization_add")
+
+        page = self.client.get(add_url)
+        self.assertEqual(page.status_code, 200)
+
+        response = self.client.post(
+            add_url,
+            {
+                "name": "Data Entry Org",
+                # Management form for the required profile inline.
+                "profile-TOTAL_FORMS": "1",
+                "profile-INITIAL_FORMS": "0",
+                "profile-MIN_NUM_FORMS": "1",
+                "profile-MAX_NUM_FORMS": "1",
+                "profile-0-org_types": ["shelter"],
+                # The read-only members inline renders for viewers; echo its
+                # (empty) management form like the real page would.
+                "organization_users-TOTAL_FORMS": "0",
+                "organization_users-INITIAL_FORMS": "0",
+                "organization_users-MIN_NUM_FORMS": "0",
+                "organization_users-MAX_NUM_FORMS": "1000",
+            },
+        )
+        if response.status_code != 302:
+            import pathlib
+
+            pathlib.Path("/tmp/gso_add_error.html").write_text(response.content.decode())
+            self.fail(f"status {response.status_code}; body written to /tmp/gso_add_error.html")
+        organization = Organization.objects.get(name="Data Entry Org")
+        # reconcile_org_groups ran from save_related, so the org is provisioned.
+        self.assertEqual(organization.profile.org_types, ["shelter"])
+        names = set(PermissionGroup.objects.filter(organization=organization).values_list("template__name", flat=True))
+        self.assertIn("Shelter Operator", names)
+
+    def test_gso_holder_can_open_org_change_page(self) -> None:
+        change_url = reverse("admin:organizations_organization_change", args=[self.org.pk])
+        response = self.client.get(change_url)
+        self.assertEqual(response.status_code, 200)

--- a/apps/betterangels-backend/shelters/groups.py
+++ b/apps/betterangels-backend/shelters/groups.py
@@ -82,6 +82,24 @@ GLOBAL_SHELTER_OPERATOR = TemplateConfig(
         Reservation.perms.CHANGE,
         Reservation.perms.DELETE,
         Reservation.perms.VIEW,
+        # ── Django admin: organization management ──
+        # GLOBAL_SHELTER_OPERATOR replaced the legacy global "Shelter Data
+        # Entry" / "Shelter Administration" auth groups (migration
+        # 0003_consolidate_shelter_operator), whose staff add and edit
+        # Organization rows in the Django admin.  The org-scoped GSO
+        # PermissionGroup *is* an auth.Group, so ``ModelBackend`` reads these
+        # permissions globally for any BA staff member holding it — exactly as
+        # it already does for the ``shelters.*`` perms below.  Without them
+        # those staff get a 403 on /admin/organizations/organization/.
+        # Deliberately scoped to add/change/view: deleting an org, or
+        # hand-editing its role (PermissionGroup) rows, stays superuser work.
+        "organizations.add_organization",
+        "organizations.change_organization",
+        "organizations.view_organization",
+        "organizations.view_organizationuser",
+        "accounts.add_organizationprofile",
+        "accounts.change_organizationprofile",
+        "accounts.view_organizationprofile",
         # ── Custom perms ──
         Shelter.perms.VIEW_PRIVATE,
         ClientProfile.perms.VIEW,

--- a/apps/betterangels-backend/shelters/groups.py
+++ b/apps/betterangels-backend/shelters/groups.py
@@ -1,4 +1,5 @@
 from accounts.models import OrganizationProfile
+from accounts.permissions import OrganizationAdminPermissions
 from clients.models import ClientProfile
 from common.models import Address
 from common.permissions.config import TemplateConfig
@@ -84,12 +85,10 @@ GLOBAL_SHELTER_OPERATOR = TemplateConfig(
         Reservation.perms.DELETE,
         Reservation.perms.VIEW,
         # ── Django admin: organization management ──
-        # Default perms on the django-organizations models, which declare no
-        # ``perms`` PermissionSet, so they are named as ``app.codename`` strings.
-        "organizations.add_organization",
-        "organizations.change_organization",
-        "organizations.view_organization",
-        "organizations.view_organizationuser",
+        OrganizationAdminPermissions.ADD_ORGANIZATION,
+        OrganizationAdminPermissions.CHANGE_ORGANIZATION,
+        OrganizationAdminPermissions.VIEW_ORGANIZATION,
+        OrganizationAdminPermissions.VIEW_ORGANIZATION_USER,
         OrganizationProfile.perms.ADD,
         OrganizationProfile.perms.CHANGE,
         OrganizationProfile.perms.VIEW,

--- a/apps/betterangels-backend/shelters/groups.py
+++ b/apps/betterangels-backend/shelters/groups.py
@@ -83,16 +83,6 @@ GLOBAL_SHELTER_OPERATOR = TemplateConfig(
         Reservation.perms.DELETE,
         Reservation.perms.VIEW,
         # ── Django admin: organization management ──
-        # GLOBAL_SHELTER_OPERATOR replaced the legacy global "Shelter Data
-        # Entry" / "Shelter Administration" auth groups (migration
-        # 0003_consolidate_shelter_operator), whose staff add and edit
-        # Organization rows in the Django admin.  The org-scoped GSO
-        # PermissionGroup *is* an auth.Group, so ``ModelBackend`` reads these
-        # permissions globally for any BA staff member holding it — exactly as
-        # it already does for the ``shelters.*`` perms below.  Without them
-        # those staff get a 403 on /admin/organizations/organization/.
-        # Deliberately scoped to add/change/view: deleting an org, or
-        # hand-editing its role (PermissionGroup) rows, stays superuser work.
         "organizations.add_organization",
         "organizations.change_organization",
         "organizations.view_organization",

--- a/apps/betterangels-backend/shelters/groups.py
+++ b/apps/betterangels-backend/shelters/groups.py
@@ -1,3 +1,4 @@
+from accounts.models import OrganizationProfile
 from clients.models import ClientProfile
 from common.models import Address
 from common.permissions.config import TemplateConfig
@@ -83,13 +84,15 @@ GLOBAL_SHELTER_OPERATOR = TemplateConfig(
         Reservation.perms.DELETE,
         Reservation.perms.VIEW,
         # ── Django admin: organization management ──
+        # Default perms on the django-organizations models, which declare no
+        # ``perms`` PermissionSet, so they are named as ``app.codename`` strings.
         "organizations.add_organization",
         "organizations.change_organization",
         "organizations.view_organization",
         "organizations.view_organizationuser",
-        "accounts.add_organizationprofile",
-        "accounts.change_organizationprofile",
-        "accounts.view_organizationprofile",
+        OrganizationProfile.perms.ADD,
+        OrganizationProfile.perms.CHANGE,
+        OrganizationProfile.perms.VIEW,
         # ── Custom perms ──
         Shelter.perms.VIEW_PRIVATE,
         ClientProfile.perms.VIEW,


### PR DESCRIPTION
## What & why

Reported: staff in the (former) **Shelter Data Entry** group can no longer add/edit orgs in the Django admin. This is true on `main`.

Migration `accounts/0003_consolidate_shelter_operator` replaced the legacy **global** `Shelter Data Entry` / `Shelter Administration` auth groups with **org-scoped `Global Shelter Operator`** PermissionGroups — GSO is the code-driven successor role for BA shelter data-entry staff. Because a `PermissionGroup` *is* an `auth.Group` (#2378), `ModelBackend` reads its permissions **globally** for any staff holder (the same mechanism by which the org-scoped group already grants `shelters.*`). But the `GLOBAL_SHELTER_OPERATOR` template carried only shelter/lookup perms, so those staff get a `403` on `/admin/organizations/organization/`.

Reproduced on a clean `origin/main` checkout: staff GSO holder → `has_perm("organizations.add_organization")` is `False`, org add page → `403`.

## Change

Add Django-admin org-management permissions to `GLOBAL_SHELTER_OPERATOR` in `shelters/groups.py`:

- `organizations.add_organization` / `change_organization` / `view_organization`
- `accounts.add_organizationprofile` / `change_organizationprofile` / `view_organizationprofile` (the org form's required profile inline)
- `organizations.view_organizationuser` (renders the read-only members inline)

**Deliberately excluded** (stays superuser-only): deleting orgs, and hand-editing `PermissionGroup` role rows.

No data migration needed: `post_migrate` reconciles every org, so existing prod GSO groups pick up the new perms on deploy.

## Verification

- New regression test `accounts/tests/test_gso_org_admin_permissions.py`: staff GSO holder can open + save the org add page (org created with `org_types` and provisioned roles) and open the org change page; template carries the perms; holder gains them globally.
- 223 tests pass across `accounts`/`shelters` permission & admin suites (`test_admin`, `test_group_permissions`, `test_services`, `test_permissions`, `test_mutations`, `test_operator_queries`).
- ruff (format + lint) and mypy clean on changed files.
- Note: shelter-operator web-app flows (create org → create shelter → edit shelter) verified unaffected on `main`.

## Out of scope

- Deleting an org from the admin remains superuser-only.
- Role-group (`PermissionGroup`) editing on the org page remains superuser-only (reconcile provisions standard groups from `org_types`).

## Summary by Sourcery

Restore Global Shelter Operator access to manage organizations in the Django admin while keeping organization deletion and role editing restricted.

Bug Fixes:
- Restore Django-admin organization add and edit access for staff assigned to the Global Shelter Operator role.

Enhancements:
- Centralize Django-admin organization permission definitions and include the required organization, profile, and member-view permissions in the Global Shelter Operator template.

Tests:
- Add regression coverage for GSO permission propagation and organization admin add, save, and change workflows.