### PR TITLE
chore(perm): perm-core hygiene — single-source role bundles, drop dead dual state

### DIFF
--- a/apps/betterangels-backend/accounts/groups.py
+++ b/apps/betterangels-backend/accounts/groups.py
@@ -36,39 +36,15 @@ ORG_SUPERUSER = TemplateConfig(
 # member-management surfaces read authority from Grants (``can()``) instead of
 # legacy ``PermissionGroup`` rows.
 #
-# The scoped Roles carry ``teams.*`` + ``reports.view_reports`` +
-# ``organizations.*`` — codenames that resolve to a real model's ContentType
-# (``_resolve_permissions`` binds ``reports.view_reports`` to
-# ``ScheduledReport`` and the member-management portal codenames to the
-# org-root ``Organization`` model).  The bundles mirror the legacy templates
-# exactly — ORG_SUPERUSER = ORG_ADMIN + ``change_org_member_role`` — so a
-# mirrored Grant never amplifies a holder beyond their legacy bundle.  The
-# legacy ``PermissionGroup`` rows are kept (dual write) until reconcile
-# retires them.
-ORG_ADMIN_ROLE = RoleDef(
-    name=ORG_ADMIN.name,
-    permissions=[
-        UserOrganizationPermissions.ACCESS_ORG_PORTAL,
-        UserOrganizationPermissions.ADD_ORG_MEMBER,
-        UserOrganizationPermissions.REMOVE_ORG_MEMBER,
-        UserOrganizationPermissions.VIEW_ORG_MEMBERS,
-        ReportPermissions.VIEW_REPORTS,
-        Team.perms.ADD,
-        Team.perms.CHANGE,
-        Team.perms.DELETE,
-        Team.perms.VIEW,
-    ],
-    is_invitable=ORG_ADMIN.is_invitable,
-)
-
-ORG_SUPERUSER_ROLE = RoleDef(
-    name=ORG_SUPERUSER.name,
-    # The template's bundle verbatim: ORG_ADMIN + ``change_org_member_role``.
-    permissions=[
-        *ORG_ADMIN_ROLE.permissions,
-        UserOrganizationPermissions.CHANGE_ORG_MEMBER_ROLE,
-    ],
-    is_invitable=ORG_SUPERUSER.is_invitable,
-)
+# Each RoleDef is built from its TemplateConfig via ``RoleDef.from_template``
+# so the grant-side bundle is the SAME source as the (now inert) legacy
+# template — ORG_SUPERUSER = ORG_ADMIN + ``change_org_member_role`` — and a
+# mirrored Grant can never drift from, or amplify beyond, the legacy bundle.
+# ``RoleDef.from_template`` copies the permission list, so the two cannot
+# diverge by hand.  (This is deliberate for ORG_ADMIN/ORG_SUPERUSER only:
+# ``CASEWORKER_ROLE`` carries a strict subset of its template — RFC 0003 step
+# 1 — and is defined by hand in notes/groups.py.)
+ORG_ADMIN_ROLE = RoleDef.from_template(ORG_ADMIN)
+ORG_SUPERUSER_ROLE = RoleDef.from_template(ORG_SUPERUSER)
 
 ORG_ADMIN_ROLES: tuple[RoleDef, ...] = (ORG_ADMIN_ROLE, ORG_SUPERUSER_ROLE)

--- a/apps/betterangels-backend/accounts/selectors.py
+++ b/apps/betterangels-backend/accounts/selectors.py
@@ -279,8 +279,9 @@ def organization_effective_permissions(user: User) -> dict[int, list[str]]:
     (house pattern: ``scopes``).
 
     The global fold is DOMAIN-AWARE (:data:`common.permissions.domain.
-    GLOBAL_TIER_ORG_APPS`): only grant-only (and, later, dual) domains treat the
-    global tier as enforceable at any org (``can()``/``scopes()`` return ALL), so
+    GLOBAL_TIER_ORG_APPS`, the grant-only set): only grant-only domains treat
+    the global tier as enforceable at any org (``can()``/``scopes()`` return
+    ALL), so
     only their global permissions fold into an org entry.  Every org-admin
     domain has cut over grant-only (member management ``organizations.*`` on the
     org root, teams, reports, shelters — all in ``LEGACY_INERT_APPS``), so the
@@ -295,7 +296,7 @@ def organization_effective_permissions(user: User) -> dict[int, list[str]]:
     (``organization_permissions``).
 
     The superuser case is therefore NOT short-circuited: a superuser's global
-    list carries every product-modeled permission, but only the grant-only/dual
+    list carries every product-modeled permission, but only the grant-only
     subset folds, and their org-group (legacy) permissions still come from the
     scoped report — so an entry can only claim what ``can()`` or the legacy
     ``organization_permissions`` arm would honor at that org.

--- a/apps/betterangels-backend/accounts/tests/test_template_permissions.py
+++ b/apps/betterangels-backend/accounts/tests/test_template_permissions.py
@@ -151,3 +151,20 @@ def test_retire_superseded_phantom_permissions_holder_with_both_rows() -> None:
     assert not Permission.objects.filter(pk=phantom.pk).exists()
     # Exactly one reference survives, on the real row — no duplicate, no revoke.
     assert list(holder.user_permissions.values_list("pk", flat=True)) == [real.pk]
+
+
+@pytest.mark.django_db
+def test_org_admin_role_bundle_is_the_template_bundle() -> None:
+    """ORG_ADMIN/ORG_SUPERUSER RoleDefs are built from their TemplateConfigs.
+
+    The grant-side bundle is the SAME source as the legacy template (single
+    source of truth, ``RoleDef.from_template``) — a mirrored Grant can never
+    drift from, or amplify beyond, the legacy bundle.  This pins that property
+    so a future hand-edit of one side without the other fails here.
+    """
+    from accounts.groups import ORG_ADMIN, ORG_ADMIN_ROLE, ORG_SUPERUSER, ORG_SUPERUSER_ROLE
+
+    assert list(ORG_ADMIN_ROLE.permissions) == list(ORG_ADMIN.permissions)
+    assert list(ORG_SUPERUSER_ROLE.permissions) == list(ORG_SUPERUSER.permissions)
+    assert ORG_ADMIN_ROLE.is_invitable == ORG_ADMIN.is_invitable
+    assert ORG_SUPERUSER_ROLE.is_invitable == ORG_SUPERUSER.is_invitable

--- a/apps/betterangels-backend/common/permissions/domain.py
+++ b/apps/betterangels-backend/common/permissions/domain.py
@@ -1,43 +1,37 @@
 """Which domains the backend enforces via grants vs legacy (ADR 0001 §4.1).
 
-The per-org permission report and its equivalence tests read THIS to decide (a)
+The per-org permission report and its equivalence tests read this to decide (a)
 whether a legacy ``PermissionGroup`` permission is still real for a domain, and
 (b) whether the domain's GLOBAL tier (superuser / global Role /
 ``user_permissions``) is enforceable at any org — and may therefore be folded
-into effective per-org entries.  During the transition a domain is in one of
-three states:
+into effective per-org entries.  After the org-admin teardown a domain is in
+one of two states:
 
-* legacy-only — enforced via ``PermissionGroup`` (``HasOrgPerm``); grant rows
-  are irrelevant and the global tier is NOT enforceable per org (the predicate
-  reads org ``PermissionGroup`` rows only — never ``user_permissions``,
-  superuser, or global Roles).  Per-org entries may carry these permissions
-  only from the user's org ``PermissionGroup`` rows (the legacy arm).
-* dual — enforced via legacy OR grant (``HasOrgPermOrGrant``, ADR §5.3): the
-  global tier becomes enforceable per org once the grant arm is live.  Empty
-  until PRs #2427-2429.
 * grant-only — enforced via grants (``can()``/``scopes()``); the global tier is
-  enforceable at any org, and legacy rows are INERT and must not be reported
-  (e.g. shelters in #2412).
+  enforceable at any org, and legacy ``PermissionGroup`` rows are INERT: not
+  reported and never consulted for authority.  ``LEGACY_INERT_APPS`` lists
+  these — shelters, teams, reports, and member management (``organizations.*``
+  on the org root).  Every ORG_ADMIN/ORG_SUPERUSER template permission is
+  grant-backed, so the legacy arm is fully redundant for them.
+* legacy-only — enforced via legacy ``PermissionGroup`` rows + guardian (the
+  notes/clients caseworker domains); grant rows are irrelevant and the global
+  tier is NOT enforceable per org.  Per-org entries carry these permissions
+  only from the user's org ``PermissionGroup`` rows (the legacy arm).
 
-``LEGACY_INERT_APPS`` lists the grant-only domains — the only state in which
-legacy permissions must be suppressed from reports.  ``GLOBAL_TIER_ORG_APPS``
-(grant-only ∪ dual) names the domains whose global-tier permissions the
-:func:`accounts.selectors.organization_effective_permissions` fold may include.
-Keep both in step with the ADR §4.1 migration matrix.
+The grant-only set is the single source of truth here — it is what the
+:func:`accounts.selectors.organization_effective_permissions` fold may include
+from the global tier (``GLOBAL_TIER_ORG_APPS`` is that same set, named for what
+it drives).  Keep it in step with the ADR §4.1 migration matrix as domains cut
+over.
 """
 
 #: Grant-only domains — legacy ``PermissionGroup`` rows are inert: not reported
 #: and never consulted for authority.  Shelters, teams, reports, and member
 #: management (organizations.* — bound to the org-root Organization model).
-#: With member management flipped, every ORG_ADMIN/ORG_SUPERUSER template
-#: permission is grant-backed; the legacy arm is fully redundant for them.
 LEGACY_INERT_APPS: frozenset[str] = frozenset({"shelters", "teams", "reports", "organizations"})
 
-#: Dual-read domains (``can()`` OR legacy, ADR §5.3).  Empty: every org-admin
-#: domain has cut over grant-only.  Reserved if a future domain needs a
-#: transitional dual-read state.
-DUAL_APPS: frozenset[str] = frozenset()
-
-#: Domains where the global tier is enforceable at any org (grant-only ∪ dual);
-#: the effective per-org report folds global-tier permissions of these apps.
-GLOBAL_TIER_ORG_APPS: frozenset[str] = LEGACY_INERT_APPS | DUAL_APPS
+#: Domains where the global tier is enforceable at any org — exactly the
+#: grant-only set (the effective per-org report may fold global-tier
+#: permissions of these apps).  Kept as its own name so the fold reads
+#: "GLOBAL_TIER_ORG_APPS" without implying the two could diverge.
+GLOBAL_TIER_ORG_APPS: frozenset[str] = frozenset(LEGACY_INERT_APPS)

--- a/apps/betterangels-backend/docs/graphql_errors.md
+++ b/apps/betterangels-backend/docs/graphql_errors.md
@@ -108,7 +108,7 @@ def _handle_exception(error: Exception):
 | `ERROR`      | `django.core.exceptions.ObjectDoesNotExist`        | Entity lookup fails (e.g., `get_by_pk_or_not_found()` returns nothing). Message is typically `"<ModelName> matching ID <pk> could not be found."`                                                                                                  |
 | `ERROR`      | Any other caught exception                         | Catch-all within the mutation handler. Any unexpected runtime error becomes `kind: ERROR`.                                                                                                                                                         |
 | `PERMISSION` | `django.core.exceptions.PermissionDenied`          | Raised explicitly by service code, or raised when `fail_silently=False` on a permission extension.                                                                                                                                                 |
-| `PERMISSION` | `strawberry_django.permissions.DjangoNoPermission` | Raised by permission extensions (`HasPerm`, `HasRetvalPerm`, `HasOrgPerm`, `IsAuthenticated`) when the user lacks required permissions. Converted to `PermissionDenied` by `handle_no_permission()`, which creates `PERMISSION` messages directly. |
+| `PERMISSION` | `strawberry_django.permissions.DjangoNoPermission` | Raised by permission extensions (`HasPerm`, `HasRetvalPerm`, `IsAuthenticated`) when the user lacks required permissions. Converted to `PermissionDenied` by `handle_no_permission()`, which creates `PERMISSION` messages directly. |
 | `INFO`       | —                                                  | **Never auto-generated.** Not used anywhere in BetterAngels. Would require a mutation to manually return `OperationInfo(messages=[OperationMessage(kind=INFO, ...)])`.                                                                             |
 | `WARNING`    | —                                                  | **Never auto-generated.** Same as `INFO` — not used in BetterAngels.                                                                                                                                                                               |
 
@@ -124,13 +124,13 @@ Understanding when `OperationMessage.field` is `null` vs. a string is critical f
 | `VALIDATION`       | ❌ Sometimes       | **No** when the `ValidationError` has an `error_list` (non-field / global errors). These are form-level errors like "The entire form is invalid" with no single field to blame.                                                                                                                                                                                          |
 | `ERROR`            | ❌ Never           | `ObjectDoesNotExist` and catch-all exceptions go through the `else` branch — `field` is never passed, always defaults to `null`.                                                                                                                                                                                                                                         |
 | `PERMISSION`       | ❌ Usually not     | When flowing through `_handle_exception` (the `PermissionDenied` → `_get_validation_errors` path), `field` is `null`.                                                                                                                                                                                                                                                    |
-| `PERMISSION`       | ✅ Sometimes       | When flowing through the **separate** `handle_no_permission()` path in `strawberry_django/permissions.py`, `field` is set to `info.field_name` (the GraphQL field name). This happens when `fail_silently=True` and the return type union includes `OperationInfo`. This path is **not commonly hit** in BetterAngels since `HasOrgPerm` defaults `fail_silently=False`. |
+| `PERMISSION`       | ✅ Sometimes       | When flowing through the **separate** `handle_no_permission()` path in `strawberry_django/permissions.py`, `field` is set to `info.field_name` (the GraphQL field name). This happens when `fail_silently=True` and the return type union includes `OperationInfo` — the case for the built-in `HasPerm`/`HasRetvalPerm` guards on notes/clients mutations. |
 | `INFO` / `WARNING` | ❌ Never           | These are never auto-generated. If manually created, `field` defaults to `null` unless explicitly set.                                                                                                                                                                                                                                                                   |
 
 **In practice for BetterAngels:**
 
 - `ERROR` messages never have `field` set
-- `PERMISSION` messages from `HasOrgPerm` (which uses `fail_silently=False`) flow through `_handle_exception` and have `field: null`
+- `PERMISSION` messages from resolver-level guards (`require_can()` raising `PermissionDenied`) flow through `_handle_exception` and have `field: null`
 - Non-field `VALIDATION` messages have `field: null`
 
 ---
@@ -154,16 +154,16 @@ In addition to the mutation-level `_handle_exception`, Strawberry's permission e
 1. The extension raises `DjangoNoPermission`.
 2. `DjangoPermissionExtension.resolve()` catches it and calls `handle_no_permission()`.
 3. `handle_no_permission()` checks if the return type union includes `OperationInfo`. If so, it returns an `OperationInfo` with a `PERMISSION` message directly (bypassing `_handle_exception`). The `field` is set to `info.field_name` — the name of the GraphQL mutation field.
-4. If `fail_silently=False` (the **default** for `HasOrgPerm` in BetterAngels, set in `accounts/extensions.py`), it instead raises `PermissionDenied`, which flows into `_handle_exception` and produces `kind: PERMISSION` with `field: null`.
+4. If `fail_silently=False`, it instead raises `PermissionDenied`, which flows into `_handle_exception` and produces `kind: PERMISSION` with `field: null` — the path BetterAngels' resolver-level `require_can()` guards take.
 
 #### Permission extensions used in BetterAngels
 
-| Extension         | Defined in                     | Used for                                                   | `fail_silently` default   |
-| ----------------- | ------------------------------ | ---------------------------------------------------------- | ------------------------- |
-| `HasOrgPerm`      | `accounts/extensions.py`       | Org-scoped mutations (teams, reports, org member management) | `False`                   |
-| `HasRetvalPerm`   | `strawberry_django` (built-in) | Object-level mutations (notes, tasks, referrals)           | `True` (built-in default) |
-| `HasPerm`         | `strawberry_django` (built-in) | Create mutations (clients, documents)                      | `True` (built-in default) |
-| `IsAuthenticated` | `strawberry_django` (built-in) | All mutations                                              | `True` (built-in default) |
+| Extension         | Defined in                                 | Used for                                                   | `fail_silently` default   |
+| ----------------- | ------------------------------------------ | ---------------------------------------------------------- | ------------------------- |
+| `require_can()`   | `common/permissions/utils.py` (not an extension — a resolver guard) | Org-scoped writes (teams, reports, member management, shelters) | n/a — raises `PermissionDenied` |
+| `HasRetvalPerm`   | `strawberry_django` (built-in)             | Object-level mutations (notes, tasks, referrals)           | `True` (built-in default) |
+| `HasPerm`         | `strawberry_django` (built-in)             | Create mutations (clients, documents)                      | `True` (built-in default) |
+| `IsAuthenticated` | `common/permissions/utils.py` (BetterAngels override) | All mutations; raises `UnauthenticatedGQLError` when anonymous | n/a                       |
 
 ---
 
@@ -312,7 +312,7 @@ Every exception type used in the BetterAngels backend, the error path each takes
 | `ValidationError`         | `django.core.exceptions`                    | Model `full_clean()`, strawberry-django create/update resolvers                                                 | ✅ Yes (→ `OperationInfo`, `kind: VALIDATION`) | Contains `OperationInfo`                        | —                                                                       |
 | `ObjectDoesNotExist`      | `django.core.exceptions`                    | `get_by_pk_or_not_found()`, `.get()` on scoped querysets                                                        | ✅ Yes (→ `OperationInfo`, `kind: ERROR`)      | Contains `OperationInfo`                        | —                                                                       |
 | `PermissionDenied`        | `django.core.exceptions`                    | `accounts/schema.py`, `referrals/schema.py`, `tasks/schema.py`, `hmis/api_bridge.py`, `common/graphql/utils.py` | ✅ Yes (→ `OperationInfo`, `kind: PERMISSION`) | Contains `OperationInfo`                        | —                                                                       |
-| `DjangoNoPermission`      | `strawberry_django.permissions`             | Permission extensions (`HasPerm`, `HasRetvalPerm`, `HasOrgPerm`, `IsAuthenticated`)                             | ❌ No — caught by `handle_no_permission()`     | Contains `OperationInfo` (if union supports it) | —                                                                       |
+| `DjangoNoPermission`      | `strawberry_django.permissions`             | Permission extensions (`HasPerm`, `HasRetvalPerm`, `IsAuthenticated`)                                          | ❌ No — caught by `handle_no_permission()`     | Contains `OperationInfo` (if union supports it) | —                                                                       |
 | `GraphQLError`            | `graphql-core`                              | `clients/schema.py`, `hmis/api_bridge.py`                                                                       | ❌ No                                          | `null`                                          | `{message, extensions: {errors: [...]}}`                                |
 | `UnauthenticatedGQLError` | `common/errors.py` (extends `GraphQLError`) | `common/permissions/utils.py` (`IsAuthenticated`), `hmis/api_bridge.py` (401)                                   | ❌ No                                          | `null`                                          | `{message, extensions: {code: "UNAUTHENTICATED", http: {status: 401}}}` |
 | `NotFoundGQLError`        | `common/errors.py` (extends `GraphQLError`) | `hmis/api_bridge.py` only (404)                                                                                 | ❌ No                                          | `null`                                          | `{message, extensions: {code: "NOT_FOUND", http: {status: 404}}}`       |
@@ -342,7 +342,8 @@ The `_handle_error_response` method maps upstream HTTP status codes to exception
 | `strawberry_django/fields/types.py`                      | Defines `OperationInfo`, `OperationMessage`, `OperationMessage.Kind`                              |
 | `strawberry_django/mutations/fields.py`                  | `_get_validation_errors()`, `_handle_exception()`, `DjangoMutationBase.get_result()`              |
 | `strawberry_django/permissions.py`                       | `DjangoPermissionExtension.handle_no_permission()`, `HasPerm`, `HasRetvalPerm`, `IsAuthenticated` |
-| `apps/betterangels-backend/accounts/extensions.py`       | `HasOrgPerm` — BetterAngels' org-scoped permission extension                                      |
+| `apps/betterangels-backend/common/permissions/selectors.py` | `can()` / `scopes()` / `visible()` — grant authority                                                                    |
+| `apps/betterangels-backend/common/permissions/utils.py`   | `require_can()`, `IsAuthenticated` (override), `PERMISSION_DENIED_MESSAGE`                        |
 | `apps/betterangels-backend/common/graphql/extensions.py` | `PermissionedQuerySet` — injects permission-filtered querysets                                    |
 | `apps/betterangels-backend/common/errors.py`             | `UnauthenticatedGQLError`, `NotFoundGQLError` — reusable `GraphQLError` subclasses                |
 | `apps/betterangels-backend/clients/schema.py`            | `validate_client_profile_data()` — custom validation raising `GraphQLError`                       |

--- a/apps/betterangels-backend/docs/permissions.md
+++ b/apps/betterangels-backend/docs/permissions.md
@@ -2,67 +2,48 @@
 
 ## Two-Layer Model
 
-BetterAngels uses a **two-layer permission model** — org-scoped permissions gate access at the organization level, and object-level permissions (via django-guardian) provide fine-grained per-object access control.
+BetterAngels uses a **two-layer permission model** — org-scoped authority gates access at the organization level, and object-level permissions provide fine-grained per-object access control.
 
-| Layer            | Mechanism                                          | Scope                                               | Used for                                            |
-| ---------------- | -------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------- |
-| **Org-scoped**   | `HasOrgPerm` extension + `permissioned_queryset()` | "Can this user perform action X in organization Y?" | Mutations, operator queries (shelters, rooms, beds) |
-| **Object-level** | django-guardian + `HasRetvalPerm`                  | "Can this user access this specific object?"        | Notes, tasks, referrals, client documents           |
+| Layer            | Mechanism                                                        | Scope                                               | Used for                                            |
+| ---------------- | ---------------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------- |
+| **Org-scoped**   | Grants: `can()` / `require_can()` / `scopes()` / `visible()`     | "Can this user perform action X in organization Y?" | Teams, reports, member management, shelters, operator queries |
+| **Object-level** | django-guardian + `HasRetvalPerm` (grant object arm in progress) | "Can this user access this specific object?"        | Notes, tasks, referrals, client documents           |
 
-Both layers are backed by Django's permission system (Groups + Permissions), but they ask different questions and are checked independently.
+Both layers sit on Django's permission primitives, but they ask different questions and are checked independently.  **ADR 0001 is the source of truth** for the target model — this page describes the current backend wiring.
 
-## How Org-Scoped Permissions Work
+## How Org-Scoped Authority Works
 
-### Header-based organization context
+### Where the org comes from
 
-A custom `OrganizationMiddleware` (in `common/middleware/organization.py`) reads the `X-Organization-ID` header from incoming requests and sets `request.organization_id`. This value is the canonical source of "which organization are we operating in?" for every request.
+Prefer the **payload**: query filters and mutation inputs carry the organization (`TeamFilter.organizationId`, `CreateTeamInput.organizationId`), and row-scoped mutations derive it from the row they name.  The `X-Organization-ID` header (set by `OrganizationMiddleware` in `common/middleware/organization.py`) survives in exactly one place — the *teams list read* keeps it as a deprecated fallback so mobile's `useOrgTeams` callers (still sending only `{ isActive }`) keep working until they pass `organizationId` (DEV-2566).  Every other cut-over surface is header-free.
 
-### `HasOrgPerm` — the gatekeeper
+### Grants — the authority
 
-`accounts/extensions.py` defines a `HasOrgPerm` Strawberry extension that replaces the old `@HasPerm(global)` + `get_user_permitted_org()` pattern:
+`OrgRoleManager` (`accounts/role_manager.py`) is the mechanical add/remove/clear/replace API for org roles:
 
-```python
-@strawberry_django.mutation(
-    permission_classes=[IsAuthenticated],
-    extensions=[HasOrgPerm(Shelter.perms.ADD)],
-)
-def create_shelter(self, info, data):
-    ...
-```
+- A **`Role`** carries the permission bundle; org-scoped roles are built from a `TemplateConfig` via `RoleDef.from_template()` (e.g. `ORG_ADMIN_ROLE` in `accounts/groups.py`), so the grant bundle cannot drift from the template.
+- A **`Grant`** binds a `principal` (user) to a `Role` at a `scope` (org) — and on the object arm, optionally to a specific row.
+- Dual-write templates keep their legacy `PermissionGroup` membership, and the `User.groups` m2m edge mirrors it to a `Grant` (`accounts/signals.py`) so every writer — the role manager, Django admin, scripts — stays consistent.  `legacy_inert` templates (ORG_ADMIN / ORG_SUPERUSER, whose apps are all in `LEGACY_INERT_APPS`) are grant-only: no `PermissionGroup` row is created, assigned, or consulted.
 
-How it validates:
+### Checking authority
 
-1. Reads `info.context.request.organization_id` (set by middleware).
-2. If `None`, raises `DjangoNoPermission` immediately.
-3. Delegates to `permissioned_queryset(Organization.objects.all(), ...)` with `organization_field="pk"` — checking that the user belongs to the org AND holds the required permission(s) via their `PermissionGroup` → `Group` → `Permission` chain.
-4. Fails fast with `fail_silently=False` (default).
+`common/permissions/selectors.py`:
 
-### `permissioned_queryset()` — single source of truth
+- `can(user, perm, org=…)` — does the user hold the permission at the org?
+- `scopes(user, perm)` — the orgs where the user holds it (finite list).
+- `visible(qs, perm, …)` / `can_obj(user, perm, obj)` — the object arm: filter/check rows by grant (guardian fallback while domains migrate).
+- `switchable_orgs(user)` — the finite org set the frontend may switch into.
 
-`common/permissions/utils.py` provides `permissioned_queryset(qs, *, user, organization_id, perms=None, any_perm=True, organization_field="organization_id")`:
+`common/permissions/utils.py`:
 
-- Filters `qs` to records in `organization_id`.
-- If `perms` is `None`, only checks org membership (user belongs to org).
-- If `perms` is provided, also verifies the user holds those permissions through their org's `PermissionGroup` → `Group` → `Permission` chain.
-- `organization_field` controls the FK path: use `"organization_id"` for direct-FK models (Shelter), `"shelter__organization_id"` for indirect (Bed, Room), or `"pk"` for Organization itself.
+- `require_can(user, perm, org=…)` — the write gate: raises `PermissionDenied(PERMISSION_DENIED_MESSAGE)` when `can()` is false.  Creates carry an explicit target org and are authorized by `can()`; `can()` never implies the org exists, so resolvers validate the org first (the `_org_or_deny` pattern).
+- `IsAuthenticated` — the custom strawberry permission class (raises `UnauthenticatedGQLError`).
 
-This single function is shared by:
-
-- **`HasOrgPerm.resolve_for_user`** — permission validation at the GraphQL extension level.
-- **`shelter_queryset` / `room_queryset` / `bed_queryset`** — selector wrappers that scope list queries and entity lookups.
-- **`OperatorShelterType.get_queryset`** — the `strawberry_django` type hook that scopes returned data.
-
-### `_perm_q()` — reusable ORM permission path
-
-`common/permissions/utils.py` provides `_perm_q(app_label, codename, *, prefix="permission_groups__group__permissions")`:
-
-- Default `prefix` resolves `Organization` → `PermissionGroup` → `Group` → `Permission` → `ContentType`.
-- Pass `prefix="group__permissions"` when querying `PermissionGroup` directly (e.g., in `permission_annotations()`).
-- Used by `HasOrgPerm`, `permission_annotations()`, and `get_user_permitted_org()`.
+The old `HasOrgPerm` extension and the `permissioned_queryset()` / `perm_filter()` / `_perm_q()` helpers are **deleted** — org-scoped surfaces authorize through the selectors above.
 
 ## Overview
 
-Permission group templates define a **set of Django permissions** that can be assigned to users within an organization. A user's effective permissions are the **union of all templates** assigned to them for that org.
+Permission group templates define a **set of Django permissions** that can be assigned to users within an organization. A user's effective authority is the **union of the roles/Grants** they hold at that org — the template defines the bundle (mirrored by `RoleDef.from_template()`), and cut-over domains read the `Grant` arm while legacy-only domains (notes/clients) still read the template-backed `PermissionGroup` rows.
 
 This composable model means you never need a single monolithic role — you combine templates to build the desired access level.
 
@@ -72,12 +53,12 @@ Each `OrgTypeConfig` exposes a `member_template` field that identifies the defau
 
 ### Organization (app-agnostic)
 
-| Template                   | Config source        | Permissions                                                                                              |
-| -------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------- |
-| **Organization Superuser** | `accounts/groups.py` | `ACCESS_ORG_PORTAL`, `ADD_ORG_MEMBER`, `CHANGE_ORG_MEMBER_ROLE`, `REMOVE_ORG_MEMBER`, `VIEW_ORG_MEMBERS` |
-| **Organization Admin**     | `accounts/groups.py` | `ACCESS_ORG_PORTAL`, `ADD_ORG_MEMBER`, `REMOVE_ORG_MEMBER`, `VIEW_ORG_MEMBERS`                           |
+| Template                   | Config source        | Permissions                                                                                                                    |
+| -------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Organization Superuser** | `accounts/groups.py` | Org Admin bundle + `CHANGE_ORG_MEMBER_ROLE`                                                                                    |
+| **Organization Admin**     | `accounts/groups.py` | `ACCESS_ORG_PORTAL`, `ADD_ORG_MEMBER`, `REMOVE_ORG_MEMBER`, `VIEW_ORG_MEMBERS`, `reports.view_reports`, `teams.add/change/delete/view` |
 
-Both use the `UserOrganizationPermissions` enum directly — org-level permissions are not tied to a specific model's `model.perms`.
+Both use the `UserOrganizationPermissions` enum directly for the org-level codenames — org-level permissions are not tied to a specific model's `model.perms`.  Both are also `legacy_inert=True`: role-backed (`ORG_ADMIN_ROLE` / `ORG_SUPERUSER_ROLE`, built via `RoleDef.from_template`) and **grant-only** — no `PermissionGroup` row is created, assigned, or consulted (ADR 0001 §5.3).
 
 ### Outreach
 
@@ -133,7 +114,7 @@ Each `groups.py` imports `TemplateConfig` and defines one or more template confi
 ### Permission sources
 
 - **Django model CRUD**: `model.perms.ADD`, `model.perms.CHANGE`, etc. — auto-generated by `PermissionSet` via `BaseModel`
-- **GraphQL domain perms**: `UserOrganizationPermissions` enum (`@strawberry.enum`), resolved via `GrantedPermissions` factory
+- **GraphQL domain perms**: enums marked `@register_permission` (e.g. `UserOrganizationPermissions` in `accounts/permissions.py`, `ReportPermissions` in `reports/permissions.py`) — registered in `common/permissions/utils.py` for frontend codegen
 
 ### Template ↔ permission binding
 
@@ -141,31 +122,30 @@ Each `groups.py` imports `TemplateConfig` and defines one or more template confi
 
 ## Key Files
 
-| File                                | Purpose                                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------------------- |
-| `common/permissions/utils.py`       | `permissioned_queryset()`, `_perm_q()`, `PermissionSet`, `get_current_organization()` |
-| `accounts/extensions.py`            | `HasOrgPerm` Strawberry extension                                                     |
-| `accounts/permissions.py`           | `get_user_permitted_org()`, `permission_annotations()`, `GrantedPermissions` factory  |
-| `common/middleware/organization.py` | `OrganizationMiddleware` — sets `request.organization_id`                             |
-| `shelters/selectors/operator.py`    | `shelter_queryset`, `room_queryset`, `bed_queryset` wrappers; `_get` selectors        |
-| `shelters/selectors/reports.py`     | Report aggregation functions                                                          |
-| `shelters/selectors/__init__.py`    | Re-exports from operator.py and reports.py                                            |
-| `shelters/open_at.py`               | `shelters_open_at` helper (extracted from models to break circular imports)           |
-| `shelters/schema.py`                | GraphQL Query/Mutation — thin layer delegating to services + `HasOrgPerm`             |
-| `shelters/services/`                | Business logic (shelter/room/bed create/update/delete/clone)                          |
-| `shelters/types/outputs.py`         | `OperatorShelterType` with `get_queryset` hook                                        |
+| File                                | Purpose                                                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `common/permissions/selectors.py`   | `can()`, `scopes()`, `visible()`, `can_obj()`, `switchable_orgs()` — grant authority                  |
+| `common/permissions/utils.py`       | `require_can()`, `IsAuthenticated`, `register_permission()`, `PERMISSION_DENIED_MESSAGE`              |
+| `common/permissions/config.py`      | `TemplateConfig`, `RoleDef` (incl. `from_template()`)                                                 |
+| `common/permissions/domain.py`      | `LEGACY_INERT_APPS` / `GLOBAL_TIER_ORG_APPS` — which domains are grant-only                           |
+| `accounts/groups.py`                | `ORG_ADMIN` / `ORG_SUPERUSER` templates + role definitions                                            |
+| `accounts/role_manager.py`          | `OrgRoleManager` — add/remove/clear/replace org roles; grant-only mirroring for `legacy_inert` roles  |
+| `accounts/signals.py`               | `User.groups` m2m edge — mirrors dual-write memberships to `Grant` rows                               |
+| `accounts/permissions.py`           | `UserOrganizationPermissions` enum + Django-admin-only `OrganizationAdminPermissions`                 |
+| `common/middleware/organization.py` | `OrganizationMiddleware` — kept only for the teams-read fallback (strip = DEV-2566)                   |
+| `shelters/selectors/operator.py`    | `shelter_queryset`, `room_queryset`, `bed_queryset` wrappers; `_get` selectors                        |
+| `shelters/selectors/reports.py`     | Report aggregation functions                                                                          |
+| `shelters/selectors/__init__.py`    | Re-exports from operator.py and reports.py                                                            |
+| `shelters/open_at.py`               | `shelters_open_at` helper (extracted from models to break circular imports)                           |
+| `shelters/schema.py`                | GraphQL Query/Mutation — thin layer delegating to services + `require_can()`                          |
+| `shelters/services/`                | Business logic (shelter/room/bed create/update/delete/clone)                                          |
+| `shelters/types/outputs.py`         | `OperatorShelterType` with `get_queryset` hook                                                        |
 
 ## Testing
 
-`accounts/tests/test_extensions.py::HasOrgPermTestCase` tests the `HasOrgPerm` extension in isolation (no GraphQL round-trips), covering:
+Grant authority is pinned per domain in `tests/test_grant_authorization.py` (teams, reports, member management, clients): scoped Grant holders pass, stale legacy-only holders are denied, cross-org grants are denied, and the global tier applies only where `GLOBAL_TIER_ORG_APPS` says so.  The org-admin backfill conversions are covered in `accounts/tests/test_roles.py`.
 
-- Happy path (valid org + permission)
-- Missing `X-Organization-ID` header
-- User not a member of the organization
-- User is a member but lacks the required permission
-- Unauthenticated user
-
-`GraphQLBaseTestCase` (`common/tests/utils.py`) provides `execute_graphql()` which accepts `**extra` kwargs (e.g., `HTTP_X_ORGANIZATION_ID=str(org_id)`) forwarded to Django's test client for header-based testing.
+`GraphQLBaseTestCase` (`common/tests/utils.py`) provides `execute_graphql()` plus `_set_active_org()` — the latter feeds the deprecated `X-Organization-ID` fallback that the teams-read tests still pin until DEV-2566.
 
 ## Adding templates or permissions
 
@@ -191,5 +171,5 @@ The frontend `hasPermission()` helper checks across all domains with O(1) lookup
 
 - `accounts/group_names.py` contains `GroupTemplateNames` — a registry of template name strings. This enum is intentionally thin and may eventually be replaced by each app registering its own names independently, removing the need for `accounts` to know about downstream apps.
 - `shelters/permissions.py` is a 3-line bridge that delegates to `Shelter.perms.as_text_choices()` for GraphQL schema generation — `model.perms` is the single source of truth.
-- The old `AdminShelterManager`/`AdminShelterQuerySet` and `Shelter.admin_objects` manager were removed — they've been replaced by `permissioned_queryset()` + selectors + `HasOrgPerm`, which provide the same org-scoping in a single, shared function.
+- The old `AdminShelterManager`/`AdminShelterQuerySet` and `Shelter.admin_objects` manager were removed — org-scoping now lives in the per-domain selectors (`visible()` / `can()` on the grant arm, with guardian fallback while domains migrate) and `require_can()` at the write boundary.
 - The `adminShelters`/`adminShelter` GraphQL queries have been renamed to `operatorShelters`/`operatorShelter` and `AdminShelterType` → `OperatorShelterType` to reflect their role as operator-facing endpoints.


### PR DESCRIPTION
## Summary

Architecture/hygiene pass over the grant-based permission core (ADR 0001). **Zero behavior change** — the role/domain contract is byte-identical; only the declaration and documentation are tightened. Stacks on the org-admin stack (#2443 teams → #2444 reports → #2445 members → #2446 teardown → #2447 write tiers).

### What changes

1. **Single source of truth for the org-admin role bundles** (`accounts/groups.py`)
   - `ORG_ADMIN_ROLE` / `ORG_SUPERUSER_ROLE` are now built via `RoleDef.from_template(ORG_ADMIN / ORG_SUPERUSER)` — the same pattern shelters already use — instead of hand-duplicated `ORG_ADMIN_ROLE_PERMISSIONS` / `ORG_SUPERUSER_ROLE_PERMISSIONS` lists.
   - Why it matters: the grant-side bundle and the legacy template must mirror **exactly** (a mirrored Grant must never amplify beyond the legacy bundle). Two hand-maintained lists were the strongest latent drift risk in the model — a future edit to one side silently widening or narrowing authority. `from_template` makes divergence impossible.
   - `CASEWORKER_ROLE` stays hand-defined deliberately (a strict RFC 0003 subset) — the comment now says why.

2. **Dead transitional state removed** (`common/permissions/domain.py`)
   - `DUAL_APPS` (empty since the org-admin cutover completed) is deleted; `GLOBAL_TIER_ORG_APPS` is now `frozenset(LEGACY_INERT_APPS)` (same value, kept as its own name for the fold's readability).
   - Module docstring rewritten to the two states that actually exist (grant-only in `LEGACY_INERT_APPS` / legacy-only notes-clients) — removing stale references to the deleted `HasOrgPerm`/`HasOrgPermOrGrant` and long-closed PR numbers.

3. **Doc drift** — the `organization_effective_permissions` fold docstring no longer references the retired "dual" transitional state.

4. **Drift guard test** — pins `ORG_ADMIN_ROLE.permissions == ORG_ADMIN.permissions` (and superuser) so a future hand-edit of one side without the other fails CI.

### Review focus
- Confirm the org-admin `RoleDef.from_template` conversion is byte-identical to the old manual `RoleDef`s (name, permission list order, `is_invitable=False`) — the targeted + full suites assert this.
- `GLOBAL_TIER_ORG_APPS` value is unchanged (it was `LEGACY_INERT_APPS | frozenset()`); only `DUAL_APPS` and stale docs are gone.

### Test plan
- Full backend suite green (~1765).
- New no-drift guard test green; `manage.py check` clean; `ruff` clean.

Deferred (noted, not done — too much import churn across five stacked PRs): splitting `common/permissions/utils.py` (permission-catalog registry vs runtime predicates) into separate modules.

## Summary by Sourcery

Consolidate organization role definitions and permission-domain metadata around the current grant-based model without changing authorization behavior.

Enhancements:
- Build the organization admin and superuser grant roles directly from their template bundles to maintain a single source of truth.
- Remove the obsolete dual permission state and simplify domain enforcement to the remaining grant-only and legacy-only states.
- Update permission documentation to reflect the current grant-based authorization model and retired permission paths.

Documentation:
- Refresh GraphQL error and permission documentation to remove retired org-permission extensions and describe current grant authorization flows.

Tests:
- Add a guard test ensuring organization admin and superuser role bundles remain identical to their templates.

Chores:
- Preserve the existing global-tier domain set while removing the unused transitional state and stale references.