### PR TITLE
feat(perm): manage.py explain_permission — grant-model authority debugger

### DIFF
--- a/apps/betterangels-backend/common/management/commands/explain_permission.py
+++ b/apps/betterangels-backend/common/management/commands/explain_permission.py
@@ -84,17 +84,20 @@ class Command(BaseCommand):
     def _resolve_user(ref: str) -> "User":
         from accounts.models import User
 
+        user: User
         if ref.isdigit():
             try:
-                return cast("User", User.objects.get(pk=int(ref)))
+                user = User.objects.get(pk=int(ref))
             except User.DoesNotExist:
                 raise CommandError(f"no user with pk {ref}.") from None
-        matches = list(User.objects.filter(Q(username=ref) | Q(email__iexact=ref))[:2])
-        if not matches:
-            raise CommandError(f"no user matches {ref!r} (pk, username, or email).")
-        if len(matches) > 1:
-            raise CommandError(f"{ref!r} matches more than one user — use the pk.")
-        return cast("User", matches[0])
+        else:
+            matches = list(User.objects.filter(Q(username=ref) | Q(email__iexact=ref))[:2])
+            if not matches:
+                raise CommandError(f"no user matches {ref!r} (pk, username, or email).")
+            if len(matches) > 1:
+                raise CommandError(f"{ref!r} matches more than one user — use the pk.")
+            user = matches[0]
+        return user
 
     @staticmethod
     def _resolve_org(ref: Optional[str]) -> Optional["Organization"]:

--- a/apps/betterangels-backend/common/management/commands/explain_permission.py
+++ b/apps/betterangels-backend/common/management/commands/explain_permission.py
@@ -1,0 +1,127 @@
+"""``manage.py explain_permission`` — why a user can or cannot do P at org O / on object R.
+
+Usage::
+
+    python manage.py explain_permission --user jane@example.org --perm shelters.change_shelter --org 7
+    python manage.py explain_permission --user 42 --perm shelters.view_shelter --object shelters.shelter:12
+
+Prints the verdict from the canonical predicate (``can`` / ``can_obj`` /
+``can_anywhere`` — never a second implementation of the rules) and the arms
+behind it: global tier, direct grant, delegated grant, object grant (not wired
+yet), and the legacy ``PermissionGroup`` arm with its live/inert domain posture.
+
+Exits 0 when allowed, 1 when denied — script-friendly.  See
+``common.permissions.explain`` and ``docs/adr/0001-grant-based-authorization.md``.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+from django.apps import apps
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+from organizations.models import Organization
+
+from common.permissions.explain import explain
+
+if TYPE_CHECKING:
+    from django.db.models import Model
+
+    from accounts.models import User
+
+
+class Command(BaseCommand):
+    help = "Explain a user's grant-model authority (can/can't they do P at org O / on object R)"
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--user", required=True, help="User pk, username, or email.")
+        parser.add_argument("--perm", required=True, help="Permission as 'app_label.codename'.")
+        parser.add_argument("--org", help="Organization pk or slug.")
+        parser.add_argument(
+            "--object",
+            dest="object_ref",
+            help="Object as 'app_label.model:pk' — e.g. shelters.shelter:12.",
+        )
+
+    def handle(self, **options: Any) -> None:
+        user = self._resolve_user(options["user"])
+        org = self._resolve_org(options.get("org"))
+        obj = self._resolve_object(options.get("object_ref"))
+        if org is not None and obj is not None:
+            raise CommandError("pass at most one of --org / --object.")
+
+        try:
+            explanation = explain(user, options["perm"], org=org, obj=obj)
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        posture = (
+            "grant-only domain — legacy rows inert" if explanation.cut_over else "legacy domain — NOT cut over yet"
+        )
+        display_name = user.full_name or user.username
+        self.stdout.write(f"user        {display_name} <{user.email or '—'}> (pk={user.pk})")
+        self.stdout.write(f"permission  {explanation.perm}  [{posture}]")
+        if explanation.org is not None:
+            self.stdout.write(f'org         {explanation.org.pk} "{explanation.org.name}"')
+        if explanation.obj is not None:
+            self.stdout.write(f"object      {explanation.obj._meta.label_lower} #{explanation.obj.pk}")
+        self.stdout.write(
+            f"verdict     {'ALLOWED' if explanation.verdict else 'DENIED'}  ({explanation.mode} predicate)"
+        )
+        self.stdout.write("arms")
+        for arm in explanation.arms:
+            self.stdout.write(f"  {arm.label:<13} {'YES' if arm.holds else 'no':<4} {arm.detail}")
+        if explanation.notes:
+            self.stdout.write("notes")
+            for note in explanation.notes:
+                self.stdout.write(f"  - {note}")
+        if not explanation.verdict:
+            sys.exit(1)
+
+    @staticmethod
+    def _resolve_user(ref: str) -> "User":
+        from accounts.models import User
+
+        if ref.isdigit():
+            try:
+                return cast("User", User.objects.get(pk=int(ref)))
+            except User.DoesNotExist:
+                raise CommandError(f"no user with pk {ref}.") from None
+        matches = list(User.objects.filter(Q(username=ref) | Q(email__iexact=ref))[:2])
+        if not matches:
+            raise CommandError(f"no user matches {ref!r} (pk, username, or email).")
+        if len(matches) > 1:
+            raise CommandError(f"{ref!r} matches more than one user — use the pk.")
+        return cast("User", matches[0])
+
+    @staticmethod
+    def _resolve_org(ref: Optional[str]) -> Optional["Organization"]:
+        if not ref:
+            return None
+        query = Q(pk=int(ref)) if ref.isdigit() else Q(slug=ref)
+        try:
+            return Organization.objects.get(query)
+        except Organization.DoesNotExist:
+            raise CommandError(f"no organization matches {ref!r} (pk or slug).") from None
+
+    @staticmethod
+    def _resolve_object(ref: Optional[str]) -> Optional["Model"]:
+        if not ref:
+            return None
+        expected = "--object must be 'app_label.model:pk' — e.g. shelters.shelter:12."
+        if ":" not in ref:
+            raise CommandError(expected)
+        label, _, pk = ref.rpartition(":")
+        app_label, _, model_name = label.partition(".")
+        if not app_label or not model_name or not pk.isdigit():
+            raise CommandError(expected)
+        try:
+            model = apps.get_model(app_label, model_name)
+        except LookupError:
+            raise CommandError(f"no installed model named {label!r}.") from None
+        obj = model._base_manager.filter(pk=int(pk)).first()
+        if obj is None:
+            raise CommandError(f"no {label} with pk {pk}.")
+        return cast("Model", obj)

--- a/apps/betterangels-backend/common/permissions/explain.py
+++ b/apps/betterangels-backend/common/permissions/explain.py
@@ -1,0 +1,349 @@
+"""Grant-model explanation — why a user can or cannot do P at org O / on object R (ADR 0001).
+
+The debugger the model was missing.  The verdict is always re-asked from the
+canonical predicate — ``can`` at an org, ``can_obj`` on a row, ``can_anywhere``
+with no scope — so an explanation can never disagree with enforcement; the arms
+that fed it are then walked one by one:
+
+* **global tier** — superuser / global Role / ``user_permissions``;
+* **direct grant** — a user-principal ``Grant`` at the org;
+* **delegated** — an org-principal delegation the user inherits (permission-matched);
+* **object grant** — rows for the object arm (not wired until the clients cutover);
+* **legacy rows** — ``PermissionGroup`` membership, with the domain's live/inert
+  posture (``common.permissions.domain``).
+
+Legacy-only domains (notes/clients) have not cut over: enforcement today rides
+the legacy arm, and the verdict here is what the grant model would answer — the
+difference between the two is exactly the cutover's remaining surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from common.permissions.domain import LEGACY_INERT_APPS
+
+if TYPE_CHECKING:
+    from django.db.models import Model
+
+    from accounts.models import User
+    from organizations.models import Organization
+
+_MAX_SHOWN = 5
+"""Names listed per arm before ``+N more`` — this is a terminal tool for humans."""
+
+
+@dataclass(frozen=True)
+class Arm:
+    """One authority input and whether it carries the permission in this scope."""
+
+    label: str
+    holds: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class Explanation:
+    """The verdict (the canonical predicate's answer) and the arms behind it."""
+
+    user: "User"
+    perm: str
+    mode: str
+    cut_over: bool
+    verdict: bool
+    org: Optional["Organization"]
+    obj: Optional["Model"]
+    arms: tuple[Arm, ...]
+    notes: tuple[str, ...]
+
+
+def _split_perm(perm: str) -> tuple[str, str]:
+    app_label, _, codename = perm.partition(".")
+    if not app_label or not codename:
+        raise ValueError(f"permission must be 'app_label.codename', got {perm!r}")
+    return app_label, codename
+
+
+def _grant_carries(app_label: str, codename: str) -> dict[str, str]:
+    return {
+        "role__permissions__content_type__app_label": app_label,
+        "role__permissions__codename": codename,
+    }
+
+
+def _legacy_carries(app_label: str, codename: str) -> dict[str, str]:
+    return {
+        "permissions__content_type__app_label": app_label,
+        "permissions__codename": codename,
+    }
+
+
+def _names(names: list[str]) -> str:
+    shown = ", ".join(names[:_MAX_SHOWN])
+    if len(names) > _MAX_SHOWN:
+        shown += f", +{len(names) - _MAX_SHOWN} more"
+    return shown
+
+
+def _global_arm(user: "User", app_label: str, codename: str) -> Arm:
+    superuser = bool(user.is_superuser)
+    roles = sorted(
+        user.groups.filter(
+            role__is_global=True,
+            role__permissions__content_type__app_label=app_label,
+            role__permissions__codename=codename,
+        )
+        .values_list("name", flat=True)
+        .distinct()
+    )
+    direct = user.user_permissions.filter(content_type__app_label=app_label, codename=codename).exists()
+    detail = (
+        f"superuser: {'yes' if superuser else 'no'}; "
+        f"global roles: {_names(roles) if roles else 'none'}; "
+        f"user_permissions: {'yes' if direct else 'no'}"
+    )
+    return Arm("global tier", superuser or bool(roles) or direct, detail)
+
+
+def _direct_arm(user: "User", app_label: str, codename: str, *, org: Optional["Organization"]) -> Arm:
+    from accounts.models import Grant
+
+    base = Grant.objects.filter(principal_user=user, scope_org__isnull=False, **_grant_carries(app_label, codename))
+    if org is not None:
+        roles = sorted({g.role.name for g in base.filter(scope_org=org).select_related("role")})
+        if roles:
+            return Arm("direct grant", True, f"role(s) {', '.join(roles)} at org {org.pk}")
+        held = sorted(
+            {g.role.name for g in Grant.objects.filter(principal_user=user, scope_org=org).select_related("role")}
+        )
+        detail = "no grant at this org carries the permission"
+        if held:
+            detail += f" (held role(s) at org: {', '.join(held)})"
+        return Arm("direct grant", False, detail)
+
+    rows = list(base.select_related("role", "scope_org"))
+    granted = sorted({f"{g.role.name} @ {g.scope_org.name}" for g in rows if g.scope_org is not None})
+    detail = _names(granted) if granted else "no scoped grant carries the permission"
+    return Arm("direct grant", bool(rows), detail)
+
+
+def _acting_org_ids(user: "User", app_label: str, codename: str) -> set[int]:
+    """Orgs where *user* is a member AND holds a direct grant carrying the permission.
+
+    The "acts at B" rule ``scopes()`` requires before a delegation B→C is
+    inheritable (permission-matched — no amplification).
+    """
+    from organizations.models import Organization
+
+    return set(
+        Organization.objects.filter(
+            users=user,
+            grants__principal_user=user,
+            grants__role__permissions__content_type__app_label=app_label,
+            grants__role__permissions__codename=codename,
+        ).values_list("pk", flat=True)
+    )
+
+
+def _delegated_arm(user: "User", app_label: str, codename: str, *, org: Optional["Organization"]) -> Arm:
+    from accounts.models import Grant
+
+    acting = _acting_org_ids(user, app_label, codename)
+
+    if org is not None:
+        delegations = list(
+            Grant.objects.filter(
+                scope_org=org, principal_org__isnull=False, **_grant_carries(app_label, codename)
+            ).select_related("role", "principal_org")
+        )
+        if not delegations:
+            return Arm("delegated", False, "no org-principal delegations scope this org for this permission")
+        matched = [d for d in delegations if d.principal_org_id in acting]
+        if matched:
+            delegators = sorted({d.principal_org.name for d in matched if d.principal_org is not None})
+            return Arm(
+                "delegated",
+                True,
+                f"inherited from {_names(delegators)} (the user acts there with this permission)",
+            )
+        delegators = sorted({d.principal_org.name for d in delegations if d.principal_org is not None})
+        return Arm(
+            "delegated",
+            False,
+            f"delegation(s) into this org exist ({_names(delegators)}) but the user does not act at the "
+            "delegator with this permission",
+        )
+
+    inherited = list(
+        Grant.objects.filter(
+            principal_org__isnull=False, scope_org__isnull=False, **_grant_carries(app_label, codename)
+        ).select_related("role", "principal_org", "scope_org")
+    )
+    matched = [d for d in inherited if d.principal_org_id in acting]
+    if matched:
+        orgs = sorted({d.scope_org.name for d in matched if d.scope_org is not None})
+        return Arm("delegated", True, f"inherited (delegated) at: {_names(orgs)}")
+    return Arm("delegated", False, "no org-principal delegations the user inherits carry this permission")
+
+
+def _object_arm(user: "User", app_label: str, codename: str) -> Arm:
+    from accounts.models import Grant
+    from common.permissions.config import OBJECT_GRANT_WHITELIST
+
+    rows = list(
+        Grant.objects.filter(
+            principal_user=user, scope_object_type__isnull=False, **_grant_carries(app_label, codename)
+        ).select_related("role")
+    )
+    wired = bool(OBJECT_GRANT_WHITELIST)
+    if rows and not wired:
+        return Arm(
+            "object grant",
+            False,
+            f"{len(rows)} object-scoped row(s) exist though the arm is not wired (permissions.E003 flags these)",
+        )
+    if rows:
+        return Arm("object grant", True, f"{len(rows)} object grant(s)")
+    detail = "no object grants"
+    if not wired:
+        detail += " — the arm is not wired yet (enabled with the clients cutover)"
+    return Arm("object grant", False, detail)
+
+
+def _legacy_arm(
+    user: "User",
+    perm: str,
+    app_label: str,
+    codename: str,
+    *,
+    org: Optional["Organization"],
+    obj: Optional["Model"],
+    cut_over: bool,
+) -> Arm:
+    from accounts.models import PermissionGroup
+
+    qs = PermissionGroup.objects.filter(user=user, **_legacy_carries(app_label, codename))
+    if org is not None:
+        qs = qs.filter(organization=org)
+    rows = list(qs.select_related("organization").distinct())
+
+    posture = (
+        "inert for this domain (grant-only — never consulted)"
+        if cut_over
+        else "live for this domain (the current authority — not cut over)"
+    )
+    if rows:
+        labels = [f"{row.label} @ {row.organization.name}" for row in rows]
+        detail = f"{_names(labels)} — {posture}"
+    else:
+        detail = f"no PermissionGroup rows carry this permission — {posture}"
+    holds = bool(rows) and not cut_over
+    if obj is not None and not cut_over:
+        detail += f"; legacy object check user.has_perm(perm, obj): {user.has_perm(perm, obj)}"
+    return Arm("legacy rows", holds, detail)
+
+
+def _write_tier_note(obj: "Model") -> str:
+    from common.models import OrgScoped, WRITE_OBJECT, WRITE_SHARED
+
+    model = type(obj)
+    if not issubclass(model, OrgScoped):
+        return "write scope: the model does not declare OrgScoped — can_obj() fails closed (no one may write)"
+    if model.org_via is not None:
+        return "write scope ORG — the row must sit in an org the user holds this permission in (scopes())"
+    tier = model.__dict__.get("write_tier")
+    if tier == WRITE_SHARED:
+        return "write scope SHARED — any holder of the permission may act (can_anywhere)"
+    if tier == WRITE_OBJECT:
+        return "write scope OBJECT — per-record object grants"
+    return "write scope fail-closed — platform-shared model with no declared write tier: only the global tier may act"
+
+
+def _notes(
+    user: "User",
+    perm: str,
+    *,
+    org: Optional["Organization"],
+    obj: Optional["Model"],
+    cut_over: bool,
+    verdict: bool,
+) -> list[str]:
+    from accounts.models import PermissionGroup
+    from common.permissions.selectors import ALL, scopes
+
+    notes: list[str] = []
+    if not cut_over:
+        app_label = _split_perm(perm)[0]
+        notes.append(
+            f"domain {app_label!r} has not cut over — enforcement today rides the legacy arm; "
+            "the verdict above is the grant model's (post-cutover) answer"
+        )
+    elif not verdict:
+        app_label, codename = _split_perm(perm)
+        if PermissionGroup.objects.filter(user=user, **_legacy_carries(app_label, codename)).exists():
+            notes.append(
+                "legacy PermissionGroup row(s) exist but are inert for this domain — grants are the only authority"
+            )
+
+    s = scopes(user, perm)
+    if s is not ALL:
+        other_ids = [pk for pk in s.values_list("scope_org", flat=True) if org is None or pk != org.pk]
+        if other_ids:
+            from organizations.models import Organization
+
+            names = sorted(Organization.objects.filter(pk__in=other_ids).values_list("name", flat=True))
+            notes.append(f"also holds this permission at {len(other_ids)} other org(s): {_names(names)}")
+
+    if obj is not None:
+        notes.append(_write_tier_note(obj))
+    return notes
+
+
+def explain(
+    user: "User",
+    perm: str,
+    *,
+    org: Optional["Organization"] = None,
+    obj: Optional["Model"] = None,
+) -> Explanation:
+    """Explain *user*'s authority for *perm* — at *org*, on *obj*, or anywhere.
+
+    Pass at most one of *org* / *obj*.  The verdict is the canonical predicate
+    for the mode (``can`` / ``can_obj`` / ``can_anywhere``) — exactly what
+    enforcement would decide; the arms and notes explain how it got there.
+    """
+    from common.permissions.selectors import can, can_anywhere, can_obj
+
+    app_label, codename = _split_perm(perm)
+    if org is not None and obj is not None:
+        raise ValueError("pass at most one of org= / obj=")
+    mode = "object" if obj is not None else "org" if org is not None else "anywhere"
+    cut_over = app_label in LEGACY_INERT_APPS
+
+    if obj is not None:
+        verdict = can_obj(user, perm, obj)
+    elif org is not None:
+        verdict = can(user, perm, org=org)
+    else:
+        verdict = can_anywhere(user, perm)
+
+    arms = (
+        _global_arm(user, app_label, codename),
+        _direct_arm(user, app_label, codename, org=org),
+        _delegated_arm(user, app_label, codename, org=org),
+        _object_arm(user, app_label, codename),
+        _legacy_arm(user, perm, app_label, codename, org=org, obj=obj, cut_over=cut_over),
+    )
+    notes = _notes(user, perm, org=org, obj=obj, cut_over=cut_over, verdict=verdict)
+    return Explanation(
+        user=user,
+        perm=perm,
+        mode=mode,
+        cut_over=cut_over,
+        verdict=verdict,
+        org=org,
+        obj=obj,
+        arms=arms,
+        notes=tuple(notes),
+    )

--- a/apps/betterangels-backend/common/tests/test_explain_permission.py
+++ b/apps/betterangels-backend/common/tests/test_explain_permission.py
@@ -1,0 +1,222 @@
+"""Tests for the grant-model explanation (``common.permissions.explain``).
+
+The load-bearing property: the verdict is the canonical predicate's answer —
+each scenario asserts parity with ``can`` / ``can_obj`` / ``can_anywhere`` — and
+the arms attribute it correctly (global tier, direct, delegated, object, legacy).
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from accounts.models import Role, User
+from accounts.services import grant_create, grant_delegate, role_assign, sync_roles
+from accounts.tests.baker_recipes import organization_recipe
+from clients.models import ClientProfile
+from common.permissions.explain import Arm, Explanation, explain
+from common.permissions.selectors import can, can_anywhere, can_obj
+from common.tests.utils import add_legacy_membership, make_permission_group
+from django.contrib.auth.models import Permission
+from django.core.management import call_command
+from django.test import TestCase
+from model_bakery import baker
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
+from shelters.models import Shelter
+from shelters.tests.baker_recipes import shelter_recipe
+
+
+def _arm(explanation: Explanation, label: str) -> Arm:
+    return next(arm for arm in explanation.arms if arm.label == label)
+
+
+class ExplainPermissionTestCase(TestCase):
+    def setUp(self) -> None:
+        sync_roles()
+        self.org_a = organization_recipe.make(name="Explain Org A")
+        self.org_b = organization_recipe.make(name="Explain Org B")
+        self.shelter_a = shelter_recipe.make(organization=self.org_a)
+        self.shelter_b = shelter_recipe.make(organization=self.org_b)
+        self.shelter_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
+        self.gso_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
+
+    # ── org mode ──────────────────────────────────────────────────────────
+
+    def test_direct_grant_allows_at_org(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+
+        result = explain(alice, Shelter.perms.VIEW, org=self.org_a)
+
+        self.assertTrue(result.verdict)
+        self.assertEqual(result.verdict, can(alice, Shelter.perms.VIEW, org=self.org_a))
+        self.assertTrue(result.cut_over)
+        self.assertTrue(_arm(result, "direct grant").holds)
+        self.assertFalse(_arm(result, "global tier").holds)
+        self.assertFalse(_arm(result, "delegated").holds)
+        self.assertFalse(_arm(result, "legacy rows").holds)
+
+    def test_no_authority_denies_every_arm(self) -> None:
+        stranger = baker.make(User)
+
+        result = explain(stranger, Shelter.perms.VIEW, org=self.org_a)
+
+        self.assertFalse(result.verdict)
+        self.assertEqual(result.verdict, can(stranger, Shelter.perms.VIEW, org=self.org_a))
+        self.assertEqual([arm.label for arm in result.arms if arm.holds], [])
+
+    def test_global_role_holder_allows(self) -> None:
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+
+        result = explain(gso, Shelter.perms.VIEW, org=self.org_b)
+        anywhere = explain(gso, Shelter.perms.VIEW)
+
+        self.assertTrue(result.verdict)
+        self.assertEqual(result.verdict, can(gso, Shelter.perms.VIEW, org=self.org_b))
+        self.assertTrue(_arm(result, "global tier").holds)
+        self.assertTrue(anywhere.verdict)
+        self.assertEqual(anywhere.verdict, can_anywhere(gso, Shelter.perms.VIEW))
+
+    def test_superuser_allows(self) -> None:
+        admin = baker.make(User, is_superuser=True)
+
+        result = explain(admin, Shelter.perms.VIEW, org=self.org_a)
+
+        self.assertTrue(result.verdict)
+        self.assertIn("superuser: yes", _arm(result, "global tier").detail)
+
+    # ── legacy arm posture ────────────────────────────────────────────────
+
+    def test_legacy_only_holder_denied_for_cut_over_domain(self) -> None:
+        group = make_permission_group(organization=self.org_a, template_name=SHELTER_OPERATOR_ROLE.name)
+        group.permissions.add(Permission.objects.get(content_type__app_label="shelters", codename="view_shelter"))
+        holder = baker.make(User)
+        self.org_a.add_user(holder)
+        add_legacy_membership(holder, group=group)
+
+        result = explain(holder, Shelter.perms.VIEW, org=self.org_a)
+
+        self.assertFalse(result.verdict)
+        self.assertEqual(result.verdict, can(holder, Shelter.perms.VIEW, org=self.org_a))
+        legacy = _arm(result, "legacy rows")
+        self.assertFalse(legacy.holds)
+        self.assertIn("inert", legacy.detail)
+        self.assertTrue(any("inert" in note for note in result.notes))
+
+    def test_legacy_domain_rows_are_reported_live(self) -> None:
+        group = make_permission_group(organization=self.org_a, template_name="Caseworker")
+        group.permissions.add(Permission.objects.get(content_type__app_label="notes", codename="view_note"))
+        holder = baker.make(User)
+        self.org_a.add_user(holder)
+        add_legacy_membership(holder, group=group)
+
+        result = explain(holder, "notes.view_note", org=self.org_a)
+
+        self.assertFalse(result.cut_over)
+        self.assertFalse(result.verdict)  # the grant model is not wired for notes yet
+        self.assertEqual(result.verdict, can(holder, "notes.view_note", org=self.org_a))
+        legacy = _arm(result, "legacy rows")
+        self.assertTrue(legacy.holds)
+        self.assertIn("live", legacy.detail)
+        self.assertTrue(any("has not cut over" in note for note in result.notes))
+
+    # ── delegated arm ─────────────────────────────────────────────────────
+
+    def test_delegation_allows_where_the_user_acts(self) -> None:
+        grant_delegate(principal_org=self.org_b, role=self.shelter_role, scope_org=self.org_a)
+        bob = baker.make(User)
+        self.org_b.add_user(bob)
+        grant_create(user=bob, role=self.shelter_role, scope_org=self.org_b)
+
+        result = explain(bob, Shelter.perms.VIEW, org=self.org_a)
+
+        self.assertTrue(result.verdict)
+        self.assertEqual(result.verdict, can(bob, Shelter.perms.VIEW, org=self.org_a))
+        self.assertTrue(_arm(result, "delegated").holds)
+        self.assertIn("Explain Org B", _arm(result, "delegated").detail)
+        self.assertFalse(_arm(result, "direct grant").holds)
+
+    def test_delegation_requires_acting_at_the_delegator(self) -> None:
+        grant_delegate(principal_org=self.org_b, role=self.shelter_role, scope_org=self.org_a)
+        charlie = baker.make(User)
+        self.org_b.add_user(charlie)  # membership alone — no grant at B
+
+        result = explain(charlie, Shelter.perms.VIEW, org=self.org_a)
+
+        self.assertFalse(result.verdict)
+        self.assertIn("does not act", _arm(result, "delegated").detail)
+
+    # ── object mode ───────────────────────────────────────────────────────
+
+    def test_object_mode_org_tier(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+
+        in_scope = explain(alice, Shelter.perms.VIEW, obj=self.shelter_a)
+        out_of_scope = explain(alice, Shelter.perms.VIEW, obj=self.shelter_b)
+
+        self.assertTrue(in_scope.verdict)
+        self.assertEqual(in_scope.verdict, can_obj(alice, Shelter.perms.VIEW, self.shelter_a))
+        self.assertTrue(any("ORG" in note for note in in_scope.notes))
+        self.assertFalse(out_of_scope.verdict)
+        self.assertEqual(out_of_scope.verdict, can_obj(alice, Shelter.perms.VIEW, self.shelter_b))
+
+    def test_object_mode_shared_tier(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)  # carries view_clientprofile
+        client = baker.make(ClientProfile)
+
+        result = explain(alice, ClientProfile.perms.VIEW, obj=client)
+
+        self.assertTrue(result.verdict)
+        self.assertEqual(result.verdict, can_obj(alice, ClientProfile.perms.VIEW, client))
+        self.assertTrue(any("SHARED" in note for note in result.notes))
+
+    # ── input validation ──────────────────────────────────────────────────
+
+    def test_rejects_malformed_perm_and_double_scope(self) -> None:
+        user = baker.make(User)
+
+        with self.assertRaises(ValueError):
+            explain(user, "view_shelter", org=self.org_a)
+        with self.assertRaises(ValueError):
+            explain(user, Shelter.perms.VIEW, org=self.org_a, obj=self.shelter_a)
+
+    # ── command surface ───────────────────────────────────────────────────
+
+    def test_command_reports_verdict(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org_a)
+        out = StringIO()
+
+        call_command(
+            "explain_permission",
+            "--user",
+            str(alice.pk),
+            "--perm",
+            Shelter.perms.VIEW,
+            "--org",
+            str(self.org_a.pk),
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        self.assertIn("verdict     ALLOWED", output)
+        self.assertIn("direct grant", output)
+
+    def test_command_exits_nonzero_on_deny(self) -> None:
+        stranger = baker.make(User)
+
+        with self.assertRaises(SystemExit) as ctx:
+            call_command(
+                "explain_permission",
+                "--user",
+                str(stranger.pk),
+                "--perm",
+                Shelter.perms.VIEW,
+                "--org",
+                str(self.org_a.pk),
+                stdout=StringIO(),
+            )
+
+        self.assertEqual(ctx.exception.code, 1)

--- a/apps/betterangels-backend/docs/permissions.md
+++ b/apps/betterangels-backend/docs/permissions.md
@@ -41,6 +41,15 @@ The org always travels in the **payload**: query filters and mutation inputs car
 
 The old `HasOrgPerm` extension and the `permissioned_queryset()` / `perm_filter()` / `_perm_q()` helpers are **deleted** — org-scoped surfaces authorize through the selectors above.
 
+### Debugging authority
+
+`manage.py explain_permission` answers "why can/can't this user do P at org O / on object R?".  It re-asks the canonical predicate (`can` / `can_obj` / `can_anywhere`) so it can never disagree with enforcement, then lists the arms behind the answer: global tier, direct grant, delegated grant, object grant (not wired yet), and the legacy `PermissionGroup` rows with the domain's live/inert posture.  Exits 0 on ALLOWED and 1 on DENIED — script-friendly.
+
+```shell
+python manage.py explain_permission --user jane@example.org --perm shelters.change_shelter --org 7
+python manage.py explain_permission --user 42 --perm shelters.view_shelter --object shelters.shelter:12
+```
+
 ## Overview
 
 Permission group templates define a **set of Django permissions** that can be assigned to users within an organization. A user's effective authority is the **union of the roles/Grants** they hold at that org — the template defines the bundle (mirrored by `RoleDef.from_template()`), and cut-over domains read the `Grant` arm while legacy-only domains (notes/clients) still read the template-backed `PermissionGroup` rows.
@@ -128,6 +137,8 @@ Each `groups.py` imports `TemplateConfig` and defines one or more template confi
 | `common/permissions/utils.py`       | `require_can()`, `IsAuthenticated`, `register_permission()`, `PERMISSION_DENIED_MESSAGE`              |
 | `common/permissions/config.py`      | `TemplateConfig`, `RoleDef` (incl. `from_template()`)                                                 |
 | `common/permissions/domain.py`      | `LEGACY_INERT_APPS` / `GLOBAL_TIER_ORG_APPS` — which domains are grant-only                           |
+| `common/permissions/explain.py`     | `explain()` — arm-by-arm explanation of a verdict; backs `explain_permission`                          |
+| `common/management/commands/explain_permission.py` | `manage.py explain_permission` — the authority debugger                              |
 | `accounts/groups.py`                | `ORG_ADMIN` / `ORG_SUPERUSER` templates + role definitions                                            |
 | `accounts/role_manager.py`          | `OrgRoleManager` — add/remove/clear/replace org roles; grant-only mirroring for `legacy_inert` roles  |
 | `accounts/signals.py`               | `User.groups` m2m edge — mirrors dual-write memberships to `Grant` rows                               |


### PR DESCRIPTION
## What

The DX gap flagged in the grant-model audit: nothing answered *"why can/can't user X do P at org O / on object R?"* — you had to read predicate code and run ad-hoc shell queries. This adds `manage.py explain_permission` plus its pure core `common.permissions.explain.explain()`.

## Design — the verdict can never disagree with enforcement

The explanation **re-asks the canonical predicate** for the mode — `can()` at an org, `can_obj()` on a row, `can_anywhere()` with no scope — then walks the arms behind it:

| arm | what it shows |
|---|---|
| global tier | superuser / global Role names / user_permissions |
| direct grant | role(s) + org; *"held roles at org that don't carry the perm"* when close-but-denied |
| delegated | permission-matched inheritance, and the *"delegation exists but the user doesn't act at the delegator"* near-miss |
| object grant | staged rows; not wired until the clients cutover |
| legacy rows | `PermissionGroup` membership with the domain's **live/inert** posture (`LEGACY_INERT_APPS`) |

The legacy arm doubles as a **cutover-progress view**: for notes/clients it shows the arm that actually authorizes today *and* the grant-model verdict (what enforcement becomes after cutover); for cut-over domains it proves leftover rows are inert.

```
user        Jane Doe <jane@example.org> (pk=42)
permission  shelters.change_shelter  [grant-only domain — legacy rows inert]
org         7 "Acme Housing"
verdict     ALLOWED  (org predicate)
arms
  global tier   no   superuser: no; global roles: none; user_permissions: no
  direct grant  YES  role(s) Shelter Operator at org 7
  delegated     no   no org-principal delegations scope this org for this permission
  object grant  no   no object grants — the arm is not wired yet (clients cutover)
  legacy rows   no   no PermissionGroup rows carry this permission — inert for this domain
```

Exits **0 on ALLOWED, 1 on DENIED** — script-friendly.

## Verified

- 13 new tests, all asserting the load-bearing property `verdict == can/can_obj/can_anywhere` per scenario, plus arm attribution (direct, delegated matched/unmatched, global role, superuser, legacy live vs inert, ORG vs SHARED write tier, command output + exit code).
- `common/tests` full suite: **245 passed**; ruff check/format clean; mypy clean on the new files (only the pre-existing `accounts/managers.py` `no-any-return` pair remains, untouched).
- Docs: `apps/betterangels-backend/docs/permissions.md` — new *Debugging authority* section + Key Files rows.

Stacked on #2453 (the ungated-mutation tripwire).

## Summary by Sourcery

Add an authority debugger that explains canonical permission decisions and identifies the grant or legacy sources behind them.

New Features:
- Add a pure permission-explanation API and `manage.py explain_permission` command for diagnosing a user's authority at an organization, on an object, or globally.
- Report authorization sources across global, direct, delegated, object, and legacy permission arms, including legacy live/inert status and near-miss details.

Enhancements:
- Ensure explanations always derive their verdict from the canonical permission predicates and provide script-friendly allowed/denied exit codes.

Documentation:
- Document the authority debugger, usage examples, and new permission explanation files.

Tests:
- Add coverage for predicate parity, authority attribution, delegation behavior, legacy-domain posture, object write tiers, validation, and command output/exit codes.