### PR TITLE
chore(fe): stop sending the retired X-Organization-ID header

### DIFF
--- a/docs/adr/0001-grant-based-authorization.md
+++ b/docs/adr/0001-grant-based-authorization.md
@@ -1189,9 +1189,8 @@ are stable (referenced elsewhere and shared with the rest of the stack).
    consumer) takes the org from the `organizationId` filter, mobile's
    `useOrgTeams` passes the active org from its store, and
    `OrganizationMiddleware` / `get_current_organization` / `active_org` are
-   deleted.  The FE may keep sending the (now ignored) header via its global
-   `createOrgInterceptor`; dropping it there is cosmetic cleanup, not
-   correctness.
+   deleted.  The FE interceptor that sent the (now ignored) header was removed
+   in the follow-up cleanup, so no client attaches a request org.
 
 [SDB-218]: https://betterangels.atlassian.net/browse/SDB-218
 [PR #2407]: https://github.com/BetterAngelsLA/monorepo/pull/2407

--- a/libs/ba-platform/expo/src/lib/fetchClient.test.ts
+++ b/libs/ba-platform/expo/src/lib/fetchClient.test.ts
@@ -67,30 +67,6 @@ describe('createExpoFetchClient', () => {
     Object.keys(mockMmkv).forEach((k) => delete mockMmkv[k]);
   });
 
-  it('injects X-Organization-ID header from the active-org store', async () => {
-    mockMmkv['betterangels_active_org_id'] = 'org-expo';
-
-    const fetchClient = createExpoFetchClient('https://api.example.com');
-    await fetchClient('/graphql', { method: 'POST' });
-
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
-    const [, init] = fetchMock.mock.lastCall as [string, RequestInit];
-    const headers = new Headers(init.headers);
-
-    expect(headers.get('X-Organization-ID')).toBe('org-expo');
-  });
-
-  it('omits X-Organization-ID header when there is no active org', async () => {
-    const fetchClient = createExpoFetchClient('https://api.example.com');
-    await fetchClient('/graphql', { method: 'GET' });
-
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
-    const [, init] = fetchMock.mock.lastCall as [string, RequestInit];
-    const headers = new Headers(init.headers);
-
-    expect(headers.get('X-Organization-ID')).toBeNull();
-  });
-
   it('appends extra interceptors after platform defaults', async () => {
     const extraInterceptor: FetchInterceptor = async (_input, init, next) => {
       const headers = new Headers(init.headers);

--- a/libs/ba-platform/expo/src/lib/fetchClient.ts
+++ b/libs/ba-platform/expo/src/lib/fetchClient.ts
@@ -10,8 +10,6 @@ import {
   configureActiveOrgStorage,
   createCsrfInterceptor,
   createCsrfTokenRefresher,
-  createOrgInterceptor,
-  getActiveOrgId,
   CSRF_COOKIE_NAME,
   CSRF_HEADER_NAME,
   CSRF_LOGIN_PATH,
@@ -25,10 +23,9 @@ import { createNativeTokenReader } from './csrfTokenProvider';
  * Pre-composed Expo / React Native fetch client.
  *
  * Chains (in order):
- * 1. Org-ID injection (from the active-org store)
- * 2. Proactive CSRF header injection (via ``CookieManager``)
- * 3. Body serialisation
- * 4. Credentials include
+ * 1. Proactive CSRF header injection (via ``CookieManager``)
+ * 2. Body serialisation
+ * 3. Credentials include
  *
  * App-specific interceptors (HMIS auth, user-agent, etc.) can be passed
  * via ``extraInterceptors`` — they are appended after the platform defaults.
@@ -48,7 +45,6 @@ export const createExpoFetchClient = (
   configureActiveOrgStorage(expoActiveOrgStorage);
 
   return composeFetchInterceptors(
-    createOrgInterceptor(getActiveOrgId),
     createCsrfInterceptor(
       createNativeTokenReader(apiUrl),
       createCsrfTokenRefresher((header) =>

--- a/libs/ba-platform/src/lib/activeOrg/activeOrgStore.ts
+++ b/libs/ba-platform/src/lib/activeOrg/activeOrgStore.ts
@@ -1,19 +1,20 @@
 /**
  * The active organization id, held outside React.
  *
- * The ``X-Organization-ID`` header is attached by a fetch interceptor, which is
- * not a component and cannot read React state. Holding the id as React state
- * and mirroring it into storage gave the interceptor a copy that lagged the UI
- * — by a commit on web, by an ``AsyncStorage`` round trip on React Native — so
- * requests went out header-less while an organization was already on screen.
+ * Non-component consumers need the id synchronously and lag-free: React state
+ * mirrored into storage produced copies that trailed the UI — by a commit on
+ * web, by an ``AsyncStorage`` round trip on React Native — so org-scoped
+ * requests went out against a stale organization.  (The ``X-Organization-ID``
+ * header this store once fed is retired; orgs now travel in the query
+ * variables, e.g. ``useOrgTeams``.)
  *
  * One value, written synchronously, read synchronously by React (via
- * ``useSyncExternalStore``) and by the interceptor (via :func:`getActiveOrgId`).
+ * ``useSyncExternalStore``) and by callers of :func:`getActiveOrgId`.
  * Persistence is a write-behind detail, not a channel between the two.
  *
  * Scope: per JavaScript context. Two browser tabs each keep their own active
  * organization and do not follow each other, which is deliberate — a tab's UI
- * and its request headers now always agree, where previously a switch in one
+ * and its request scope now always agree, where previously a switch in one
  * tab changed the other's headers without changing what it displayed. Add a
  * ``storage`` event listener here if cross-tab following is ever wanted.
  */

--- a/libs/ba-platform/src/lib/interceptors.ts
+++ b/libs/ba-platform/src/lib/interceptors.ts
@@ -13,7 +13,6 @@ export {
   type CookiePersister,
   composeFetchInterceptors,
   createCsrfInterceptor,
-  createOrgInterceptor,
   createCsrfTokenRefresher,
   includeCredentialsInterceptor,
 } from '@monorepo/fetch';

--- a/libs/ba-platform/web/src/lib/fetchClient.test.ts
+++ b/libs/ba-platform/web/src/lib/fetchClient.test.ts
@@ -46,35 +46,6 @@ describe('createWebFetchClient', () => {
     global.fetch = originalFetch;
   });
 
-  it('injects X-Organization-ID header from the active-org store', async () => {
-    window.localStorage.setItem('betterangels_active_org_id', 'org-1');
-    document.cookie = 'csrftoken=csrf-abc; Path=/';
-
-    const fetchClient = createWebFetchClient();
-    await fetchClient('/api/test', { method: 'POST' });
-
-    const fetchMock = global.fetch as vi.Mock;
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    const headers = new Headers(init.headers);
-
-    expect(headers.get('X-Organization-ID')).toBe('org-1');
-    expect(headers.get('x-csrftoken')).toBe('csrf-abc');
-  });
-
-  it('omits X-Organization-ID header when there is no active org', async () => {
-    document.cookie = 'csrftoken=csrf-abc; Path=/';
-
-    const fetchClient = createWebFetchClient();
-    await fetchClient('/api/test', { method: 'GET' });
-
-    const fetchMock = global.fetch as vi.Mock;
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    const headers = new Headers(init.headers);
-
-    expect(headers.get('X-Organization-ID')).toBeNull();
-    expect(headers.get('x-csrftoken')).toBe('csrf-abc');
-  });
-
   it('preserves existing custom headers', async () => {
     document.cookie = 'csrftoken=csrf-abc; Path=/';
 

--- a/libs/ba-platform/web/src/lib/fetchClient.ts
+++ b/libs/ba-platform/web/src/lib/fetchClient.ts
@@ -3,8 +3,6 @@ import {
   configureActiveOrgStorage,
   createCsrfInterceptor,
   createCsrfTokenRefresher,
-  createOrgInterceptor,
-  getActiveOrgId,
   includeCredentialsInterceptor,
   CSRF_COOKIE_NAME,
   CSRF_HEADER_NAME,
@@ -16,7 +14,7 @@ import { readCsrfToken } from './csrfTokenProvider';
 /**
  * Pre-composed web fetch client.
  *
- * Chains org-id injection + CSRF token refresh, backed by browser-native
+ * Chains CSRF token refresh + credential inclusion, backed by browser-native
  * localStorage and cookie APIs.  Returns a ``fetch``-compatible function.
  *
  * Pass the result to ``ApiConfigProvider`` (as ``fetch``) and to Apollo's
@@ -29,7 +27,6 @@ export const createWebFetchClient = () => {
   configureActiveOrgStorage(webActiveOrgStorage);
 
   return composeFetchInterceptors(
-    createOrgInterceptor(getActiveOrgId),
     createCsrfInterceptor(
       readCsrfToken,
       createCsrfTokenRefresher(),

--- a/libs/fetch/src/lib/fetchInterceptors.test.ts
+++ b/libs/fetch/src/lib/fetchInterceptors.test.ts
@@ -1,9 +1,6 @@
 /**
  */
-import {
-  createCsrfInterceptor,
-  createOrgInterceptor,
-} from './fetchInterceptors';
+import { createCsrfInterceptor } from './fetchInterceptors';
 
 describe('createCsrfInterceptor', () => {
   it('injects CSRF header when token is available', async () => {
@@ -168,61 +165,5 @@ describe('createCsrfInterceptor', () => {
         ),
       ).toBe('existing');
     });
-  });
-});
-
-describe('createOrgInterceptor', () => {
-  it('injects the Org header from the reader', async () => {
-    const next = vi.fn().mockResolvedValue(new Response());
-
-    const interceptor = createOrgInterceptor(() => 'org-1');
-    await interceptor('/api', {}, next);
-
-    const init = next.mock.calls[0][1] as RequestInit;
-    expect(new Headers(init.headers).get('X-Organization-ID')).toBe('org-1');
-  });
-
-  it('passes through when there is no active org', async () => {
-    const next = vi.fn().mockResolvedValue(new Response());
-
-    const interceptor = createOrgInterceptor(() => null);
-    await interceptor('/api', { headers: { Authorization: 'Bearer x' } }, next);
-
-    const init = next.mock.calls[0][1] as RequestInit;
-    const h = new Headers(init.headers);
-    expect(h.get('X-Organization-ID')).toBeNull();
-    expect(h.get('Authorization')).toBe('Bearer x');
-  });
-
-  it('reads the current value per request, not once at construction', async () => {
-    // Switching organizations must affect the very next request; the reader is
-    // called per request precisely so a long-lived client picks up the change.
-    let orgId: string | null = 'org-1';
-    const interceptor = createOrgInterceptor(() => orgId);
-    const next = vi.fn().mockResolvedValue(new Response());
-
-    await interceptor('/api', {}, next);
-    orgId = 'org-2';
-    await interceptor('/api', {}, next);
-
-    const headerFor = (call: number) =>
-      new Headers((next.mock.calls[call][1] as RequestInit).headers).get(
-        'X-Organization-ID',
-      );
-    expect(headerFor(0)).toBe('org-1');
-    expect(headerFor(1)).toBe('org-2');
-  });
-
-  it('does not await — the reader must be synchronous', async () => {
-    const interceptor = createOrgInterceptor(() => 'org-1');
-    const next = vi.fn().mockResolvedValue(new Response());
-
-    await interceptor('/api', {}, next);
-
-    const value = new Headers(
-      (next.mock.calls[0][1] as RequestInit).headers,
-    ).get('X-Organization-ID');
-    expect(value).not.toContain('Promise');
-    expect(value).toBe('org-1');
   });
 });

--- a/libs/fetch/src/lib/fetchInterceptors.ts
+++ b/libs/fetch/src/lib/fetchInterceptors.ts
@@ -119,26 +119,6 @@ export const createCsrfInterceptor =
   };
 
 // ---------------------------------------------------------------------------
-// Org Interceptor
-// ---------------------------------------------------------------------------
-
-/**
- * Inject the ``X-Organization-ID`` header, read per request.
- *
- * *readOrgId* must not do I/O — see ``getActiveOrgId`` in
- * ``@monorepo/ba-platform``.
- */
-export const createOrgInterceptor =
-  (readOrgId: () => string | null): FetchInterceptor =>
-  async (_input, init, next) => {
-    const orgId = readOrgId();
-    if (!orgId) return next(_input, init);
-    const headers = new Headers(init.headers);
-    headers.set('X-Organization-ID', orgId);
-    return next(_input, { ...init, headers });
-  };
-
-// ---------------------------------------------------------------------------
 // Credentials Interceptor
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The backend no longer reads a request org anywhere — DEV-2566 (#2450) retired the `X-Organization-ID` header, its middleware, and every header-era fixture. This removes the dead FE-side injection so no client attaches a request org.

Stacks on #2451; **must land after #2450** (i.e. after the backend stack) so no app deploy can be ahead of a backend that still required the header.

## What changes

- `libs/fetch` — delete `createOrgInterceptor` and its unit tests.
- `libs/ba-platform` — drop the interceptor from the web and expo fetch clients and from the convenience re-exports.
- The **active-org store stays**: it still drives the UI and the org query variables (`useOrgTeams` reads `getActiveOrgId` reactively); its rationale docstring now records the header's retirement instead of describing the interceptor.
- web/expo fetch-client tests: header-injection cases removed.
- ADR §7 (header-retirement note): the "FE may keep sending it" sentence updated to reflect the removal.

## Test plan

- ESLint clean on all changed files.
- `vitest` on the fetch/ba-platform suites runs in CI (local container lacks the rolldown native binding).
- No API/schema changes; backend is untouched.

## Summary by Sourcery

Stop frontend fetch clients from sending the retired `X-Organization-ID` header.

Enhancements:
- Remove frontend support for the retired `X-Organization-ID` request header while retaining the active-organization store for UI state and query scoping.

Documentation:
- Update the authorization ADR to document that frontend clients no longer attach the retired organization header.

Tests:
- Remove tests covering organization-header injection from the shared, web, and Expo fetch clients.