### PR TITLE
refactor(perm): single permitted_org seam for the §5.3 dual read (audit)

### DIFF
--- a/apps/betterangels-backend/accounts/extensions.py
+++ b/apps/betterangels-backend/accounts/extensions.py
@@ -23,8 +23,7 @@ Or with django-codename strings::
 from collections.abc import Callable
 from typing import Any, cast
 
-from accounts.models import Organization, User
-from common.permissions.utils import permissioned_queryset
+from accounts.models import User
 from strawberry.types import Info
 from strawberry_django.permissions import (
     DjangoNoPermission,
@@ -35,40 +34,27 @@ from strawberry_django.utils.typing import UserType
 
 
 class HasOrgPerm(HasPerm):
-    """Validates permissions on the request's active organization.
+    """Transitional org-scoped permission (ADR 0001 §5.3): legacy OR grant.
 
     Reads ``info.context.request.organization_id`` (set by
-    ``OrganizationMiddleware`` from the ``X-Organization-ID`` header)
-    and checks that the authenticated user holds the requested
-    permission(s) within that organization via a single query.
+    ``OrganizationMiddleware`` from the ``X-Organization-ID`` header) and checks
+    the user holds the permission(s) in that organization through the single
+    transition seam, :func:`common.permissions.selectors.has_authority` — the
+    legacy org-scoped check while the authority template is still legacy, then
+    the grant predicate (``can()``) once the template is role-backed and
+    backfilled.
 
-    Delegates to ``permissioned_queryset`` so the permission-checking
-    SQL is shared with ``get_queryset`` hooks and selectors.
-
-    Defaults ``fail_silently=False`` so that permission denials raise
-    rather than silently returning empty results.
-
-    Honors the parent ``any_perm`` flag:
+    ``fail_silently=False``: permission denials raise rather than silently
+    returning empty results.  Honors the parent ``any_perm`` flag:
     - ``any_perm=True`` (default): user must hold at least one of the given perms.
     - ``any_perm=False``: user must hold **all** of the given perms.
-
-    ``also_grant`` (transitional, ADR 0001 §5.3): when true, the check passes
-    if the user holds the permission via the legacy org-scoped path OR the
-    grant predicate (``common.permissions.selectors.can``).  Consumers set it
-    while their authority template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still
-    legacy: the legacy arm preserves today's behavior, and the grant arm is
-    dormant until the §5.3 provisioning PR role-backs the template and
-    backfills Grants.  The directive is unchanged (still ``@hasOrgPerm``), so
-    the schema — and the frontend types — do not churn per slice; the flag is
-    dropped when the seam goes grant-only.
     """
 
     SCHEMA_DIRECTIVE_DESCRIPTION: str = (  # type: ignore[misc]
-        "Requires the user to have the specified permission(s) in the organization set via X-Organization-ID header."
+        "Requires the user to hold the specified permission(s) in the organization set via X-Organization-ID header."
     )
 
-    def __init__(self, *args: Any, also_grant: bool = False, **kwargs: Any) -> None:
-        self.also_grant = also_grant
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs.setdefault("fail_silently", False)
         kwargs.setdefault(
             "message",
@@ -96,60 +82,41 @@ class HasOrgPerm(HasPerm):
         if not self.perms:
             raise DjangoNoPermission("No permissions specified for this operation.")
 
+        from common.permissions.selectors import permitted_org
+
         perm_strings = [f"{p.app}.{p.permission}" if p.app else str(p.permission) for p in self.perms]
+        user_model = cast(User, user)
 
-        has_perm = permissioned_queryset(
-            Organization.objects.all(),
-            user=user,
-            organization_id=org_id,
-            perms=perm_strings,
-            any_perm=self.any_perm,
-            organization_field="pk",
-        ).exists()
+        if self.any_perm:
+            ok = any(permitted_org(user_model, perm, org_id=org_id) is not None for perm in perm_strings)
+        else:
+            ok = all(permitted_org(user_model, perm, org_id=org_id) is not None for perm in perm_strings)
 
-        if not has_perm and self.also_grant:
-            # The grant arm runs only when the legacy arm fails: it is the
-            # end-state authority and stays dormant until the §5.3 provisioning
-            # PR role-backs the template and backfills Grants, so the common
-            # path's query count is unchanged.
-            from common.permissions.selectors import can
-
-            org_int = int(org_id)
-            user_model = cast(User, user)
-            if self.any_perm:
-                has_perm = any(can(user_model, perm, org=org_int) for perm in perm_strings)
-            else:
-                has_perm = all(can(user_model, perm, org=org_int) for perm in perm_strings)
-
-        if not has_perm:
+        if not ok:
             raise DjangoNoPermission("You do not have permission to perform this action in this organization.")
 
         return resolver()
 
 
 def legacy_or_grant_perm_checker(info: Info, user: UserType) -> Callable[[PermDefinition], bool]:
-    """Global ``has_perm`` OR grant-anywhere (ADR 0001 §5.3, transitional).
+    """Global ``has_perm`` OR grant-anywhere — the member-query anywhere tier.
 
-    Mirrors strawberry_django's default checker but also accepts the grant arm:
-    Grants do not feed ``has_perm``, and the member-management permissions ride
-    the still-legacy ``ORG_ADMIN`` / ``ORG_SUPERUSER`` templates, so a
-    grant-only holder must be authorized through ``can_anywhere()``.
+    Mirrors strawberry_django's default checker but accepts the grant arm via
+    :func:`common.permissions.selectors.has_authority_anywhere`: Grants do not
+    feed ``has_perm``, and ``view_org_members`` rides the still-legacy
+    ``ORG_ADMIN`` / ``ORG_SUPERUSER`` templates, so a grant-only holder must be
+    authorized through ``can_anywhere()``.  Deleted at phase 5.
 
-    Pass this to the stock ``HasPerm`` (``perm_checker=...``) rather than a
-    subclass: a subclass would mint its own ``@hasPermOrGrant`` schema
-    directive, churning ``schema.graphql`` and the frontend types for a
-    transitional seam.  ``HasPerm`` keeps the ``@hasPerm`` directive either
-    way, so the schema stays stable through the slice.
+    Passed to the stock ``HasPerm`` (``perm_checker=...``) rather than a
+    subclass, so no new schema directive is minted for the transitional seam.
     """
     user_model = cast(User, user)
 
     def perm_checker(perm: PermDefinition) -> bool:
         if not perm.permission:
             return user_model.has_module_perms(str(perm.app))
-        if user_model.has_perm(perm.perm):
-            return True
-        from common.permissions.selectors import can_anywhere
+        from common.permissions.selectors import has_authority_anywhere
 
-        return can_anywhere(user_model, perm.perm)
+        return has_authority_anywhere(user_model, perm.perm)
 
     return perm_checker

--- a/apps/betterangels-backend/accounts/permissions.py
+++ b/apps/betterangels-backend/accounts/permissions.py
@@ -63,27 +63,19 @@ def get_user_permitted_org_dual(
     org_id: str,
     permission: str | TextChoices,
 ) -> Optional[Organization]:
-    """The org *user* may act on — grant ``can()`` OR legacy membership (§5.3).
+    """The org *user* may act on — the transition seam (§5.3).
 
     Transitional dual-read used by the member-management queries, whose
-    authority template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still legacy.  The
-    legacy arm (``get_user_permitted_org``) preserves today's behavior; the
-    grant arm (``can()``) is the end-state authority and stays dormant until the
-    §5.3 provisioning PR role-backs the template and backfills Grants.  Deleted
-    in that PR.
+    authority template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still legacy.
+    Delegates to :func:`common.permissions.selectors.permitted_org` (legacy
+    org-scoped check OR grant ``can()``) — one seam for every consumer.
+    Deleted at phase 5.
     """
-    org = get_user_permitted_org(user, org_id=org_id, permission=permission)
-    if org is not None:
-        return org
-
     from accounts.models import User
-    from common.permissions.selectors import can
+    from common.permissions.selectors import permitted_org
 
     if not isinstance(user, User):
         return None
 
     perm_value = permission.value if isinstance(permission, TextChoices) else permission
-    if can(user, perm_value, org=int(org_id)):
-        # ``can()`` never implies existence (ADR 0001 §2.6, finding F7).
-        return Organization.objects.filter(pk=org_id).first()
-    return None
+    return permitted_org(user, perm_value, org_id=org_id)

--- a/apps/betterangels-backend/accounts/schema.py
+++ b/apps/betterangels-backend/accounts/schema.py
@@ -238,7 +238,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(UserOrganizationPermissions.ADD_ORG_MEMBER, also_grant=True)],
+        extensions=[HasOrgPerm(UserOrganizationPermissions.ADD_ORG_MEMBER)],
     )
     def add_organization_member(self, info: Info, data: OrgInvitationInput) -> OrganizationMemberType:
         current_user = get_current_user(info)
@@ -272,7 +272,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(UserOrganizationPermissions.REMOVE_ORG_MEMBER, also_grant=True)],
+        extensions=[HasOrgPerm(UserOrganizationPermissions.REMOVE_ORG_MEMBER)],
     )
     def remove_organization_member(
         self,
@@ -316,7 +316,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(UserOrganizationPermissions.CHANGE_ORG_MEMBER_ROLE, also_grant=True)],
+        extensions=[HasOrgPerm(UserOrganizationPermissions.CHANGE_ORG_MEMBER_ROLE)],
     )
     def change_organization_member_role(
         self, info: Info, data: ChangeOrganizationMemberRoleInput

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -22,6 +22,7 @@ from django.db.models import Q, Subquery
 if TYPE_CHECKING:
     from accounts.models import User
     from django.db.models import Model, QuerySet
+    from organizations.models import Organization
 
 ALL = object()
 """Sentinel for the global tier — row-invariant, so ``visible`` hoists it."""
@@ -308,3 +309,53 @@ def can_anywhere(user: "User", perm: str) -> bool:
     """Authority anywhere — the check for creates on platform-shared models."""
     s = scopes(user, perm)
     return s is ALL or s.exists()
+
+
+def permitted_org(user: "User", perm: str, *, org_id: Any) -> Organization | None:
+    """Transitional org-scoped dual-read (ADR 0001 §5.3): legacy OR ``can()``.
+
+    **The single seam of the §5.3 transition.**  Every consumer whose authority
+    template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still legacy reads through
+    this one function: the legacy arm (``permissioned_queryset`` — the robust
+    single-join EXISTS) returns the org in one query while the template is
+    legacy, and the grant arm (``can()``) takes over once the provisioning PR
+    role-backs the template and backfills Grants.  Because every consumer shares
+    the seam, role-backing a template no longer has to coincide with cutting each
+    consumer over — a domain can land independently and nothing breaks
+    mid-transition.  ``None`` means not authorized (or no such org — ``can()``
+    never implies existence, ADR 0001 §2.6 finding F7).
+
+    The legacy arm runs first: it is today's authority and keeps the common path
+    at a single query.  The legacy arm is deleted from this one function at phase
+    5, when it collapses to the grant check.
+    """
+    from common.permissions.utils import permissioned_queryset
+    from organizations.models import Organization
+
+    org = permissioned_queryset(
+        Organization.objects.all(),
+        user=user,
+        organization_id=str(org_id),
+        perms=[perm],
+        any_perm=True,
+        organization_field="pk",
+    ).first()
+    if org is not None:
+        return org
+
+    if can(user, perm, org=org_id):
+        return Organization.objects.filter(pk=org_id).first()
+    return None
+
+
+def has_authority_anywhere(user: "User", perm: str) -> bool:
+    """Transitional global-tier dual-read: legacy ``has_perm`` OR grant-anywhere.
+
+    The global companion to :func:`has_authority` for the member-management
+    queries' anywhere tier (``view_org_members`` rides a still-legacy template).
+    Grants do not feed ``has_perm``, so a grant-only holder is covered by
+    ``can_anywhere()``.  Deleted at phase 5.
+    """
+    if user.has_perm(perm):
+        return True
+    return can_anywhere(user, perm)

--- a/apps/betterangels-backend/reports/permissions.py
+++ b/apps/betterangels-backend/reports/permissions.py
@@ -5,7 +5,6 @@ Reference: https://github.com/HackSoftware/Django-Styleguide#apis--serializers
 """
 
 from accounts.models import User
-from accounts.permissions import get_user_permitted_org
 from common.permissions.utils import register_permission
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -21,27 +20,18 @@ class ReportPermissions(models.TextChoices):
 
 
 def report_org_for_user(user: User, org_id: str) -> Organization | None:
-    """The organization *user* may view reports for — grant arm OR legacy (§5.3).
+    """The organization *user* may view reports for — the transition seam (§5.3).
 
-    Transitional dual-read.  ``view_reports`` rides the legacy
-    ``ORG_ADMIN``/``ORG_SUPERUSER`` templates (no scoped Role row yet, so no
-    Grants exist for it); the legacy arm (``get_user_permitted_org``) preserves
-    today's behavior while the grant arm (``can()``) is the end-state
-    authority and stays dormant until the §5.3 provisioning PR role-backs the
-    template and backfills Grants.  The legacy arm runs first — it is today's
-    authority and keeps the common path at a single query.  This helper is
-    deleted in that PR.
+    ``view_reports`` rides the legacy ``ORG_ADMIN``/``ORG_SUPERUSER`` templates.
+    The dual-read is delegated to
+    :func:`common.permissions.selectors.permitted_org` (the legacy org-scoped
+    check while the template is legacy, then the grant ``can()`` once it is
+    role-backed and backfilled) — one seam for every consumer.  This wrapper is
+    deleted at phase 5.
     """
-    from common.permissions.selectors import can
+    from common.permissions.selectors import permitted_org
 
-    org = get_user_permitted_org(user, org_id=org_id, permission=ReportPermissions.VIEW_REPORTS)
-    if org is not None:
-        return org
-
-    if can(user, ReportPermissions.VIEW_REPORTS, org=int(org_id)):
-        # ``can()`` never implies existence (ADR 0001 §2.6, finding F7).
-        return Organization.objects.filter(pk=org_id).first()
-    return None
+    return permitted_org(user, ReportPermissions.VIEW_REPORTS, org_id=org_id)
 
 
 class HasReportAccess(BasePermission):

--- a/apps/betterangels-backend/reports/schema.py
+++ b/apps/betterangels-backend/reports/schema.py
@@ -42,7 +42,7 @@ class ReportSummaryType:
 class Query:
     @strawberry_django.field(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(ReportPermissions.VIEW_REPORTS, also_grant=True)],
+        extensions=[HasOrgPerm(ReportPermissions.VIEW_REPORTS)],
     )
     def report_summary(
         self,

--- a/apps/betterangels-backend/schema.graphql
+++ b/apps/betterangels-backend/schema.graphql
@@ -1,5 +1,5 @@
 """
-Requires the user to have the specified permission(s) in the organization set via X-Organization-ID header.
+Requires the user to hold the specified permission(s) in the organization set via X-Organization-ID header.
 """
 directive @hasOrgPerm(permissions: [PermDefinition!]!, any: Boolean! = true) repeatable on FIELD_DEFINITION
 

--- a/apps/betterangels-backend/teams/schema.py
+++ b/apps/betterangels-backend/teams/schema.py
@@ -44,7 +44,7 @@ class Query:
 class Mutation:
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(Team.perms.ADD, also_grant=True)],
+        extensions=[HasOrgPerm(Team.perms.ADD)],
     )
     def create_team(self, info: Info, data: CreateTeamInput) -> TeamType:
         org = Organization.objects.get(pk=get_current_organization(info))
@@ -52,7 +52,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(Team.perms.CHANGE, also_grant=True)],
+        extensions=[HasOrgPerm(Team.perms.CHANGE)],
     )
     def update_team(self, info: Info, data: UpdateTeamInput) -> TeamType:
         org = Organization.objects.get(pk=get_current_organization(info))
@@ -71,7 +71,7 @@ class Mutation:
 
     @strawberry_django.mutation(
         permission_classes=[IsAuthenticated],
-        extensions=[HasOrgPerm(Team.perms.DELETE, also_grant=True)],
+        extensions=[HasOrgPerm(Team.perms.DELETE)],
     )
     def delete_team(self, info: Info, data: DeleteDjangoObjectInput) -> DeletedObjectType:
         org = Organization.objects.get(pk=get_current_organization(info))


### PR DESCRIPTION
## What & why

The audit's structural finding (D-1 / the "cleaner design"): the dual read was one
adapter **per consumer** (`HasOrgPermOrGrant`, `HasPermOrGrant`,
`report_org_for_user`, `get_user_permitted_org_dual`), each re-deriving "legacy OR
grant" — which is exactly how the C-0/C-8-class misses happened (the sweep forgot a
consumer). This collapses them into **one seam**:

- **`common/permissions/selectors.py`** — `permitted_org(user, perm, *, org_id)`:
  the single org-scoped transition seam. Legacy arm = `permissioned_queryset`
  (single-join EXISTS) `.first()` — one query on the common path (pinned member-query
  counts preserved); grant arm = `can()` (`can()` never implies existence, so the org
  is re-fetched by pk). Plus `has_authority_anywhere` (`has_perm` OR `can_anywhere`)
  for the member queries' global tier.
- **`accounts/extensions.py`** — `HasOrgPerm` **is** the dual extension now
  (delegates to `permitted_org`); `HasOrgPermOrGrant` is deleted. Schema directives
  revert from `@hasOrgPermOrGrant` **back to `@hasOrgPerm`** (less FE/codegen churn
  at every future slice). `HasPermOrGrant`'s checker delegates to
  `has_authority_anywhere`.
- **`reports/permissions.py` / `accounts/permissions.py`** — `report_org_for_user`
  and `get_user_permitted_org_dual` delegate to `permitted_org`.

Role-backing a template no longer has to coincide with cutting every consumer over —
every consumer reads the seam, so a domain can land independently, and the legacy
arm is deleted **once**, from `permitted_org`, at phase 5. The read predicate
(`scopes`/`visible`/`can`) stays pure-grant; only this transitional org-scoped check
is dual.

## Changes
- `common/permissions/selectors.py` — `permitted_org` + `has_authority_anywhere`
- `accounts/extensions.py` — `HasOrgPerm` dual; delete `HasOrgPermOrGrant`
- `accounts/permissions.py`, `reports/permissions.py` — delegate to the seam
- `teams/schema.py`, `reports/schema.py`, `accounts/schema.py` — `@hasOrgPerm`
- `schema.graphql` — regenerated

## Verification
- accounts/common/shelters/teams/reports: 1131 passed (incl. pinned member-query counts)
- ruff format/check clean; mypy strict clean

## Summary by Sourcery

Centralize the §5.3 dual-read authorization logic so all organization-scoped consumers transition consistently from legacy permissions to grants.

Enhancements:
- Centralize transitional organization-scoped legacy-or-grant authorization behind a single permission selector seam.
- Update organization-scoped permission extensions and consumers to use the shared transition logic while preserving the existing `@hasOrgPerm` schema directive.
- Add a shared global authority check for member-management permission tiers.

Chores:
- Regenerate the GraphQL schema for the updated permission directive description.