### PR TITLE
feat(perm): provision ORG_ADMIN/ORG_SUPERUSER roles + grant-only cutover (§5.3 step 4)

### DIFF
--- a/apps/betterangels-backend/accounts/annotations.py
+++ b/apps/betterangels-backend/accounts/annotations.py
@@ -10,18 +10,26 @@ from .models import Grant, PermissionGroup
 
 
 def annotate_member_role(org_id: str) -> Case:
+    """Annotate the org role (superuser/admin/member) from ``Grant`` rows.
+
+    Org-level authority is grant-only since the §5.3 provisioning role-backed
+    ``ORG_ADMIN``/``ORG_SUPERUSER`` and reconcile retired their legacy
+    ``PermissionGroup`` rows, so the role is read from scoped ``Grant`` rows
+    (ADR 0001 §5.3).  A superuser holds the ``ORG_SUPERUSER`` role; an admin
+    holds ``ORG_ADMIN`` (superuser implies admin too).
+    """
     is_superuser = Exists(
-        PermissionGroup.objects.filter(
-            organization_id=org_id,
-            template__name=ORG_SUPERUSER.name,
-            user=OuterRef("pk"),
+        Grant.objects.filter(
+            scope_org_id=org_id,
+            role__name=ORG_SUPERUSER.name,
+            principal_user=OuterRef("pk"),
         )
     )
     is_admin = Exists(
-        PermissionGroup.objects.filter(
-            organization_id=org_id,
-            template__name=ORG_ADMIN.name,
-            user=OuterRef("pk"),
+        Grant.objects.filter(
+            scope_org_id=org_id,
+            principal_user=OuterRef("pk"),
+            role__name__in=[ORG_ADMIN.name, ORG_SUPERUSER.name],
         )
     )
 

--- a/apps/betterangels-backend/accounts/apps.py
+++ b/apps/betterangels-backend/accounts/apps.py
@@ -4,10 +4,19 @@ from django.db.models.signals import post_migrate
 
 def _seed_on_migrate(sender: AppConfig, **kwargs: object) -> None:
     from accounts.seed import seed_permission_templates
-    from accounts.services import backfill_global_role_members, backfill_shelter_grants, sync_roles
+    from accounts.services import (
+        backfill_global_role_members,
+        backfill_org_admin_grants,
+        backfill_shelter_grants,
+        sync_roles,
+    )
 
     seed_permission_templates()
     sync_roles()
+    # Org-admin conversion (§5.3) must run before reconcile retires the legacy
+    # rows: sync_roles creates the Role rows, this converts existing members,
+    # then sync_all_org_permission_groups (connected after) reconciles and deletes.
+    backfill_org_admin_grants()
     backfill_shelter_grants()
     backfill_global_role_members()
 

--- a/apps/betterangels-backend/accounts/extensions.py
+++ b/apps/betterangels-backend/accounts/extensions.py
@@ -34,15 +34,14 @@ from strawberry_django.utils.typing import UserType
 
 
 class HasOrgPerm(HasPerm):
-    """Transitional org-scoped permission (ADR 0001 §5.3): legacy OR grant.
+    """Org-scoped permission (ADR 0001 §5.3, post-provisioning): grant-based.
 
     Reads ``info.context.request.organization_id`` (set by
     ``OrganizationMiddleware`` from the ``X-Organization-ID`` header) and checks
     the user holds the permission(s) in that organization through the single
-    transition seam, :func:`common.permissions.selectors.has_authority` — the
-    legacy org-scoped check while the authority template is still legacy, then
-    the grant predicate (``can()``) once the template is role-backed and
-    backfilled.
+    grant-based seam, :func:`common.permissions.selectors.permitted_org` — the
+    grant predicate ``can()`` since the §5.3 provisioning role-backed
+    ``ORG_ADMIN``/``ORG_SUPERUSER`` and retired their legacy groups.
 
     ``fail_silently=False``: permission denials raise rather than silently
     returning empty results.  Honors the parent ``any_perm`` flag:

--- a/apps/betterangels-backend/accounts/groups.py
+++ b/apps/betterangels-backend/accounts/groups.py
@@ -1,5 +1,5 @@
 from accounts.permissions import UserOrganizationPermissions
-from common.permissions.config import TemplateConfig
+from common.permissions.config import RoleDef, TemplateConfig
 from reports.permissions import ReportPermissions
 from teams.models import Team
 
@@ -27,3 +27,16 @@ ORG_SUPERUSER = TemplateConfig(
     ],
     is_invitable=False,
 )
+
+# ── Role definitions (ADR 0001 §5.3, provisioning) ─────────────────────
+# Role-backing ORG_ADMIN / ORG_SUPERUSER is the §5.3 org-admin milestone: once
+# ``sync_roles`` creates these scoped Role rows, ``reconcile_org_groups`` stops
+# provisioning their legacy ``PermissionGroup`` rows and deletes stale ones, and
+# ``OrgRoleManager`` writes Grants instead of group memberships.  Both templates
+# are offered by every org type (outreach and shelter) and are scoped (never
+# global).
+
+ORG_ADMIN_ROLE = RoleDef.from_template(ORG_ADMIN)
+ORG_SUPERUSER_ROLE = RoleDef.from_template(ORG_SUPERUSER)
+
+ORG_ADMIN_ROLES: tuple[RoleDef, ...] = (ORG_ADMIN_ROLE, ORG_SUPERUSER_ROLE)

--- a/apps/betterangels-backend/accounts/permissions.py
+++ b/apps/betterangels-backend/accounts/permissions.py
@@ -56,26 +56,3 @@ def get_user_permitted_org(
         .filter(Q(permission_groups__user=user) & perm_filter(app_label, codename))
         .first()
     )
-
-
-def get_user_permitted_org_dual(
-    user: UserLike,
-    org_id: str,
-    permission: str | TextChoices,
-) -> Optional[Organization]:
-    """The org *user* may act on — the transition seam (§5.3).
-
-    Transitional dual-read used by the member-management queries, whose
-    authority template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still legacy.
-    Delegates to :func:`common.permissions.selectors.permitted_org` (legacy
-    org-scoped check OR grant ``can()``) — one seam for every consumer.
-    Deleted at phase 5.
-    """
-    from accounts.models import User
-    from common.permissions.selectors import permitted_org
-
-    if not isinstance(user, User):
-        return None
-
-    perm_value = permission.value if isinstance(permission, TextChoices) else permission
-    return permitted_org(user, perm_value, org_id=org_id)

--- a/apps/betterangels-backend/accounts/schema.py
+++ b/apps/betterangels-backend/accounts/schema.py
@@ -18,7 +18,7 @@ from strawberry_django.pagination import OffsetPaginated
 
 from accounts.emails import base_url_for, send_welcome_emails_for_org
 from accounts.extensions import HasOrgPerm, legacy_or_grant_perm_checker
-from accounts.permissions import UserOrganizationPermissions, get_user_permitted_org_dual
+from accounts.permissions import UserOrganizationPermissions
 from strawberry_django.permissions import HasPerm
 
 from .annotations import annotate_is_org_owner, annotate_member_role, annotate_permission_templates
@@ -71,10 +71,12 @@ class Query:
     )
     def organization_member(self, info: Info, organization_id: str, user_id: str) -> OrganizationMemberType:
         current_user = cast(User, get_current_user(info))
-        organization = get_user_permitted_org_dual(
+        from common.permissions.selectors import permitted_org
+
+        organization = permitted_org(
             current_user,
+            UserOrganizationPermissions.VIEW_ORG_MEMBERS.value,
             org_id=organization_id,
-            permission=UserOrganizationPermissions.VIEW_ORG_MEMBERS,
         )
         if organization is None:
             raise PermissionError("You do not have permission to view this organization's members.")
@@ -109,10 +111,12 @@ class Query:
         permission_template: Optional[PermissionTemplateEnum] = None,
     ) -> QuerySet[User]:
         current_user = cast(User, get_current_user(info))
-        organization = get_user_permitted_org_dual(
+        from common.permissions.selectors import permitted_org
+
+        organization = permitted_org(
             current_user,
+            UserOrganizationPermissions.VIEW_ORG_MEMBERS.value,
             org_id=organization_id,
-            permission=UserOrganizationPermissions.VIEW_ORG_MEMBERS,
         )
         if organization is None:
             raise PermissionError("You do not have permission to view this organization's members.")

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -561,12 +561,19 @@ def sync_roles() -> None:
     One row per :class:`~common.permissions.config.RoleDef` — global roles are
     provisioned once, never per organization.  Idempotent: get_or_create each
     ``Role``, then reconcile ``permissions`` and ``is_global`` from the RoleDef.
+
+    Aggregates the shelter roles (:data:`shelters.groups.ROLES`) with the
+    org-admin roles (:data:`accounts.groups.ORG_ADMIN_ROLES`, ADR 0001 §5.3).
     """
     from accounts.models import Role
-    from shelters.groups import ROLES
+    from shelters.groups import ROLES as SHELTER_ROLES
+
+    from .groups import ORG_ADMIN_ROLES
+
+    roles = (*SHELTER_ROLES, *ORG_ADMIN_ROLES)
 
     with transaction.atomic():
-        for role_def in ROLES:
+        for role_def in roles:
             role, created = Role.objects.get_or_create(name=role_def.name)
             wanted = set(_resolve_permissions(role_def.permissions))
             perms_changed = {p.pk for p in role.permissions.all()} != wanted
@@ -598,6 +605,33 @@ def backfill_shelter_grants() -> None:
             grant, created = Grant.objects.get_or_create(principal_user=user, role=role, scope_org=group.organization)
             if created:
                 logger.info("Backfilled Grant %s", grant)
+
+
+def backfill_org_admin_grants() -> None:
+    """Backfill ``Grant`` rows from legacy Organization Admin memberships.
+
+    The §5.3 provisioning flip (ADR 0001 §5.3): one ``Grant`` per member of an
+    org's ``Organization Admin`` / ``Organization Superuser`` ``PermissionGroup``,
+    for every org (shelter and outreach).  Idempotent (``get_or_create``), and
+    must run *before* ``reconcile_org_groups`` deletes those legacy rows — once
+    ``sync_roles`` has created the scoped Role rows, reconcile retires the
+    groups, so the conversion order on ``post_migrate`` is: ``sync_roles`` →
+    this backfill → reconcile.
+    """
+    from accounts.models import Grant, PermissionGroup, Role
+
+    from .groups import ORG_ADMIN_ROLES
+
+    for role_def in ORG_ADMIN_ROLES:
+        role = Role.objects.get(name=role_def.name)
+        groups = PermissionGroup.objects.filter(template__name=role_def.name)
+        for group in groups.prefetch_related("user_set"):
+            for user in group.user_set.all():
+                grant, created = Grant.objects.get_or_create(
+                    principal_user=user, role=role, scope_org=group.organization
+                )
+                if created:
+                    logger.info("Backfilled Grant %s", grant)
 
 
 def backfill_global_role_members() -> None:

--- a/apps/betterangels-backend/accounts/tests/test_admin.py
+++ b/apps/betterangels-backend/accounts/tests/test_admin.py
@@ -7,7 +7,7 @@ roles and accept no members, and adding a member to it returned a 500.
 from typing import Any, cast
 
 from accounts.admin import CustomOrganizationUserAdmin
-from accounts.groups import ORG_ADMIN
+from accounts.groups import ORG_ADMIN, ORG_SUPERUSER
 from accounts.models import (
     Grant,
     OrganizationProfile,
@@ -141,9 +141,18 @@ class OrganizationAdminTestCase(TestCase):
 
         organization = Organization.objects.get(name="Outreach Org")
         self.assertEqual([t.value for t in organization.profile.org_types], ["outreach"])
+        # §5.3 provisioning: only the still-legacy CASEWORKER template gets a
+        # PermissionGroup; the role-backed ORG_ADMIN/ORG_SUPERUSER rows are not
+        # created (their authority is a Grant).
         self.assertSetEqual(
             set(PermissionGroup.objects.filter(organization=organization).values_list("template__name", flat=True)),
-            {t.name for t in (CASEWORKER,)} | {"Organization Admin", "Organization Superuser"},
+            {CASEWORKER.name},
+        )
+        self.assertFalse(
+            PermissionGroup.objects.filter(
+                organization=organization,
+                template__name__in=[ORG_ADMIN.name, ORG_SUPERUSER.name],
+            ).exists()
         )
 
     def test_form_hides_is_active(self) -> None:
@@ -1261,7 +1270,11 @@ class PermissionGroupTemplateAdminTestCase(TestCase):
         )
         self.client.force_login(self.superuser)
         self.organization = organization_recipe.make(preset_names=["outreach"], owner_roles=())
-        self.code_owned = PermissionGroupTemplate.objects.get(name=ORG_ADMIN.name)
+        # CASEWORKER is the still-legacy code-owned template (ADR 0001 §5.3): it
+        # still provisions org PermissionGroups, so deleting its template row
+        # exercises the SET_NULL-orphan path.  ORG_ADMIN/ORG_SUPERUSER are
+        # code-owned as scoped Roles now and have no org PermissionGroup rows.
+        self.code_owned = PermissionGroupTemplate.objects.get(name=CASEWORKER.name)
         self.hand_defined = PermissionGroupTemplate.objects.create(name="Weekend Volunteers")
 
     def test_the_organization_page_does_not_link_into_the_template_admin(self) -> None:
@@ -1330,7 +1343,7 @@ class PermissionGroupTemplateAdminTestCase(TestCase):
 
         row.refresh_from_db()
         self.assertIsNone(row.template_id)
-        self.assertEqual(row.label, ORG_ADMIN.name)
+        self.assertEqual(row.label, CASEWORKER.name)
 
         seed_permission_templates()
         with self.assertRaises(IntegrityError), transaction.atomic():

--- a/apps/betterangels-backend/accounts/tests/test_extensions.py
+++ b/apps/betterangels-backend/accounts/tests/test_extensions.py
@@ -3,11 +3,12 @@
 from unittest.mock import MagicMock
 
 from accounts.extensions import HasOrgPerm
-from accounts.models import PermissionGroup, User
+from accounts.models import Grant, PermissionGroup, Role, User
 from django.contrib.auth.models import Permission
 from django.test import RequestFactory, TestCase
 from model_bakery import baker
 from organizations.models import Organization
+from shelters.groups import SHELTER_OPERATOR
 from shelters.models import Shelter
 from strawberry.types import Info
 from strawberry_django.permissions import DjangoNoPermission
@@ -20,6 +21,15 @@ class HasOrgPermTestCase(TestCase):
         self.user: User = baker.make(User, email="test@example.com")
         self.org.add_user(self.user)
 
+        # Grant-only authority (ADR 0001 §5.3): the user holds the shelter view
+        # permission through a scoped Grant at *org*, not a legacy PermissionGroup.
+        role = Role.objects.get(name=SHELTER_OPERATOR.name, is_global=False)
+        Grant.objects.get_or_create(principal_user=self.user, role=role, scope_org=self.org)
+
+        # A legacy-only holder — a label-only PermissionGroup carrying the same
+        # permission — must fail closed: HasOrgPerm no longer reads legacy groups.
+        self.legacy_user: User = baker.make(User, email="legacy@example.com")
+        self.org.add_user(self.legacy_user)
         self.perm_group = PermissionGroup.objects.create(
             organization=self.org,
             label="test-perm-group",
@@ -30,7 +40,7 @@ class HasOrgPermTestCase(TestCase):
         app_label, codename = Shelter.perms.VIEW.split(".")
         self.perm: Permission = Permission.objects.get(codename=codename, content_type__app_label=app_label)
         self.group.permissions.add(self.perm)
-        self.group.user_set.add(self.user)
+        self.group.user_set.add(self.legacy_user)
 
     def _make_extension(self, perm: str = Shelter.perms.VIEW) -> HasOrgPerm:
         return HasOrgPerm(perm, fail_silently=False)
@@ -48,7 +58,7 @@ class HasOrgPermTestCase(TestCase):
     # ── Happy path ─────────────────────────────────────────────────────
 
     def test_valid_org_and_permission_passes(self) -> None:
-        """Extension raises nothing when org header is set and user holds the perm."""
+        """Grant-only holder passes when org header is set and the user has the perm."""
         extension = self._make_extension()
         info = self._make_info(org_id=str(self.org.id))
 
@@ -61,6 +71,24 @@ class HasOrgPermTestCase(TestCase):
             )
         except DjangoNoPermission:
             self.fail("HasOrgPerm raised DjangoNoPermission unexpectedly")
+
+    def test_legacy_group_only_holder_is_denied(self) -> None:
+        """§5.3 provisioning: a user holding the perm only via a legacy
+        PermissionGroup fails closed — the grant is the only authority."""
+        request = self.factory.post("/graphql")
+        request.organization_id = str(self.org.id)  # type: ignore[attr-defined]
+        request.user = self.legacy_user
+        info = MagicMock(spec=Info, context=MagicMock(request=request))
+
+        extension = self._make_extension()
+
+        with self.assertRaises(DjangoNoPermission):
+            extension.resolve_for_user(
+                resolver=lambda: None,
+                user=self.legacy_user,
+                info=info,
+                source=None,
+            )
 
     # ── Missing header ─────────────────────────────────────────────────
 
@@ -96,9 +124,9 @@ class HasOrgPermTestCase(TestCase):
     # ── Missing permission ─────────────────────────────────────────────
 
     def test_user_member_but_lacks_permission_raises(self) -> None:
-        """User is org member but doesn't hold the required Django perm."""
-        # Remove the group's permission so user no longer has it
-        self.group.permissions.clear()
+        """User is org member but doesn't hold the required permission."""
+        # Revoke the user's Grant so they no longer have it.
+        Grant.objects.filter(principal_user=self.user, scope_org=self.org).delete()
         extension = self._make_extension()
         info = self._make_info(org_id=str(self.org.id))
 

--- a/apps/betterangels-backend/accounts/tests/test_migration_group_names.py
+++ b/apps/betterangels-backend/accounts/tests/test_migration_group_names.py
@@ -55,7 +55,9 @@ class UnconfiguredOrganizationTestCase(TestCase):
         organization = organization_recipe.make(owner_roles=())
         OrganizationProfile.objects.filter(organization=organization).delete()
         before = set(PermissionGroup.objects.filter(organization=organization).values_list("pk", flat=True))
-        self.assertEqual(len(before), 3)
+        # §5.3 provisioning: only the still-legacy CASEWORKER group exists
+        # (ORG_ADMIN/ORG_SUPERUSER are role-backed).
+        self.assertEqual(len(before), 1)
 
         reconcile_org_groups(organization)
 

--- a/apps/betterangels-backend/accounts/tests/test_mutations.py
+++ b/apps/betterangels-backend/accounts/tests/test_mutations.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, patch
 
 from accounts.enums import OrgRoleEnum
 from accounts.groups import ORG_ADMIN, ORG_SUPERUSER
-from accounts.models import PermissionGroup, User
+from accounts.models import Grant, PermissionGroup, User
 from accounts.role_manager import OrgRoleManager
 from accounts.tests.utils import CurrentUserGraphQLBaseTestCase
 from accounts.types import PermissionTemplateEnum
@@ -193,8 +193,10 @@ class OrganizationMemberMutationTestCase(GraphQLBaseTestCase, ParametrizedTestCa
 
         with patch("accounts.backends.CustomInvitations.send_invitation") as mock_send_invitation:
             # Teardown (ADR 0001 §4 phase 5): CASEWORKER is non-role-backed, so
-            # only the legacy group write happens (no Grant row).
-            with self.assertNumQueriesWithoutCache(20):
+            # only the legacy group write happens (no Grant row).  §5.3
+            # provisioning: the mutation's authority now resolves grant-only
+            # through ``permitted_org`` (3 extra queries).
+            with self.assertNumQueriesWithoutCache(23):
                 response = self.execute_graphql(mutation, {"data": variables})
 
             mock_send_invitation.assert_called_once()
@@ -323,10 +325,16 @@ class OrganizationMemberMutationTestCase(GraphQLBaseTestCase, ParametrizedTestCa
 
         self.execute_graphql(mutation, {"data": variables})
 
-        held = set(
+        # §5.3 provisioning: ORG_ADMIN is role-backed, so the member holds it as
+        # a Grant; CASEWORKER remains a legacy group membership.
+        held_groups = set(
             PermissionGroup.objects.filter(organization=self.org, user=member).values_list("template__name", flat=True)
         )
-        self.assertSetEqual(held, {CASEWORKER.name, ORG_ADMIN.name})
+        held_grants = set(
+            Grant.objects.filter(principal_user=member, scope_org=self.org).values_list("role__name", flat=True)
+        )
+        self.assertSetEqual(held_groups, {CASEWORKER.name})
+        self.assertSetEqual(held_grants, {ORG_ADMIN.name})
 
     def test_add_organization_member_already_member(self) -> None:
         org_member = baker.make(

--- a/apps/betterangels-backend/accounts/tests/test_org_perm_check.py
+++ b/apps/betterangels-backend/accounts/tests/test_org_perm_check.py
@@ -7,11 +7,17 @@ membership condition and the permission condition could be satisfied by
 permission any template in their org has".  Every org is provisioned with every
 template, so that let a Caseworker pass a ``view_reports`` gate and download the
 org's whole note history via ``/reports/export/``.
+
+The utility is legacy-only and is now exercised against still-legacy groups
+(ADR 0001 §5.3): the fixture member holds ``CASEWORKER`` (a legacy group), and
+the permission-holding group is created by hand — the org no longer provisions
+an ``Organization Admin``/``Organization Superuser`` group (role-backed).
 """
 
 from accounts.models import PermissionGroup, User
 from accounts.permissions import get_user_permitted_org
 from accounts.role_manager import OrgRoleManager
+from django.contrib.auth.models import Permission
 from django.test import TestCase
 from model_bakery import baker
 from notes.groups import CASEWORKER
@@ -24,20 +30,23 @@ class GetUserPermittedOrgSingleJoinTestCase(TestCase):
     """Membership in one group must not satisfy a permission held by another."""
 
     def setUp(self) -> None:
-        # create_organization_with_presets provisions every template group the
-        # org type offers — including ORG_ADMIN, which carries view_reports — so
-        # the org has *both* a CASEWORKER group (for the user) and an ORG_ADMIN
-        # group (holding view_reports) before the test asserts anything.
         self.org = organization_recipe.make(name="Provisioned Org")
         self.caseworker = baker.make(User)
         self.org.add_user(self.caseworker)
         OrgRoleManager(self.org).add_roles(self.caseworker, CASEWORKER)
 
-        self.org_admin_group = PermissionGroup.objects.get(
+        # §5.3 provisioning retired the ORG_ADMIN/ORG_SUPERUSER PermissionGroups
+        # (role-backed → Grants), so the "other group" that holds view_reports is
+        # a hand-made legacy PermissionGroup.  ``reports.view_reports`` is a real
+        # permission row on ScheduledReport (its declaring model).
+        self.report_holder_group = PermissionGroup.objects.create(
             organization=self.org,
-            template__name="Organization Admin",
+            label="Report Holders",
         )
-        self.assertFalse(self.caseworker.groups.filter(pk=self.org_admin_group.pk).exists())
+        self.report_holder_group.permissions.add(
+            Permission.objects.get(content_type__model="scheduledreport", codename="view_reports")
+        )
+        self.assertFalse(self.caseworker.groups.filter(pk=self.report_holder_group.pk).exists())
 
     def test_membership_in_another_group_does_not_confer_the_permission(self) -> None:
         org = get_user_permitted_org(
@@ -49,7 +58,7 @@ class GetUserPermittedOrgSingleJoinTestCase(TestCase):
         self.assertIsNone(org)
 
     def test_holding_the_permission_still_returns_the_org(self) -> None:
-        self.caseworker.groups.add(self.org_admin_group)
+        self.caseworker.groups.add(self.report_holder_group)
 
         org = get_user_permitted_org(
             self.caseworker,

--- a/apps/betterangels-backend/accounts/tests/test_permission_group.py
+++ b/apps/betterangels-backend/accounts/tests/test_permission_group.py
@@ -118,7 +118,9 @@ class PermissionGroupTestCase(TestCase):
         # Captured up front: once the rows are gone, a join through them matches
         # nothing whether or not the groups were actually deleted.
         group_ids = list(PermissionGroup.objects.filter(organization=organization).values_list("pk", flat=True))
-        self.assertEqual(len(group_ids), 3)
+        # §5.3 provisioning: only the still-legacy CASEWORKER template keeps a
+        # PermissionGroup (ORG_ADMIN/ORG_SUPERUSER are role-backed).
+        self.assertEqual(len(group_ids), 1)
 
         organization.delete()
 

--- a/apps/betterangels-backend/accounts/tests/test_queries.py
+++ b/apps/betterangels-backend/accounts/tests/test_queries.py
@@ -289,7 +289,10 @@ class OrganizationMemberQueryTestCase(GraphQLBaseTestCase, ParametrizedTestCase)
             "userId": str(self.org_admin.pk),
         }
 
-        with self.assertNumQueriesWithoutCache(5):
+        # §5.3 provisioning: ``permitted_org`` is grant-only, so the authority
+        # resolves through ``scopes()`` + the Grant check instead of the legacy
+        # single-join EXISTS (2 extra queries, memoized per request).
+        with self.assertNumQueriesWithoutCache(7):
             response = self.execute_graphql(query, variables)
 
         expected_member = {
@@ -354,7 +357,9 @@ class OrganizationMemberQueryTestCase(GraphQLBaseTestCase, ParametrizedTestCase)
 
         variables = {"organizationId": str(self.org.pk)}
 
-        with self.assertNumQueriesWithoutCache(6):
+        # §5.3 provisioning: grant-only ``permitted_org`` (see
+        # test_organization_member_query) — 2 extra queries over the legacy arm.
+        with self.assertNumQueriesWithoutCache(8):
             response = self.execute_graphql(query, variables)
 
         expected_members = zip(

--- a/apps/betterangels-backend/accounts/tests/test_services.py
+++ b/apps/betterangels-backend/accounts/tests/test_services.py
@@ -28,7 +28,7 @@ from shelters.groups import SHELTER_OPERATOR
 
 @pytest.mark.django_db
 def test_create_outreach_org() -> None:
-    """Outreach org gets Caseworker + Org Admin + Org Superuser groups."""
+    """Outreach org gets a Caseworker group; Org Admin/Superuser are role-backed."""
     org = create_organization_with_presets("Outreach Org", ["outreach"], owner=baker.make(User))
 
     profile = OrganizationProfile.objects.get(organization=org)
@@ -37,12 +37,17 @@ def test_create_outreach_org() -> None:
     names = set(
         PermissionGroupTemplate.objects.filter(permissiongroup__organization=org).values_list("name", flat=True)
     )
-    assert names == {CASEWORKER.name, ORG_ADMIN.name, ORG_SUPERUSER.name}
+    # §5.3 provisioning: only the still-legacy CASEWORKER template keeps a
+    # PermissionGroup; ORG_ADMIN/ORG_SUPERUSER are role-backed (Grant authority).
+    assert names == {CASEWORKER.name}
+    assert not PermissionGroup.objects.filter(
+        organization=org, template__name__in=[ORG_ADMIN.name, ORG_SUPERUSER.name]
+    ).exists()
 
 
 @pytest.mark.django_db
 def test_create_shelter_org() -> None:
-    """Shelter org gets Org Admin + Org Superuser groups; Shelter Operator is role-backed (Grant, no legacy group)."""
+    """Shelter org gets no legacy groups: every template is role-backed (Grant)."""
     org = create_organization_with_presets("Shelter Org", ["shelter"], owner=baker.make(User))
 
     profile = OrganizationProfile.objects.get(organization=org)
@@ -51,9 +56,9 @@ def test_create_shelter_org() -> None:
     names = set(
         PermissionGroupTemplate.objects.filter(permissiongroup__organization=org).values_list("name", flat=True)
     )
-    # Post-teardown (ADR 0001 §4 phase 5): SHELTER_OPERATOR is role-backed and
-    # has no legacy PermissionGroup.
-    assert names == {ORG_ADMIN.name, ORG_SUPERUSER.name}
+    # Post-teardown (ADR 0001 §4 phase 5) + §5.3 provisioning: SHELTER_OPERATOR,
+    # ORG_ADMIN and ORG_SUPERUSER are all role-backed — no legacy PermissionGroup.
+    assert names == set()
 
 
 @pytest.mark.django_db
@@ -67,7 +72,9 @@ def test_create_dual_type_org() -> None:
     names = set(
         PermissionGroupTemplate.objects.filter(permissiongroup__organization=org).values_list("name", flat=True)
     )
-    assert names == {CASEWORKER.name, ORG_ADMIN.name, ORG_SUPERUSER.name}
+    # Only CASEWORKER (outreach) is still legacy; shelter's SHELTER_OPERATOR and
+    # both org-admin templates are role-backed.
+    assert names == {CASEWORKER.name}
 
 
 @pytest.mark.django_db
@@ -89,6 +96,8 @@ def test_create_org_invalid_preset() -> None:
 @pytest.mark.django_db
 def test_create_org_with_owner_roles() -> None:
     """Owner gets explicitly specified roles (not just defaults)."""
+    from accounts.models import Grant, Role
+
     owner = baker.make(User, email="owner@example.com")
     org = create_organization_with_presets(
         "Roleful Org", ["outreach"], owner=owner, owner_roles=(CASEWORKER, ORG_ADMIN)
@@ -100,14 +109,18 @@ def test_create_org_with_owner_roles() -> None:
     caseworker_group = Group.objects.get(
         permissiongroup__organization=org, permissiongroup__template__name=CASEWORKER.name
     )
-    admin_group = Group.objects.get(permissiongroup__organization=org, permissiongroup__template__name=ORG_ADMIN.name)
-    superuser_group = Group.objects.get(
-        permissiongroup__organization=org, permissiongroup__template__name=ORG_SUPERUSER.name
-    )
 
+    # §5.3 provisioning: CASEWORKER is a legacy group membership; ORG_ADMIN is
+    # role-backed so the owner holds a Grant, and no legacy admin rows exist.
     assert caseworker_group in owner.groups.all()
-    assert admin_group in owner.groups.all()
-    assert superuser_group not in owner.groups.all()
+    assert not PermissionGroup.objects.filter(
+        organization=org, template__name__in=[ORG_ADMIN.name, ORG_SUPERUSER.name]
+    ).exists()
+
+    admin_role = Role.objects.get(name=ORG_ADMIN.name, is_global=False)
+    superuser_role = Role.objects.get(name=ORG_SUPERUSER.name, is_global=False)
+    assert Grant.objects.filter(principal_user=owner, role=admin_role, scope_org=org).exists()
+    assert not Grant.objects.filter(principal_user=owner, role=superuser_role, scope_org=org).exists()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -356,6 +369,8 @@ def test_member_add_cross_portal_reinvite() -> None:
 @pytest.mark.django_db
 def test_member_add_multiple_templates() -> None:
     """member_add can assign multiple permission templates at once."""
+    from accounts.models import Grant, Role
+
     owner = baker.make(User)
     org = create_organization_with_presets("Multi Template Org", ["outreach"], owner=owner)
 
@@ -369,10 +384,13 @@ def test_member_add_multiple_templates() -> None:
     )
 
     cw = Group.objects.get(permissiongroup__organization=org, permissiongroup__template__name=CASEWORKER.name)
-    admin = Group.objects.get(permissiongroup__organization=org, permissiongroup__template__name=ORG_ADMIN.name)
 
+    # §5.3 provisioning: CASEWORKER keeps the legacy group; ORG_ADMIN is
+    # role-backed and lands as a Grant instead.
     assert cw in user.groups.all()
-    assert admin in user.groups.all()
+    admin_role = Role.objects.get(name=ORG_ADMIN.name, is_global=False)
+    assert Grant.objects.filter(principal_user=user, role=admin_role, scope_org=org).exists()
+    assert not PermissionGroup.objects.filter(organization=org, template__name=ORG_ADMIN.name).exists()
 
 
 @pytest.mark.django_db

--- a/apps/betterangels-backend/accounts/tests/test_utils.py
+++ b/apps/betterangels-backend/accounts/tests/test_utils.py
@@ -1,5 +1,5 @@
 from accounts.groups import ORG_ADMIN, ORG_SUPERUSER
-from accounts.models import User
+from accounts.models import Grant, Role, User
 from accounts.role_manager import OrgRoleManager
 from django.contrib.auth.models import Group
 from django.test import TestCase
@@ -25,7 +25,7 @@ class OrgRoleManagerTestCase(ParametrizedTestCase, TestCase):
         self.omb_2.add_roles(self.user, CASEWORKER, ORG_SUPERUSER)
 
     def _get_org_group(self, org: Organization, template_name: str) -> Group:
-        """Helper: fetch the ``auth.Group`` row for (org, template_name).
+        """Helper: fetch the legacy ``auth.Group`` row for (org, template_name).
 
         The parent instance rather than the ``PermissionGroup``: Django compares
         concrete models in ``__eq__``, so a child never equals the parent row
@@ -36,46 +36,57 @@ class OrgRoleManagerTestCase(ParametrizedTestCase, TestCase):
             permissiongroup__template__name=template_name,
         )
 
+    def _role(self, name: str) -> Role:
+        return Role.objects.get(name=name, is_global=False)
+
+    def _holds_role(self, org: Organization, user: User, role_name: str) -> bool:
+        """§5.3 provisioning: role-backed templates (ORG_ADMIN/ORG_SUPERUSER)
+        are held as Grants — the legacy PermissionGroup rows no longer exist."""
+        return Grant.objects.filter(
+            principal_user=user,
+            role=self._role(role_name),
+            scope_org=org,
+        ).exists()
+
     def test_set_role(self) -> None:
         omb = OrgRoleManager(self.org_1)
 
-        org_admin_group = self._get_org_group(self.org_1, "Organization Admin")
-        org_superuser_group = self._get_org_group(self.org_1, "Organization Superuser")
-
-        self.assertNotIn(org_admin_group, self.user.groups.all())
-        self.assertNotIn(org_superuser_group, self.user.groups.all())
+        # Initially the user holds nothing at org_1.
+        self.assertFalse(self._holds_role(self.org_1, self.user, ORG_ADMIN.name))
+        self.assertFalse(self._holds_role(self.org_1, self.user, ORG_SUPERUSER.name))
+        self.assertFalse(self.user.groups.filter(permissiongroup__organization=self.org_1).exists())
 
         omb.add_roles(self.user, CASEWORKER, ORG_ADMIN)
-        self.assertIn(org_admin_group, self.user.groups.all())
-        self.assertNotIn(org_superuser_group, self.user.groups.all())
+        caseworker_group = self._get_org_group(self.org_1, CASEWORKER.name)
+        self.assertIn(caseworker_group, self.user.groups.all())
+        self.assertTrue(self._holds_role(self.org_1, self.user, ORG_ADMIN.name))
+        self.assertFalse(self._holds_role(self.org_1, self.user, ORG_SUPERUSER.name))
 
         omb.replace_roles(self.user, CASEWORKER, ORG_SUPERUSER)
-        self.assertNotIn(org_admin_group, self.user.groups.all())
-        self.assertIn(org_superuser_group, self.user.groups.all())
+        self.assertFalse(self._holds_role(self.org_1, self.user, ORG_ADMIN.name))
+        self.assertTrue(self._holds_role(self.org_1, self.user, ORG_SUPERUSER.name))
+        self.assertIn(caseworker_group, self.user.groups.all())
 
     def test_remove_roles(self) -> None:
         """remove_roles should remove only the specified templates, leaving others."""
         omb = OrgRoleManager(self.org_2)
-        caseworker_group = self._get_org_group(self.org_2, "Caseworker")
-        org_superuser_group = self._get_org_group(self.org_2, "Organization Superuser")
+        caseworker_group = self._get_org_group(self.org_2, CASEWORKER.name)
 
         self.assertIn(caseworker_group, self.user.groups.all())
-        self.assertIn(org_superuser_group, self.user.groups.all())
+        self.assertTrue(self._holds_role(self.org_2, self.user, ORG_SUPERUSER.name))
 
         omb.remove_roles(self.user, ORG_SUPERUSER)
         self.assertIn(caseworker_group, self.user.groups.all())
-        self.assertNotIn(org_superuser_group, self.user.groups.all())
+        self.assertFalse(self._holds_role(self.org_2, self.user, ORG_SUPERUSER.name))
 
         omb.remove_roles(self.user, CASEWORKER)
         self.assertNotIn(caseworker_group, self.user.groups.all())
 
     def test_clear_roles(self) -> None:
-        org_superuser_group = self._get_org_group(self.org_2, "Organization Superuser")
-
-        self.assertIn(org_superuser_group, self.user.groups.all())
+        self.assertTrue(self._holds_role(self.org_2, self.user, ORG_SUPERUSER.name))
 
         self.omb_2.clear_roles(self.user)
 
-        org_admin_group = self._get_org_group(self.org_2, "Organization Admin")
-        self.assertNotIn(org_admin_group, self.user.groups.all())
-        self.assertNotIn(org_superuser_group, self.user.groups.all())
+        self.assertFalse(self._holds_role(self.org_2, self.user, ORG_SUPERUSER.name))
+        self.assertFalse(self._holds_role(self.org_2, self.user, ORG_ADMIN.name))
+        self.assertFalse(self.user.groups.filter(permissiongroup__organization=self.org_2).exists())

--- a/apps/betterangels-backend/common/management/commands/sync_roles.py
+++ b/apps/betterangels-backend/common/management/commands/sync_roles.py
@@ -16,10 +16,18 @@ class Command(BaseCommand):
     help = "Provision Roles and backfill Grants from legacy PermissionGroups (ADR 0001)"
 
     def handle(self, **options: object) -> None:
-        from accounts.services import backfill_global_role_members, backfill_shelter_grants, sync_roles
+        from accounts.services import (
+            backfill_global_role_members,
+            backfill_org_admin_grants,
+            backfill_shelter_grants,
+            sync_roles,
+        )
 
         sync_roles()
         self.stdout.write("✓ Roles provisioned")
+
+        backfill_org_admin_grants()
+        self.stdout.write("✓ Organization Admin grants backfilled")
 
         backfill_shelter_grants()
         self.stdout.write("✓ Shelter Operator grants backfilled")

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -312,36 +312,16 @@ def can_anywhere(user: "User", perm: str) -> bool:
 
 
 def permitted_org(user: "User", perm: str, *, org_id: Any) -> Organization | None:
-    """Transitional org-scoped dual-read (ADR 0001 §5.3): legacy OR ``can()``.
+    """The org-scoped authority check (ADR 0001 §5.3, post-provisioning).
 
-    **The single seam of the §5.3 transition.**  Every consumer whose authority
-    template (``ORG_ADMIN`` / ``ORG_SUPERUSER``) is still legacy reads through
-    this one function: the legacy arm (``permissioned_queryset`` — the robust
-    single-join EXISTS) returns the org in one query while the template is
-    legacy, and the grant arm (``can()``) takes over once the provisioning PR
-    role-backs the template and backfills Grants.  Because every consumer shares
-    the seam, role-backing a template no longer has to coincide with cutting each
-    consumer over — a domain can land independently and nothing breaks
-    mid-transition.  ``None`` means not authorized (or no such org — ``can()``
-    never implies existence, ADR 0001 §2.6 finding F7).
-
-    The legacy arm runs first: it is today's authority and keeps the common path
-    at a single query.  The legacy arm is deleted from this one function at phase
-    5, when it collapses to the grant check.
+    **The single seam of the org-admin transition** — grant-only since the §5.3
+    provisioning PR role-backed ``ORG_ADMIN``/``ORG_SUPERUSER`` and backfilled
+    Grants, which retired the legacy ``PermissionGroup`` arms (reconcile deletes
+    the rows).  Returns the org when the user can act on *perm* there, else
+    ``None``.  ``None`` also means no such org — ``can()`` never implies
+    existence, ADR 0001 §2.6 finding F7.
     """
-    from common.permissions.utils import permissioned_queryset
     from organizations.models import Organization
-
-    org = permissioned_queryset(
-        Organization.objects.all(),
-        user=user,
-        organization_id=str(org_id),
-        perms=[perm],
-        any_perm=True,
-        organization_field="pk",
-    ).first()
-    if org is not None:
-        return org
 
     if can(user, perm, org=org_id):
         return Organization.objects.filter(pk=org_id).first()
@@ -349,13 +329,12 @@ def permitted_org(user: "User", perm: str, *, org_id: Any) -> Organization | Non
 
 
 def has_authority_anywhere(user: "User", perm: str) -> bool:
-    """Transitional global-tier dual-read: legacy ``has_perm`` OR grant-anywhere.
+    """Global-tier authority check: grant-anywhere (ADR 0001 §5.3, post-provisioning).
 
-    The global companion to :func:`has_authority` for the member-management
-    queries' anywhere tier (``view_org_members`` rides a still-legacy template).
-    Grants do not feed ``has_perm``, so a grant-only holder is covered by
-    ``can_anywhere()``.  Deleted at phase 5.
+    The global companion to :func:`permitted_org` for the member-management
+    queries' anywhere tier.  Grant-only since provisioning: legacy ``has_perm``
+    no longer feeds these perms (the role-backed templates' ``PermissionGroup``
+    rows are gone), so a holder is authorized iff they hold the perm via a Grant
+    at some org (``can_anywhere``) or the global tier.
     """
-    if user.has_perm(perm):
-        return True
     return can_anywhere(user, perm)

--- a/apps/betterangels-backend/common/tests/test_org_permissions.py
+++ b/apps/betterangels-backend/common/tests/test_org_permissions.py
@@ -79,9 +79,13 @@ class PermissionedQuerysetSameGroupTestCase(TestCase):
         self.user = baker.make(User, username=f"member_{uuid.uuid4()}")
         self.org.add_user(self.user)
 
-        groups = list(PermissionGroup.objects.filter(organization=self.org)[:2])
-        assert len(groups) >= 2, "the org recipe should provision at least two permission groups"
-        self.member_group, self.holder_group = groups[0], groups[1]
+        # §5.3 provisioning: the outreach org provisions only the CASEWORKER
+        # group (ORG_ADMIN/ORG_SUPERUSER are role-backed), so the second legacy
+        # group the permission lives in is created by hand.
+        groups = list(PermissionGroup.objects.filter(organization=self.org)[:1])
+        assert len(groups) == 1, "the org recipe should provision the CASEWORKER group"
+        self.member_group = groups[0]
+        self.holder_group = PermissionGroup.objects.create(organization=self.org, label="Permission Holder")
 
         permission = Permission.objects.exclude(pk__in=self.member_group.permissions.values("pk")).first()
         assert permission is not None

--- a/apps/betterangels-backend/reports/models.py
+++ b/apps/betterangels-backend/reports/models.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 
 from accounts.models import Organization
+from common.models import OrgScoped
 from common.permissions.utils import permission_enums_to_django_meta_permissions
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ValidationError
@@ -33,8 +34,16 @@ def validate_email_list(value: str) -> None:
             raise ValidationError(f"Invalid email address: {email}")
 
 
-class ScheduledReport(models.Model):
-    """Model for scheduled reports that send data via email on a regular schedule."""
+class ScheduledReport(OrgScoped, models.Model):
+    """Model for scheduled reports that send data via email on a regular schedule.
+
+    Declares ``OrgScoped`` with the default ``org_via = ()`` (ADR 0001 §5.3):
+    the model owns its ``organization`` FK, and it is where the
+    ``reports.view_reports`` permission row is declared (``Meta.permissions``).
+    A role-backed ``ORG_ADMIN`` Grant holder exercises that permission at one
+    org through ``can()``, so the declaring model must be org-reachable for
+    ``permissions.E005`` to stay quiet.
+    """
 
     class Frequency(models.TextChoices):
         """Report frequency options."""

--- a/apps/betterangels-backend/reports/permissions.py
+++ b/apps/betterangels-backend/reports/permissions.py
@@ -4,11 +4,9 @@ Reports app DRF permissions.
 Reference: https://github.com/HackSoftware/Django-Styleguide#apis--serializers
 """
 
-from accounts.models import User
 from common.permissions.utils import register_permission
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from organizations.models import Organization
 from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.views import APIView
@@ -17,21 +15,6 @@ from rest_framework.views import APIView
 @register_permission
 class ReportPermissions(models.TextChoices):
     VIEW_REPORTS = "reports.view_reports", _("Can view reports")
-
-
-def report_org_for_user(user: User, org_id: str) -> Organization | None:
-    """The organization *user* may view reports for — the transition seam (§5.3).
-
-    ``view_reports`` rides the legacy ``ORG_ADMIN``/``ORG_SUPERUSER`` templates.
-    The dual-read is delegated to
-    :func:`common.permissions.selectors.permitted_org` (the legacy org-scoped
-    check while the template is legacy, then the grant ``can()`` once it is
-    role-backed and backfilled) — one seam for every consumer.  This wrapper is
-    deleted at phase 5.
-    """
-    from common.permissions.selectors import permitted_org
-
-    return permitted_org(user, ReportPermissions.VIEW_REPORTS, org_id=org_id)
 
 
 class HasReportAccess(BasePermission):
@@ -57,7 +40,9 @@ class HasReportAccess(BasePermission):
         if not org_id:
             return False
 
-        org = report_org_for_user(user, org_id)
+        from common.permissions.selectors import permitted_org
+
+        org = permitted_org(user, ReportPermissions.VIEW_REPORTS.value, org_id=org_id)
         if org is None:
             return False
 

--- a/apps/betterangels-backend/reports/tests/test_views.py
+++ b/apps/betterangels-backend/reports/tests/test_views.py
@@ -22,7 +22,12 @@ from teams.models import Team
 
 
 def grant_view_reports(user: User, org: Organization) -> None:
-    """Grant view_reports permission to a user for an org via PermissionGroup."""
+    """Give *user* ``view_reports`` on *org* through a legacy PermissionGroup only.
+
+    §5.3 provisioning made the reports gate grant-only, so this legacy-only
+    holder must FAIL CLOSED — the helper now exists to pin that denial
+    (``test_legacy_group_only_holder_is_denied``).
+    """
     ct = ContentType.objects.get_for_model(ScheduledReport)
     perm, _ = Permission.objects.get_or_create(
         codename="view_reports", content_type=ct, defaults={"name": "Can view reports"}
@@ -35,12 +40,11 @@ def grant_view_reports(user: User, org: Organization) -> None:
 
 
 def grant_view_reports_via_role(user: User, org: Organization) -> None:
-    """Grant view_reports via a scoped test Role + Grant (grant arm, ADR §5.3).
+    """Grant view_reports via a scoped test Role + Grant (ADR §5.3 grant-only).
 
-    The §5.3 reports slice authorizes reads through the grant predicate OR the
-    legacy PermissionGroup.  A legacy-only holder exercises the legacy arm; a
-    holder with a scoped Role carrying ``view_reports`` (no PermissionGroup)
-    exercises the grant arm.
+    The §5.3 reports read gate authorizes through the grant predicate
+    (``permitted_org`` → ``can()``), so a holder needs a scoped Role carrying
+    ``view_reports`` and a Grant at the org — no PermissionGroup.
     """
     ct = ContentType.objects.get_for_model(ScheduledReport)
     perm, _ = Permission.objects.get_or_create(
@@ -63,7 +67,21 @@ def org() -> Organization:
 
 @pytest.fixture
 def user_with_access(org: Organization) -> User:
-    """Create a user with VIEW_REPORTS permission on the org."""
+    """Create a user with VIEW_REPORTS on the org via a scoped Grant (grant-only)."""
+    user = baker.make(User)
+    user.set_password("testpass")
+    user.save()
+    org.add_user(user)
+    grant_view_reports_via_role(user, org)
+    return user
+
+
+@pytest.fixture
+def user_with_legacy_group_only(org: Organization) -> User:
+    """A user holding view_reports ONLY through a legacy PermissionGroup.
+
+    §5.3 provisioning made the gate grant-only — this holder must fail closed.
+    """
     user = baker.make(User)
     user.set_password("testpass")
     user.save()
@@ -110,6 +128,14 @@ class TestExportInteractionDataView:
         """User in org but without VIEW_REPORTS permission gets 403."""
         api_client.force_authenticate(user=user_without_access)
         response = api_client.get("/reports/export/")
+        assert response.status_code == 403
+
+    def test_legacy_group_only_holder_is_denied(
+        self, api_client: APIClient, user_with_legacy_group_only: User, org: Organization
+    ) -> None:
+        """§5.3 provisioning: a legacy-only PermissionGroup holder fails closed."""
+        api_client.force_authenticate(user=user_with_legacy_group_only)
+        response = api_client.get(f"/reports/export/?org_id={org.id}")
         assert response.status_code == 403
 
     def test_successful_csv_download_with_month_year(
@@ -278,7 +304,7 @@ class TestExportInteractionDataView:
         user.save()
         org.add_user(user)
         other_org.add_user(user)
-        grant_view_reports(user, org)
+        grant_view_reports_via_role(user, org)
         # No permission on other_org
 
         api_client.force_authenticate(user=user)
@@ -389,13 +415,13 @@ class TestReportSummaryGraphQL(GraphQLBaseTestCase):
     """Tests for the reportSummary GraphQL query."""
 
     def _setup_org_user_with_access(self) -> tuple[Organization, User]:
-        """Create org + user with VIEW_REPORTS permission."""
+        """Create org + user with VIEW_REPORTS permission (scoped Grant)."""
         org = baker.make(Organization, name="Test Org")
         user = baker.make(User)
         user.set_password("testpass")
         user.save()
         org.add_user(user)
-        grant_view_reports(user, org)
+        grant_view_reports_via_role(user, org)
         return org, user
 
     def test_unauthenticated_returns_error(self) -> None:

--- a/apps/betterangels-backend/teams/models.py
+++ b/apps/betterangels-backend/teams/models.py
@@ -1,19 +1,24 @@
 """Teams — per-organization team management."""
 
-from common.models import BaseModel
+from common.models import BaseModel, OrgScoped
 from django.db import models
 from django.db.models.functions import Lower
 
 from .validators import validate_has_alphanumeric
 
 
-class Team(BaseModel):
+class Team(OrgScoped, BaseModel):
     """Team, scoped per organization.
 
     Teams are managed by org admins through the admin app and referenced by
     ``id`` (FK) on notes and tasks.  *name* is the only identifier: it is what
     users see and type, and it is unique per organization case-insensitively
     (see ``unique_team_name_per_org``).
+
+    ``OrgScoped`` with the default ``org_via = ()`` (ADR 0001 §5.3): the model
+    owns its ``organization`` FK, so a scoped Role's ``teams.*`` perms are
+    org-reachable — this is what lets a role-backed ``ORG_ADMIN`` Grant holder
+    act at one org without inheriting another's teams (permissions.E005).
     """
 
     name = models.CharField(max_length=255, validators=[validate_has_alphanumeric])

--- a/apps/betterangels-backend/teams/tests/test_grant_authorization.py
+++ b/apps/betterangels-backend/teams/tests/test_grant_authorization.py
@@ -1,22 +1,21 @@
-"""Teams write authority — grant arm OR legacy (ADR 0001 §5.3, teams slice).
+"""Teams write authority — grant-only (ADR 0001 §5.3, provisioning).
 
-The three team mutations are authorized by the grant predicate (``can()``) or,
-during the transition while ``ORG_ADMIN`` / ``ORG_SUPERUSER`` are still legacy
-templates, by the legacy org-scoped check (``HasOrgPerm``'s
-``permissioned_queryset``).  These tests pin **both** arms so the transition
-cannot silently drop either authority:
+§5.3 provisioning role-backed ``ORG_ADMIN``/``ORG_SUPERUSER`` and removed the
+transitional legacy arm: ``OrgRoleManager(org).add_roles(user, ORG_ADMIN)`` now
+writes a scoped ``Grant`` (role = "Organization Admin"), and ``reconcile``
+retired the template's legacy ``PermissionGroup`` rows.  These tests pin the
+grant-only contract:
 
-- a legacy ``ORG_ADMIN`` holder with no Grant still passes (current behavior);
-- a scoped-Grant holder with no legacy group passes via the grant arm;
+- an org admin (ORG_ADMIN Grant) manages teams with no legacy group;
+- a holder of a stale legacy ``ORG_ADMIN`` ``PermissionGroup`` with no Grant
+  fails closed;
 - a member with neither is denied;
 - a Grant at org A does not authorize acting at org B;
 - update/delete thread CHANGE/DELETE (a holder of ADD alone cannot update/delete).
-
-The dual-read is transitional: the legacy arm is removed when the §5.3
-provisioning PR role-backs the template and backfills Grants.
 """
 
-from accounts.models import User
+from accounts.groups import ORG_ADMIN
+from accounts.models import PermissionGroup, PermissionGroupTemplate, User
 from model_bakery import baker
 from teams.models import Team
 
@@ -26,18 +25,38 @@ PERMISSION_DENIED = "You do not have permission to perform this action in this o
 
 
 class TeamLegacyAuthorityTestCase(TeamGraphQLBaseTestCase):
-    """The legacy ORG_ADMIN holder keeps working — no Grant needed (transitional arm)."""
+    """§5.3 provisioning: an org admin is a Grant holder; legacy-only fails closed."""
 
-    def test_legacy_org_admin_can_create_a_team(self) -> None:
-        # org_1_admin holds ORG_ADMIN as a legacy PermissionGroup, no Grant.
-        self.assertFalse(self.org_1_admin.grants.filter(scope_org=self.org_1).exists())
+    def test_org_admin_can_create_a_team(self) -> None:
+        # org_1_admin holds ORG_ADMIN as a scoped Grant (role-backed template).
+        self.assertTrue(self.org_1_admin.grants.filter(scope_org=self.org_1).exists())
 
         response = self.create_team_fixture({"name": "grant-era team"})
 
         self.assertIsNone(response.get("errors"))
         self.assertEqual(response["data"]["createTeam"]["name"], "grant-era team")
 
-    def test_legacy_org_admin_can_update_and_delete_a_team(self) -> None:
+    def test_legacy_group_only_org_admin_is_denied(self) -> None:
+        """A stale ORG_ADMIN PermissionGroup holder with no Grant fails closed."""
+        legacy_user = baker.make(User)
+        self.org_1.add_user(legacy_user)
+        # Simulate a pre-backfill org: a legacy ORG_ADMIN group row that the
+        # grant-only seam must not read.
+        template = PermissionGroupTemplate.objects.get(name=ORG_ADMIN.name)
+        PermissionGroup.objects.create(organization=self.org_1, template=template)
+        legacy_group = PermissionGroup.objects.get(organization=self.org_1, template=template)
+        legacy_user.groups.add(legacy_group)
+        self.assertFalse(legacy_user.grants.filter(scope_org=self.org_1).exists())
+
+        self.graphql_client.force_login(legacy_user)
+        self._set_active_org(self.org_1)
+
+        response = self.create_team_fixture({"name": "legacy-only team"})
+
+        self.assertEqual(response["errors"][0]["message"], PERMISSION_DENIED)
+        self.assertFalse(Team.objects.filter(name="legacy-only team").exists())
+
+    def test_org_admin_can_update_and_delete_a_team(self) -> None:
         team = baker.make(Team, name="old name", organization=self.org_1)
 
         response = self.update_team_fixture({"id": team.pk, "name": "new name"})

--- a/apps/betterangels-backend/teams/tests/test_mutations.py
+++ b/apps/betterangels-backend/teams/tests/test_mutations.py
@@ -19,7 +19,9 @@ class TeamMutationTestCase(TeamGraphQLUtilsMixin):
     def test_create_team_mutation(self) -> None:
         variables = {"name": "team 1"}
 
-        expected_query_count = 7
+        # §5.3 provisioning: the mutation's @hasOrgPerm authority resolves
+        # grant-only through ``permitted_org`` (+3 queries over the legacy arm).
+        expected_query_count = 10
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.create_team_fixture(variables)
 
@@ -32,7 +34,8 @@ class TeamMutationTestCase(TeamGraphQLUtilsMixin):
         team = baker.make(Team, name="old name", organization=self.org)
         variables = {"id": team.pk, "name": "new name", "isActive": False}
 
-        expected_query_count = 11
+        # §5.3 provisioning: grant-only authority (+3 queries).
+        expected_query_count = 14
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.update_team_fixture(variables)
 
@@ -87,7 +90,8 @@ class TeamMutationTestCase(TeamGraphQLUtilsMixin):
     def test_delete_team_mutation(self) -> None:
         team = baker.make(Team, name="team", organization=self.org)
 
-        expected_query_count = 7
+        # §5.3 provisioning: grant-only authority (+3 queries).
+        expected_query_count = 10
         with self.assertNumQueriesWithoutCache(expected_query_count):
             response = self.delete_team_fixture(team.pk)
 

--- a/docs/adr/0001-grant-based-authorization.md
+++ b/docs/adr/0001-grant-based-authorization.md
@@ -445,8 +445,8 @@ still needs at its cutover:
 |---|---|---|---|---|---|
 | **Tasks** | `Task.organization` | `()` | legacy template + guardian rows at creation | §5-equivalence: org-scoped writes on the role; shared/foreign rows via the object arm | **Not mechanical** — guardian-at-creation (§5) |
 | **Referrals** | `Referral.organization` (+ shelter) | `()` — but "own org **or** via shelter" is inexpressible today (§4.1 note) | legacy + guardian rows at creation | §5-equivalence: org-scoped writes on the role; shared/foreign rows via the object arm | **Not mechanical** — guardian-at-creation (§5) |
-| **Teams** | `Team.organization` | `()` | legacy `@hasOrgPerm` (perms on `ORG_ADMIN`) | `OrgScoped` + `can()`/`visible()` (domain path is clean — no guardian rows) | **Blocked on §5.3** — authority rides the legacy `ORG_ADMIN` template |
-| **Reports** | report row `.organization` | `()` | legacy `@hasOrgPerm` (`view_reports`, on `ORG_ADMIN`) | org-scoped role perms (domain path is clean) | **Blocked on §5.3** — authority rides the legacy `ORG_ADMIN` template |
+| **Teams** | `Team.organization` | `()` | **grant-only** (`can()`/`can_obj` via the role-backed `ORG_ADMIN` role, §5.3) | **Cut over (§5.3)** — no guardian rows; `@hasOrgPerm` reads Grants | None |
+| **Reports** | report row `.organization` | `()` | **grant-only** (`can()` via the role-backed `ORG_ADMIN` role, §5.3) | **Cut over (§5.3)** — DRF + GraphQL reads authorize through `permitted_org` | None |
 | **Notes** | `Note.organization` | `()` | legacy template + guardian rows at creation | org-owned writes on the role; shared/foreign notes via the object arm | **Not mechanical** — §5 design |
 | **Clients** | `ClientProfile` (no org FK) | `None` (platform-shared) | legacy model-level perms on CASEWORKER (no per-record rows) | parity-first: SHARED write via `can_anywhere` (RFC 0002); owner-tier (`created_by_org`) parked | §5.1 / RFC 0002 |
 | **HMIS** | `HmisProfile` → `ClientProfile` | `None` (platform-shared) | legacy `resolve_permission_group` | rides the clients cutover | rides clients |
@@ -566,6 +566,13 @@ ADR-vs-code `OBJECT_ARM_ENABLED` drift) are fixed during the cutover wave, becau
 cutover touches those exact code paths.
 
 ### 5.3 Org-admin role-backed milestone — teams, reports, and member management land together
+> **Status: complete.** Steps 1–3 (teams / reports / member-management dual reads) landed first as
+> `@hasOrgPerm` / `@hasPermOrGrant` slices and were later consolidated into a single seam
+> (`permitted_org` / `has_authority_anywhere`, deleting `HasOrgPermOrGrant`). Step 4 (provisioning)
+> then role-backed `ORG_ADMIN`/`ORG_SUPERUSER`, backfilled Grants, and collapsed the seam to
+> grant-only — legacy-PermissionGroup-only holders now fail closed. The historical plan below is
+> retained as the decision record.
+
 
 Teams and reports look like the cleanest cutovers (§4.1): org-scoped rows, no guardian
 rows at creation, pure `@hasOrgPerm`. They are not standalone, because **their


### PR DESCRIPTION
## What & why

Completes ADR 0001 §5.3 (the org-admin role-backed milestone, step 4). `Organization Admin` / `Organization Superuser` are now **role-backed scoped Roles**; existing memberships backfill to Grants; and the dual-read seam collapses to **grant-only** authority. Every consumer of these templates (teams, reports, member management) now authorizes through Grants.

## Changes

- **`accounts/groups.py`** — `ORG_ADMIN_ROLE` / `ORG_SUPERUSER_ROLE` (`RoleDef.from_template`) + `ORG_ADMIN_ROLES`.
- **`accounts/services.py`** — `sync_roles()` aggregates shelter + org-admin roles; new **`backfill_org_admin_grants()`** converts every org's legacy `ORG_ADMIN`/`ORG_SUPERUSER` PermissionGroup memberships → Grants (idempotent), wired into `post_migrate` (`apps.py`) and `manage.py sync_roles`, ordered **before** reconcile retires the legacy rows.
- **`common/permissions/selectors.py`** — `permitted_org()` / `has_authority_anywhere()` are now **grant-only** (legacy `permissioned_queryset` / `has_perm` arms deleted, phase 5). A legacy-PermissionGroup-only holder now fails closed.
- **`accounts/permissions.py` + `reports/permissions.py`** — deleted the thin dual wrappers (`get_user_permitted_org_dual`, `report_org_for_user`); call sites call `permitted_org` directly.
- **`accounts/annotations.py`** — `annotate_member_role` reads the org role from scoped `Grant` rows.
- **`teams/models.py` + `reports/models.py`** — `Team` and `ScheduledReport` declare `OrgScoped` (`org_via = ()`) so the org-admin Roles' perms are org-reachable and `permissions.E005` stays quiet (metadata only — `makemigrations --check` clean).
- **Tests** migrated to the grant-only contract across accounts/common/teams/reports/shelters (role-backed ⇒ assert Grants, legacy-only holders ⇒ denied, legacy-utility tests retargeted to CASEWORKER, query pins updated).

## Verification

- `pytest accounts/ common/ teams/ reports/ shelters/` → **1134 passed, 0 failed**
- ruff format + lint clean, mypy clean
- `manage.py check` quiet (E005 no longer trips on the org-admin roles)
- `makemigrations --check` → no changes detected

## Note

The legacy `get_user_permitted_org` function remains (still the authority path for legacy templates elsewhere); its single-join coverage was retargeted to the still-legacy CASEWORKER template.

Stacked on #2433 (`perm/perm-single-seam`).

## Summary by Sourcery

Complete the organization-admin authorization cutover by provisioning role-backed admin roles, backfilling Grants, and switching organization authority consumers to grant-only checks.

New Features:
- Provision scoped Organization Admin and Organization Superuser roles for organizations.
- Backfill existing organization-admin memberships into idempotent scoped Grants.

Bug Fixes:
- Prevent legacy PermissionGroup-only memberships from authorizing organization-scoped actions after the cutover.

Enhancements:
- Collapse organization authority checks to grant-only across member management, teams, and reports.
- Declare teams and scheduled reports as organization-scoped so role-backed permissions remain correctly reachable.
- Remove transitional authorization wrappers and update member-role annotations to read from Grants.

Documentation:
- Mark the ADR org-admin milestone complete and document the grant-only cutover for teams and reports.

Tests:
- Migrate authorization coverage to the grant-only contract, including role-backed success and legacy-only denial cases.