### PR TITLE
feat(perm): write tiers — decouple write scope from read scope (RFC 0002)

### DIFF
--- a/apps/betterangels-backend/clients/models.py
+++ b/apps/betterangels-backend/clients/models.py
@@ -22,7 +22,7 @@ from clients.enums import (
     VeteranStatusEnum,
 )
 from common.constants import CALIFORNIA_ID_REGEX
-from common.models import Attachment, BaseModel, OrgScoped, PhoneNumber
+from common.models import Attachment, BaseModel, OrgScoped, PhoneNumber, WRITE_SHARED
 from common.permissions.utils import PermissionSet
 from dateutil.relativedelta import relativedelta
 from django.contrib.contenttypes.fields import GenericRelation
@@ -168,6 +168,11 @@ class ClientProfileManager(models.Manager.from_queryset(ClientProfileQuerySet)["
 )
 class ClientProfile(OrgScoped, AbstractClientProfile):
     org_via = None  # platform-shared by product decision (ADR 0001 §2.3)
+    # SHARED write tier (RFC 0002 decision #1): client CHANGE/DELETE today come
+    # from model-level perms on the CASEWORKER group (global-tier behavior in
+    # disguise), so the cutover preserves that as "holds the permission
+    # anywhere" — can_obj(user, clients.change_clientprofile, row) == can_anywhere.
+    write_tier = WRITE_SHARED
 
     objects = ClientProfileManager()  # hides merged profiles by default
     gender = TextChoicesField(choices_enum=GenderEnum, blank=True, null=True)

--- a/apps/betterangels-backend/common/models.py
+++ b/apps/betterangels-backend/common/models.py
@@ -27,6 +27,24 @@ class BaseModel(models.Model):
         abstract = True
 
 
+# Write tiers (RFC 0002 §Precondition / ADR 0001 §2.5).  ``can_obj`` consults a
+# model's write scope independently of ``org_via`` (its read scope).  ORG is the
+# derived default for any org-anchored model (``org_via`` not ``None``) and
+# needs no declaration; these constants are the explicit declarations a model
+# makes when the derived default is not what its writes need.
+WRITE_SHARED = "shared"
+"""Platform-shared write tier: any holder of the permission anywhere may act.
+
+"""
+
+WRITE_OBJECT = "object"
+"""Object-grant write tier: only an object ``Grant`` (or the global tier) may act.
+
+Reserved — the object arm turns on with the clients cutover (ADR 0001 §2.5);
+``permissions.E007`` refuses it until then.
+"""
+
+
 class OrgScoped(models.Model):
     """Declares how a model reaches the organizations that scope it (ADR 0001).
 
@@ -44,6 +62,17 @@ class OrgScoped(models.Model):
 
     org_via: ClassVar[tuple[str, ...] | None] = ()
     _org_paths: ClassVar[tuple[str, ...] | None] = None
+
+    write_tier: ClassVar[str | None] = None
+    """Write scope for :func:`common.permissions.selectors.can_obj` (RFC 0002).
+
+    ``None`` derives the safe default: ORG for an org-anchored model (the org
+    filter, unchanged from the pre-tier contract) and fail-closed for a
+    platform-shared model (``org_via = None``) — only the global tier may act
+    until the model declares a tier.  Declare :data:`WRITE_SHARED` on a
+    platform-shared model whose writes are shared-by-role-anywhere
+    (``ClientProfile`` today).
+    """
 
     class Meta:
         abstract = True

--- a/apps/betterangels-backend/common/permissions/checks.py
+++ b/apps/betterangels-backend/common/permissions/checks.py
@@ -1,6 +1,6 @@
 """System checks for the grant-based authorization model (ADR 0001).
 
-IDs: ``permissions.E001``–``permissions.E006``.
+IDs: ``permissions.E001``–``permissions.E007``.
 
 The data-reading checks return ``[]`` on any ``DatabaseError`` — unreachable
 database, or tables not migrated yet — so ``manage.py check``, ``makemigrations``
@@ -242,3 +242,49 @@ def check_object_grant_principal_is_a_user(app_configs: Any, **kwargs: Any) -> l
         return errors
     except DatabaseError:
         return []
+
+
+@register(Tags.models)
+def check_write_tier_declarations(app_configs: Any, **kwargs: Any) -> list[Error]:
+    """E007 — ``write_tier`` declarations must be legal (RFC 0002 §Precondition).
+
+    ``write_tier`` is consulted by ``can_obj`` independently of ``org_via``:
+
+    * only a platform-shared model (``org_via = None``) may declare a tier —
+      org-anchored models derive the ORG write tier from their org anchor;
+    * ``WRITE_OBJECT`` stays reserved until the object arm turns on with the
+      clients cutover (ADR 0001 §2.5) — declaring it today would silently route
+      writes to an object-grant predicate nothing can satisfy.
+    """
+    from django.apps import apps
+
+    from common.models import OrgScoped, WRITE_OBJECT
+
+    errors: list[Error] = []
+    for model in apps.get_models():
+        if not issubclass(model, OrgScoped):
+            continue
+        tier = model.__dict__.get("write_tier")
+        if tier is None:
+            continue
+        if model.org_via is not None:
+            errors.append(
+                Error(
+                    f"{model.__name__}.write_tier = {tier!r} on an org-anchored model.",
+                    hint="Org-anchored models derive the ORG write tier from org_via; "
+                    "only a platform-shared model (org_via = None) declares a tier.",
+                    obj=model,
+                    id="permissions.E007",
+                )
+            )
+        elif tier == WRITE_OBJECT:
+            errors.append(
+                Error(
+                    f"{model.__name__}.write_tier = {tier!r} is reserved.",
+                    hint="The object-grant arm (WRITE_OBJECT) turns on with the clients "
+                    "cutover (ADR 0001 §2.5) — do not declare it before then.",
+                    obj=model,
+                    id="permissions.E007",
+                )
+            )
+    return errors

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -267,16 +267,32 @@ def can(user: "User", perm: str, *, org: Any) -> bool:
 
 
 def can_obj(user: "User", perm: str, obj: "Model") -> bool:
-    """The single-row check *is* the row filter, applied to one row.
+    """The single-row write check — the row filter applied to one row.
 
-    WARNING (finding C1): on a platform-shared model (``org_via = None``)
-    ``visible`` applies the read rule — "holds the perm anywhere ⇒ all rows" —
-    so ``can_obj`` currently returns True for *every* row to any perm-holder.
-    Do not route platform-shared single-row *writes* through this until the C1
-    fix (object arm + fail-closed ``can_obj``) lands; until then it is the
-    org-scoped row filter only.
+    Write scope is chosen independently of read scope (RFC 0002 §Precondition):
+
+    * **ORG** (derived default for an org-anchored model, ``org_via`` not
+      ``None``) — the row must sit in an org the user can exercise *perm* in.
+      Unchanged from the pre-tier contract.
+    * **SHARED** (declared ``write_tier = WRITE_SHARED`` on a platform-shared
+      model) — any holder of *perm* anywhere may act (``can_anywhere``).
+      ``ClientProfile`` declares this to match ``main`` (RFC 0002 decision #1).
+    * **Fail-closed default** for a platform-shared model with no declared tier
+      (finding C1 / RFC 0002): the read rule never feeds an undeclared write —
+      only the global tier (``scopes`` is ALL) may act, until an object grant
+      covers the row once the object arm is wired at the clients cutover.
     """
-    return visible(obj.__class__._base_manager.filter(pk=obj.pk), user, perm).exists()
+    from common.models import OrgScoped, WRITE_SHARED
+
+    model = obj.__class__
+    if not issubclass(model, OrgScoped):
+        return False
+    if model.org_via is not None:
+        return visible(model._base_manager.filter(pk=obj.pk), user, perm).exists()
+    if model.write_tier == WRITE_SHARED:
+        return can_anywhere(user, perm)
+    s = scopes(user, perm)
+    return s is ALL
 
 
 def can_anywhere(user: "User", perm: str) -> bool:

--- a/apps/betterangels-backend/common/tests/test_permission_checks.py
+++ b/apps/betterangels-backend/common/tests/test_permission_checks.py
@@ -1,8 +1,8 @@
-"""Tests for the grant system checks (ADR 0001 §2.7, ``permissions.E001``–E005)."""
+"""Tests for the grant system checks (ADR 0001 §2.7, ``permissions.E001``–E007)."""
 
 from accounts.models import Grant, Role, User
 from accounts.tests.baker_recipes import organization_recipe
-from common.models import OrgScoped
+from common.models import OrgScoped, WRITE_OBJECT, WRITE_SHARED
 from common.permissions.checks import (
     _org_via_errors_for_model,
     check_grant_never_references_global_role,
@@ -11,6 +11,7 @@ from common.permissions.checks import (
     check_org_via_hops_are_single_valued,
     check_role_permissions_models_declare_org_scoping,
     check_scoped_role_never_in_user_groups,
+    check_write_tier_declarations,
 )
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
@@ -170,3 +171,35 @@ class GrantSystemChecksTestCase(TestCase):
             _errors_with(check_role_permissions_models_declare_org_scoping(None), "permissions.E005"),
             [],
         )
+
+
+class WriteTierChecksTestCase(TestCase):
+    """E007 — ``write_tier`` declarations must be legal (RFC 0002 §Precondition)."""
+
+    def test_e007_is_quiet_for_clientprofile_shared_declaration(self) -> None:
+        from clients.models import ClientProfile
+
+        self.assertEqual(ClientProfile.write_tier, WRITE_SHARED)  # guard against a vacuous pass
+        self.assertEqual(_errors_with(check_write_tier_declarations(None), "permissions.E007"), [])
+
+    def test_e007_fires_when_an_org_anchored_model_declares_a_tier(self) -> None:
+        from unittest.mock import patch
+
+        from shelters.models import Shelter
+
+        with patch.object(Shelter, "write_tier", WRITE_SHARED):
+            errors = _errors_with(check_write_tier_declarations(None), "permissions.E007")
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("org-anchored", errors[0].msg)
+
+    def test_e007_fires_when_the_object_tier_is_declared_before_the_arm(self) -> None:
+        from unittest.mock import patch
+
+        from clients.models import ClientProfile
+
+        with patch.object(ClientProfile, "write_tier", WRITE_OBJECT):
+            errors = _errors_with(check_write_tier_declarations(None), "permissions.E007")
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("reserved", errors[0].msg)

--- a/apps/betterangels-backend/common/tests/test_permissions_selectors.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_selectors.py
@@ -139,6 +139,50 @@ class GrantSelectorsTestCase(TestCase):
         self.assertTrue(can_obj(alice, Shelter.perms.VIEW, self.shelter_a))
         self.assertFalse(can_obj(alice, Shelter.perms.VIEW, self.shelter_b))
 
+    def test_can_obj_shared_tier_is_any_holder_anywhere(self) -> None:
+        """ClientProfile declares WRITE_SHARED (RFC 0002 #1): can_obj == can_anywhere."""
+        from clients.models import ClientProfile
+
+        client = baker.make(ClientProfile)
+        editor = baker.make(User)
+        client_role = Role.objects.create(name="Client Editor", is_global=False)
+        perm = Permission.objects.get(
+            codename=ClientProfile.perms.CHANGE.split(".")[1], content_type__app_label="clients"
+        )
+        client_role.permissions.add(perm)
+        grant_create(user=editor, role=client_role, scope_org=self.org_a)
+        stranger = baker.make(User)
+        admin = baker.make(User, is_superuser=True)
+
+        self.assertTrue(can_obj(editor, ClientProfile.perms.CHANGE, client))
+        self.assertFalse(can_obj(stranger, ClientProfile.perms.CHANGE, client))
+        self.assertTrue(can_obj(admin, ClientProfile.perms.CHANGE, client))
+
+    def test_can_obj_fails_closed_for_undeclared_platform_shared(self) -> None:
+        """A platform-shared OrgScoped model with no write_tier: only the global tier acts.
+
+        RFC 0002 §Precondition — the read rule never feeds an undeclared write
+        (finding C1): a finite org-scoped holder is denied; an anywhere/global
+        holder (scopes is ALL) still acts.
+        """
+        from common.models import OrgScoped
+
+        class UndeclaredShared(OrgScoped):
+            org_via = None
+
+            class Meta:
+                app_label = "common"
+                managed = False
+
+        row = UndeclaredShared()  # no DB access in the fail-closed branch
+        scoped = baker.make(User)
+        grant_create(user=scoped, role=self.shelter_role, scope_org=self.org_a)
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+
+        self.assertFalse(can_obj(scoped, Shelter.perms.VIEW, row))
+        self.assertTrue(can_obj(gso, Shelter.perms.VIEW, row))
+
     def test_can_anywhere_holds_for_platform_shared_creates(self) -> None:
         from clients.models import ClientProfile
 

--- a/docs/adr/0001-grant-based-authorization.md
+++ b/docs/adr/0001-grant-based-authorization.md
@@ -392,6 +392,15 @@ subquery, not a re-derivation.
   a stated convention for every child-create service, not per-site.
 - The arm is `OBJECT_ARM_ENABLED = False` until the clients cutover ships (finding F9);
   it is turned on with its first consumer, not before.
+- **Write tiers are in (RFC 0002 §Precondition, 2026-09-09).** `OrgScoped.write_tier`
+  lets a model declare its write scope independently of `org_via` (its read scope):
+  `can_obj` uses the ORG filter for org-anchored models (derived default), a declared
+  SHARED tier for platform-shared models whose writes are shared-by-role-anywhere
+  (`ClientProfile` today — matches `main`), and fails closed for an undeclared
+  platform-shared model (finding C1 default — only the global tier acts until the model
+  declares a tier or an object grant covers the row). `permissions.E007` guards the
+  declarations; the OBJECT tier and the object-grant predicate stay off until the
+  clients cutover turns the arm on with its first consumer.
 - **Object grants are user-principal only (decision).** Sharing is person-granular:
   `Grant(principal_user, role, scope_object)` — authority attaches to a person you can
   audit and revoke. Org-principal object grants (`principal_org` + `scope_object`) are


### PR DESCRIPTION
## Summary

Implements the **RFC 0002 §Precondition** on the grant predicate core: `can_obj` now consults a model's **write tier** independently of `org_via` (its read scope). Read scope and write scope no longer fall out of one declaration. This is the shared prerequisite the object-grant arm and every outreach cutover (clients §5.1, notes §5, tasks/referrals via RFC 0003) inherit — and it is **behavior-preserving today**, because `can_obj` has no production caller yet (verified: only its def + tests).

Stacks on the org-admin stack: `#2443 teams → #2444 reports → #2445 members → #2446 org-admin teardown` → this PR.

### What changes
- **`OrgScoped.write_tier`** (`common/models.py`) + `WRITE_SHARED` / `WRITE_OBJECT` constants. `None` derives the safe default: **ORG** for any org-anchored model (`org_via` not `None`), **fail-closed** for platform-shared.
- **`can_obj` is tier-aware** (`common/permissions/selectors.py`):
  - ORG (derived) → the row filter, unchanged from the pre-tier contract.
  - `WRITE_SHARED` (declared) → `can_anywhere` — any holder of the permission anywhere may act.
  - undeclared platform-shared → **fails closed** (finding C1 / RFC 0002 §Precondition): only the global tier (`scopes` is ALL) acts; the read rule never feeds an undeclared write.
  - Replaces the old "do not route platform-shared writes through this until the C1 fix lands" WARNING with the implemented contract.
- **`ClientProfile` declares `WRITE_SHARED`** (`clients/models.py`, RFC 0002 decision #1) — its CHANGE/DELETE on `main` come from model-level perms on the CASEWORKER group, so the cutover preserves them as "holds the permission anywhere" rather than C1 fail-closed. It is the only `org_via = None` model in the codebase.
- **`permissions.E007`** — only a platform-shared model may declare a tier (org-anchored models derive ORG from their anchor), and `WRITE_OBJECT` stays **reserved** until the object arm turns on with the clients cutover (declaring it today would route writes to a predicate nothing satisfies).
- **ADR 0001 §2.5** — status note recording the write-tier precondition.

### Behavior notes / review focus
- **No authority change on any current surface**: no production code calls `can_obj`; `visible()` (reads) is untouched and still `org_via`-driven; `ClientProfile`'s declared SHARED tier matches what the old fail-open `can_obj` would have returned anyway. This PR is the predicate groundwork, not a cutover.
- **The fail-closed default is the safety property**: any *future* platform-shared model without a declared tier is unwritable by finite org-scoped holders until it declares one (or an object grant covers the row, once the arm ships).
- **OBJECT tier / object-grant predicate / whitelist are deliberately NOT in this PR** — per ADR §2.5 the arm turns on with its first consumer (clients), and E007 refuses `WRITE_OBJECT` until then.

### Test plan
- Full backend suite green (~1760).
- `manage.py check` clean (E007 quiet with `ClientProfile`).
- New unit tests: ORG tier unchanged; SHARED == `can_anywhere` (holder anywhere yes, stranger no, superuser yes); fail-closed default (finite holder denied, global tier allowed); E007 quiet + both error paths.
- `ruff` clean on all touched files.

## Summary by Sourcery

Decouple object write authorization from model read scope while preserving current behavior and establishing safe defaults for future platform-shared write surfaces.

New Features:
- Introduce independent write-tier declarations for models, including shared write access for platform-shared client profiles.

Bug Fixes:
- Make object-level authorization fail closed for platform-shared models without an explicit write tier, preventing read scope from granting unintended write access.

Enhancements:
- Update object permission checks to support organization-scoped, shared, and safe default write behavior independently of read scoping.
- Add validation preventing invalid write-tier declarations and document the write-tier authorization precondition.

Documentation:
- Record the write-tier authorization model and its reserved object-tier status in the authorization ADR.

Tests:
- Add coverage for organization-scoped behavior, shared-tier authorization, fail-closed defaults, and invalid tier declarations.