### PR TITLE
test(perm): shared helpers for legacy-only holders & grantless members

### DIFF
--- a/apps/betterangels-backend/accounts/tests/test_member_management_grant_authorization.py
+++ b/apps/betterangels-backend/accounts/tests/test_member_management_grant_authorization.py
@@ -25,11 +25,11 @@ These tests pin the flipped contract:
 from typing import Any
 
 from accounts.groups import ORG_ADMIN, ORG_SUPERUSER
-from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, User
+from accounts.models import PermissionGroup, User
 from accounts.role_manager import OrgRoleManager
 from accounts.services import sync_roles
 from accounts.types import PermissionTemplateEnum
-from common.tests.utils import GraphQLBaseTestCase
+from common.tests.utils import GraphQLBaseTestCase, make_legacy_only_holder
 from django.contrib.auth.models import Group
 from model_bakery import baker
 from notes.groups import CASEWORKER
@@ -311,16 +311,13 @@ class MemberManagementGrantAuthorityDeniedTestCase(GraphQLBaseTestCase, MemberMa
         stale leftover row; even if one exists it confers no member-management
         authority.
         """
-        legacy_admin = baker.make(User, email="legacy-admin@example.com")
+        legacy_admin = make_legacy_only_holder(
+            user=baker.make(User, email="legacy-admin@example.com"),
+            organization=self.org_1,
+            template_name=ORG_ADMIN.name,
+        )
         removable = baker.make(User, email="removable@example.com")
-        self.org_1.add_user(legacy_admin)
         self.org_1.add_user(removable)
-        template, _ = PermissionGroupTemplate.objects.get_or_create(name=ORG_ADMIN.name)
-        group, _ = PermissionGroup.objects.get_or_create(organization=self.org_1, template=template)
-        group.user_set.add(legacy_admin)
-        # Direct membership mirrors a Grant at the m2m edge now; a pre-cutover
-        # legacy-only holder has none — drop the mirror to model that state.
-        Grant.objects.filter(principal_user=legacy_admin).delete()
         self.assertFalse(legacy_admin.grants.filter(scope_org=self.org_1).exists())
 
         response = self._view_members(legacy_admin, self.org_1)

--- a/apps/betterangels-backend/accounts/tests/test_permission_group.py
+++ b/apps/betterangels-backend/accounts/tests/test_permission_group.py
@@ -2,6 +2,7 @@ from accounts.models import BigGroupObjectPermission, PermissionGroup, Permissio
 from accounts.seed import sync_group_permissions
 from accounts.services import reconcile_org_groups
 from common.permissions.utils import assign_object_permissions
+from common.tests.utils import make_permission_group
 from django.contrib.auth.models import Group, Permission
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
@@ -30,9 +31,8 @@ class PermissionGroupTestCase(TestCase):
     def test_a_long_organization_name_is_truncated_to_fit(self) -> None:
         """``Organization.name`` allows 200 characters, ``auth.Group.name`` 150."""
         organization = Organization.objects.create(name="L" * 200)
-        template, _ = PermissionGroupTemplate.objects.get_or_create(name=CASEWORKER.name)
 
-        permission_group = PermissionGroup.objects.create(organization=organization, template=template)
+        permission_group = make_permission_group(organization=organization, template_name=CASEWORKER.name)
 
         self.assertLessEqual(len(permission_group.name), 150)
         self.assertTrue(permission_group.name.endswith(f"[{organization.pk}] · {CASEWORKER.name}"))
@@ -40,10 +40,9 @@ class PermissionGroupTestCase(TestCase):
     def test_two_organizations_may_share_a_name(self) -> None:
         first = Organization.objects.create(name="Acme")
         second = Organization.objects.create(name="Acme")
-        template, _ = PermissionGroupTemplate.objects.get_or_create(name=CASEWORKER.name)
 
-        first_group = PermissionGroup.objects.create(organization=first, template=template)
-        second_group = PermissionGroup.objects.create(organization=second, template=template)
+        first_group = make_permission_group(organization=first, template_name=CASEWORKER.name)
+        second_group = make_permission_group(organization=second, template_name=CASEWORKER.name)
 
         self.assertNotEqual(first_group.name, second_group.name)
 

--- a/apps/betterangels-backend/accounts/tests/test_role_manager_grants.py
+++ b/apps/betterangels-backend/accounts/tests/test_role_manager_grants.py
@@ -9,9 +9,10 @@ not just ``OrgRoleManager``.
 
 from typing import Any
 
-from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, Role, User
+from accounts.models import Grant, PermissionGroup, Role, User
 from accounts.role_manager import OrgRoleManager
 from common.permissions.config import TemplateConfig
+from common.tests.utils import make_permission_group
 from django.test import TestCase
 from model_bakery import baker
 from notes.groups import CASEWORKER
@@ -36,8 +37,7 @@ class OrgRoleManagerDualWriteTestCase(TestCase):
 
     def _ensure_not_role_backed_group(self) -> None:
         """Create a PermissionGroup for the test-only template."""
-        template, _ = PermissionGroupTemplate.objects.get_or_create(name=NOT_ROLE_BACKED.name)
-        PermissionGroup.objects.get_or_create(organization=self.org, template=template)
+        make_permission_group(organization=self.org, template_name=NOT_ROLE_BACKED.name)
 
     def _shelter_operator_role(self) -> Role:
         return Role.objects.get(name=SHELTER_OPERATOR.name, is_global=False)

--- a/apps/betterangels-backend/accounts/tests/test_roles.py
+++ b/apps/betterangels-backend/accounts/tests/test_roles.py
@@ -21,17 +21,7 @@ from notes.models import Note
 from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
 
 from accounts.groups import ORG_ADMIN_ROLE
-
-
-def _add_legacy_membership(group: PermissionGroup, member: User) -> None:
-    """Give *member* the legacy group membership, without the Grant mirror.
-
-    The m2m edge mirrors a Grant for role-backed groups (``accounts.signals``),
-    but a pre-cutover membership — the state a backfill exists to convert — has
-    none, so drop the mirror the add just created.
-    """
-    group.user_set.add(member)
-    Grant.objects.filter(principal_user=member).delete()
+from common.tests.utils import add_legacy_membership, make_permission_group
 
 
 class SyncRolesTestCase(TestCase):
@@ -131,7 +121,7 @@ class BackfillTestCase(TestCase):
     def test_backfill_shelter_grants_creates_one_grant_per_member(self) -> None:
         group = PermissionGroup.objects.get(organization=self.org, template__name=SHELTER_OPERATOR_ROLE.name)
         member = baker.make(User)
-        _add_legacy_membership(group, member)
+        add_legacy_membership(member, group=group)
 
         backfill_shelter_grants()
 
@@ -141,7 +131,7 @@ class BackfillTestCase(TestCase):
     def test_backfill_shelter_grants_is_idempotent(self) -> None:
         group = PermissionGroup.objects.get(organization=self.org, template__name=SHELTER_OPERATOR_ROLE.name)
         member = baker.make(User)
-        _add_legacy_membership(group, member)
+        add_legacy_membership(member, group=group)
 
         backfill_shelter_grants()
         backfill_shelter_grants()
@@ -187,21 +177,11 @@ class OrgAdminAndCaseworkerBackfillTestCase(TestCase):
         self.org_admin_role = Role.objects.get(name=ORG_ADMIN_ROLE.name)
         self.caseworker_role = Role.objects.get(name=CASEWORKER_ROLE.name)
 
-    def _legacy_org_admin_group(self) -> PermissionGroup:
-        """A leftover pre-teardown ORG_ADMIN row — none is provisioned now.
-
-        The org-admin roles are grant-only (ADR 0001 teardown) and
-        ``reconcile_org_groups`` retires their ``PermissionGroup`` rows, so a
-        migration test has to recreate the row the backfill exists to convert.
-        """
-        template, _ = PermissionGroupTemplate.objects.get_or_create(name=ORG_ADMIN_ROLE.name)
-        group, _ = PermissionGroup.objects.get_or_create(organization=self.org, template=template)
-        return group
-
     def test_backfill_org_admin_grants_creates_one_grant_per_member(self) -> None:
-        group = self._legacy_org_admin_group()
+        # A leftover pre-teardown ORG_ADMIN row — none is provisioned now.
+        group = make_permission_group(organization=self.org, template_name=ORG_ADMIN_ROLE.name)
         member = baker.make(User)
-        _add_legacy_membership(group, member)
+        add_legacy_membership(member, group=group)
 
         backfill_org_admin_grants()
 
@@ -209,9 +189,9 @@ class OrgAdminAndCaseworkerBackfillTestCase(TestCase):
         self.assertIsNotNone(grant.pk)
 
     def test_backfill_org_admin_grants_is_idempotent(self) -> None:
-        group = self._legacy_org_admin_group()
+        group = make_permission_group(organization=self.org, template_name=ORG_ADMIN_ROLE.name)
         member = baker.make(User)
-        _add_legacy_membership(group, member)
+        add_legacy_membership(member, group=group)
 
         backfill_org_admin_grants()
         backfill_org_admin_grants()
@@ -224,7 +204,7 @@ class OrgAdminAndCaseworkerBackfillTestCase(TestCase):
         cw_group = PermissionGroup.objects.get(organization=self.org, template__name=CASEWORKER_ROLE.name)
         other = PermissionGroup.objects.create(organization=self.org, label="Hand-made Role")
         member = baker.make(User)
-        _add_legacy_membership(cw_group, member)
+        add_legacy_membership(member, group=cw_group)
         other.user_set.add(member)
 
         backfill_org_admin_grants()
@@ -234,7 +214,7 @@ class OrgAdminAndCaseworkerBackfillTestCase(TestCase):
     def test_backfill_caseworker_grants_creates_one_grant_per_member(self) -> None:
         group = PermissionGroup.objects.get(organization=self.org, template__name=CASEWORKER_ROLE.name)
         member = baker.make(User)
-        _add_legacy_membership(group, member)
+        add_legacy_membership(member, group=group)
 
         backfill_caseworker_grants()
 
@@ -244,7 +224,7 @@ class OrgAdminAndCaseworkerBackfillTestCase(TestCase):
     def test_backfill_caseworker_grants_is_idempotent(self) -> None:
         group = PermissionGroup.objects.get(organization=self.org, template__name=CASEWORKER_ROLE.name)
         member = baker.make(User)
-        _add_legacy_membership(group, member)
+        add_legacy_membership(member, group=group)
 
         backfill_caseworker_grants()
         backfill_caseworker_grants()
@@ -253,9 +233,9 @@ class OrgAdminAndCaseworkerBackfillTestCase(TestCase):
 
     def test_backfill_caseworker_converts_only_caseworker(self) -> None:
         # An org-admin membership must not be converted into a caseworker grant.
-        group = self._legacy_org_admin_group()
+        group = make_permission_group(organization=self.org, template_name=ORG_ADMIN_ROLE.name)
         member = baker.make(User)
-        _add_legacy_membership(group, member)
+        add_legacy_membership(member, group=group)
 
         backfill_caseworker_grants()
 

--- a/apps/betterangels-backend/common/tests/utils.py
+++ b/apps/betterangels-backend/common/tests/utils.py
@@ -4,7 +4,7 @@ import json
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Tuple, Union
 
-from accounts.models import User
+from accounts.models import PermissionGroup, User
 from accounts.role_manager import OrgRoleManager
 from accounts.tests.baker_recipes import organization_recipe
 from django.contrib.contenttypes.models import ContentType
@@ -161,6 +161,65 @@ class NumQueriesWithoutCacheMixin:
         ContentType.objects.clear_cache()
         Site.objects.clear_cache()
         return _MaxNumQueriesContext(self, max_query_count)
+
+
+# ---------------------------------------------------------------------------
+# Grant-model fixtures — leftover legacy rows and grantless members
+# ---------------------------------------------------------------------------
+
+
+def make_permission_group(*, organization: Organization, template_name: str) -> PermissionGroup:
+    """The org's ``PermissionGroup`` for *template_name*, created on demand.
+
+    Grant-only templates (ORG_ADMIN / ORG_SUPERUSER) are no longer provisioned
+    with these rows — reconcile retires them — so a test that models a
+    pre-cutover holder (or exercises group naming) recreates the row by hand.
+    Idempotent: template and org row are ``get_or_create``.
+    """
+    from accounts.models import PermissionGroupTemplate
+
+    template, _ = PermissionGroupTemplate.objects.get_or_create(name=template_name)
+    group, _ = PermissionGroup.objects.get_or_create(organization=organization, template=template)
+    return group
+
+
+def revoke_grants(user: User) -> None:
+    """Drop every ``Grant`` *user* holds — the grantless-org-member state.
+
+    Authority is the grant arm (ADR 0001): membership (or a leftover legacy
+    row) alone confers nothing, so a test that wants "no authority" removes
+    the grants.
+    """
+    from accounts.models import Grant
+
+    Grant.objects.filter(principal_user=user).delete()
+
+
+def add_legacy_membership(user: User, *, group: PermissionGroup) -> None:
+    """Give *user* the legacy group membership, WITHOUT the Grant mirror.
+
+    The ``User.groups`` m2m edge mirrors role-backed memberships as ``Grant``
+    rows (``accounts.signals``); a pre-cutover membership — the state the
+    backfills convert and the cutover denies — predates the mirror, so the
+    just-created Grant is dropped.
+    """
+    group.user_set.add(user)
+    revoke_grants(user)
+
+
+def make_legacy_only_holder(*, organization: Organization, template_name: str, user: User) -> User:
+    """A member whose only authority is a leftover legacy group row.
+
+    Adds *user* to *organization*, hangs the leftover ``PermissionGroup`` for
+    *template_name* off them, and drops the mirrored Grant — the pre-cutover
+    state the org-admin cutover treats as authority-less and the backfills
+    convert when they apply.
+    """
+    organization.add_user(user)
+    add_legacy_membership(
+        user, group=make_permission_group(organization=organization, template_name=template_name)
+    )
+    return user
 
 
 class GraphQLBaseTestCase(

--- a/apps/betterangels-backend/common/tests/utils.py
+++ b/apps/betterangels-backend/common/tests/utils.py
@@ -216,9 +216,7 @@ def make_legacy_only_holder(*, organization: Organization, template_name: str, u
     convert when they apply.
     """
     organization.add_user(user)
-    add_legacy_membership(
-        user, group=make_permission_group(organization=organization, template_name=template_name)
-    )
+    add_legacy_membership(user, group=make_permission_group(organization=organization, template_name=template_name))
     return user
 
 

--- a/apps/betterangels-backend/reports/tests/test_grant_authorization.py
+++ b/apps/betterangels-backend/reports/tests/test_grant_authorization.py
@@ -20,10 +20,10 @@ from datetime import datetime
 from typing import Any
 
 from accounts.groups import ORG_ADMIN
-from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, User
+from accounts.models import User
 from accounts.role_manager import OrgRoleManager
 from accounts.services import sync_roles
-from common.tests.utils import GraphQLBaseTestCase
+from common.tests.utils import GraphQLBaseTestCase, make_legacy_only_holder
 from django.utils import timezone
 from model_bakery import baker
 from notes.models import Note
@@ -150,14 +150,9 @@ class ReportGrantAuthorityDeniedTestCase(ReportSummaryGraphQLGrantMixin, ReportE
         Reconcile retires org-admin rows (ADR 0001 teardown) — this simulates a
         stale leftover row; even if one exists it confers no report authority.
         """
-        legacy_admin = baker.make(User)
-        self.org_1.add_user(legacy_admin)
-        template, _ = PermissionGroupTemplate.objects.get_or_create(name=ORG_ADMIN.name)
-        group, _ = PermissionGroup.objects.get_or_create(organization=self.org_1, template=template)
-        group.user_set.add(legacy_admin)
-        # Direct membership mirrors a Grant at the m2m edge now; a pre-cutover
-        # legacy-only holder has none — drop the mirror to model that state.
-        Grant.objects.filter(principal_user=legacy_admin).delete()
+        legacy_admin = make_legacy_only_holder(
+            user=baker.make(User), organization=self.org_1, template_name=ORG_ADMIN.name
+        )
         self.assertFalse(legacy_admin.grants.filter(scope_org=self.org_1).exists())
 
         self._assert_denied(self._read(legacy_admin, self.org_1))

--- a/apps/betterangels-backend/shelters/tests/test_bed_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_bed_queries.py
@@ -1,6 +1,7 @@
 from accounts.tests.baker_recipes import organization_recipe
 from django.test import TestCase
 from model_bakery import baker
+from common.tests.utils import revoke_grants
 from shelters.enums import BedStatusChoices, BedTypeChoices, ReservationStatusChoices, StatusChoices
 from shelters.models import Bed, Reservation, Room
 from shelters.tests.baker_recipes import shelter_recipe
@@ -191,9 +192,7 @@ class BedsQueryTestCase(BedQueriesTestCase):
         # The grant model reads permissions from the Role a Grant references,
         # so removing access means deleting the operator's Grant (ADR 0001).
         # Queries fail closed: no Grant ⇒ no rows, not an error.
-        from accounts.models import Grant
-
-        Grant.objects.filter(principal_user=self.operator).delete()
+        revoke_grants(self.operator)
 
         response = self.execute_graphql(self.beds_query, variables={"pagination": {"offset": 0, "limit": 10}})
 

--- a/apps/betterangels-backend/shelters/tests/test_reservation_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_reservation_queries.py
@@ -1,6 +1,7 @@
 from accounts.tests.baker_recipes import organization_recipe
 from django.test import TestCase
 from model_bakery import baker
+from common.tests.utils import revoke_grants
 
 from shelters.enums import ReservationStatusChoices, StatusChoices
 from shelters.models import Bed, Reservation, Room
@@ -209,9 +210,7 @@ class ReservationsQueryTestCase(ReservationQueriesTestCase):
     def test_reservations_query_without_permission_returns_empty(self) -> None:
         # The grant model reads permissions from the Role a Grant references,
         # so removing access means deleting the operator's Grant (ADR 0001).
-        from accounts.models import Grant
-
-        Grant.objects.filter(principal_user=self.operator).delete()
+        revoke_grants(self.operator)
 
         expected_query_count = 10
         with self.assertNumQueriesWithoutCache(expected_query_count):

--- a/apps/betterangels-backend/shelters/tests/test_room_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_room_queries.py
@@ -1,6 +1,7 @@
 from accounts.tests.baker_recipes import organization_recipe
 from django.test import TestCase
 from model_bakery import baker
+from common.tests.utils import revoke_grants
 from shelters.enums import (
     BedStatusChoices,
     ReservationStatusChoices,
@@ -225,9 +226,7 @@ class RoomsQueryTestCase(RoomQueriesTestCase):
         # The grant model reads permissions from the Role a Grant references,
         # so removing access means deleting the operator's Grant (ADR 0001).
         # Queries fail closed: no Grant ⇒ no rows, not an error.
-        from accounts.models import Grant
-
-        Grant.objects.filter(principal_user=self.operator).delete()
+        revoke_grants(self.operator)
 
         response = self.execute_graphql(self.rooms_query, variables={"pagination": {"offset": 0, "limit": 10}})
 

--- a/apps/betterangels-backend/teams/tests/test_grant_authorization.py
+++ b/apps/betterangels-backend/teams/tests/test_grant_authorization.py
@@ -9,10 +9,11 @@ The three team mutations authorize through ``require_can`` (``can()``) since
 from typing import Any
 
 from accounts.groups import ORG_ADMIN
-from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, User
+from accounts.models import User
 from accounts.role_manager import OrgRoleManager
 from accounts.services import sync_roles
 from common.permissions.utils import PERMISSION_DENIED_MESSAGE
+from common.tests.utils import make_legacy_only_holder
 from model_bakery import baker
 from teams.models import Team
 
@@ -97,14 +98,9 @@ class TeamGrantAuthorityDeniedTestCase(TeamGraphQLUtilsMixin):
         Reconcile retires org-admin rows (ADR 0001 teardown) — this simulates a
         stale leftover row; even if one exists it confers no team authority.
         """
-        legacy_admin = baker.make(User)
-        self.org_1.add_user(legacy_admin)
-        template, _ = PermissionGroupTemplate.objects.get_or_create(name=ORG_ADMIN.name)
-        group, _ = PermissionGroup.objects.get_or_create(organization=self.org_1, template=template)
-        group.user_set.add(legacy_admin)
-        # Direct membership mirrors a Grant at the m2m edge now; a pre-cutover
-        # legacy-only holder has none — drop the mirror to model that state.
-        Grant.objects.filter(principal_user=legacy_admin).delete()
+        legacy_admin = make_legacy_only_holder(
+            user=baker.make(User), organization=self.org_1, template_name=ORG_ADMIN.name
+        )
         self.assertFalse(legacy_admin.grants.filter(scope_org=self.org_1).exists())
 
         self._login(legacy_admin)


### PR DESCRIPTION
## Summary

Consolidates the **legacy-only fixture dance** the grant cutover left copy-pasted across suites — create a leftover `PermissionGroup` row (nothing provisions grant-only templates any more), add a membership, drop the auto-mirrored `Grant` — into shared helpers, and adopts them everywhere.

Stacks on #2450 (`feat/perm/teams-header-strip`); lands after it.

## What changes

**New helpers (`common/tests/utils.py`)**
- `make_permission_group(*, organization, template_name)` — the org's `PermissionGroup`, created on demand (idempotent template + row).
- `revoke_grants(user)` — drop every `Grant` for the user: the grantless-org-member state.
- `add_legacy_membership(user, *, group)` — legacy membership **without** the Grant mirror (m2m-edge mirror dropped).
- `make_legacy_only_holder(*, organization, template_name, user)` — the composite: org membership + leftover group + no Grants.

**Adopted in**
- teams / reports / member-management `test_grant_authorization` suites (each lost its inline template/group/mirror block);
- `accounts/tests/test_roles.py` — its local `_add_legacy_membership` and `_legacy_org_admin_group` copies are gone;
- `accounts/tests/test_role_manager_grants.py`, `accounts/tests/test_permission_group.py` — `make_permission_group`;
- shelters `test_room_queries` / `test_bed_queries` / `test_reservation_queries` — `revoke_grants(self.operator)` replaces the inline `Grant…delete()`.

## Test plan

- `accounts common reports teams shelters` — **1310 passed**; `ruff` clean.
- No production code touched (test utilities only).

## Summary by Sourcery

Centralize legacy permission and grantless-member test fixtures and adopt them across the affected test suites.

New Features:
- Add shared test helpers for creating permission groups, modeling legacy-only memberships, and removing user grants.

Enhancements:
- Consolidate duplicated legacy permission fixture setup across account, team, report, member-management, and shelter tests.

Tests:
- Update authorization, role, permission-group, and shelter query tests to use the shared helpers.