### PR TITLE
fix(perm): #2443 review follow-ups — reconcile unmirrors, teams canary, nits

### DIFF
--- a/apps/betterangels-backend/accounts/admin.py
+++ b/apps/betterangels-backend/accounts/admin.py
@@ -130,7 +130,7 @@ class PermissionGroupAdmin(admin.ModelAdmin):
         """
         deletable, model_count, perms_needed, protected = super().get_deleted_objects(objs, request)
 
-        role_backed = set(scoped_roles_for_groups(objs))
+        role_backed = set(scoped_roles_for_groups(objs).keys())
         losses = []
         for permission_group in objs:
             holders = permission_group.user_set.count()
@@ -487,13 +487,25 @@ class GrantAdmin(SuperuserOnlyWritesMixin, admin.ModelAdmin):
     )
     autocomplete_fields = ("principal_user", "principal_org", "role", "scope_org")
     readonly_fields = ("id",)
-    fields = (
-        "principal_user",
-        "principal_org",
-        "role",
-        "scope_org",
-        "scope_object_type",
-        "scope_object_id",
+    fieldsets = (
+        (
+            "Grant",
+            {
+                "fields": (
+                    "principal_user",
+                    "principal_org",
+                    "role",
+                    "scope_org",
+                    "scope_object_type",
+                    "scope_object_id",
+                ),
+                "description": (
+                    "A role-backed membership mirror creates its Grant row — and removing that "
+                    "membership deletes this row even when the role was also granted directly here "
+                    "(the unique constraint makes them the same row)."
+                ),
+            },
+        ),
     )
 
     @admin.display(description="Principal")
@@ -547,6 +559,7 @@ class GrantRowForm(forms.ModelForm):
                     rel=widget.rel,
                     admin_site=widget.admin_site,
                     attrs=getattr(widget, "attrs", None),
+                    using=getattr(widget, "using", None),
                     current_object=loaded if loaded is not None and loaded.pk is not None else None,
                 )
 
@@ -642,9 +655,12 @@ class CustomOrganizationAdmin(MemberInviteAdminMixin, admin.ModelAdmin):
         """Confirm before a save takes a role away from the people holding it.
 
         Two edits on this page do that, and neither shows it: unchecking an org
-        type, and ticking Delete on a permission group row.  Both end with
-        ``delete_orphaned_group`` tearing out the ``auth.Group``, and every member
-        holding that role loses it.
+        type, and ticking Delete on a permission group row.  Both delete
+        ``PermissionGroup`` rows, and the delete tears out each row's
+        ``auth.Group`` — the structural MTI cascade — dropping its memberships
+        with it.  The org-type route also revokes the members' mirrored Grants
+        (``reconcile_org_groups`` unmirrors stale derived rows); a plain row
+        delete leaves Grants standing, per the teardown asymmetry.
 
         Interposed here rather than in the form because the form cannot re-render
         the whole change view, and because a ``clean()`` error would be the wrong

--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -28,7 +28,7 @@ from .models import (
     Role,
 )
 from .models import User as UserModel
-from .role_manager import OrgRoleManager
+from .role_manager import OrgRoleManager, unmirror_membership_grants
 from .seed import _resolve_permissions, sync_group_permissions
 
 if TYPE_CHECKING:
@@ -298,9 +298,9 @@ def reconcile_org_groups(org: Organization) -> None:
     permissions are still applied, so this function always leaves *org*
     consistent with config and is the only pass any caller needs to make.
 
-    Group names are refreshed from the organization's current name, and each
-    removed row's ``auth.Group`` is torn down by
-    :func:`accounts.signals.delete_orphaned_group`, and the surviving groups have
+    Group names are refreshed from the organization's current name, each removed
+    row's ``auth.Group`` is torn down structurally (the MTI cascade on
+    ``PermissionGroup`` delete — migration 0007), and the surviving groups have
     their permissions applied by :func:`accounts.seed.sync_group_permissions` —
     without this a newly created group would grant nothing until the next
     ``migrate``.
@@ -339,10 +339,21 @@ def reconcile_org_groups(org: Organization) -> None:
         unscoped = {template_config.name for template_config in REGISTRY.unscoped}
         derived = {name for name in REGISTRY.template_names() if name not in unscoped}
 
-        PermissionGroup.objects.filter(
-            organization=org,
-            template__name__in=derived - expected,
-        ).delete()
+        # Config cleanup revokes the mirrored authority (finding F1): the org's
+        # current types no longer grant this role, so its Grant goes with the
+        # row.  Unlike a teardown delete — which deliberately leaves Grants
+        # standing — reconcile knows these are stale derived rows, so their
+        # members are unmirrored before the delete.
+        stale = list(
+            PermissionGroup.objects.filter(
+                organization=org,
+                template__name__in=derived - expected,
+            ).prefetch_related("user_set")
+        )
+        for permission_group in stale:
+            for member in permission_group.user_set.all():
+                unmirror_membership_grants(member, [permission_group])
+        PermissionGroup.objects.filter(pk__in=[permission_group.pk for permission_group in stale]).delete()
 
     _refresh_group_names(org)
     sync_group_permissions(organization=org)
@@ -354,7 +365,7 @@ def _retire_legacy_inert_rows(org: Organization) -> None:
     The org-admin org-portal roles are grant-only (ADR 0001 teardown): their
     legacy rows are inert and redundant with the mirrored ``Grant`` rows, so
     they are retired idempotently wherever reconcile runs.  Deleting the row
-    tears down its ``auth.Group`` (``delete_orphaned_group``) and drops the
+    tears down its ``auth.Group`` (structural MTI cascade) and drops the
     group memberships — authority and member-role reporting now read the grant
     arm only.
     """

--- a/apps/betterangels-backend/accounts/signals.py
+++ b/apps/betterangels-backend/accounts/signals.py
@@ -164,9 +164,16 @@ def mirror_group_membership_grants(
 ) -> None:
     """Keep role-backed ``PermissionGroup`` memberships and Grants in step.
 
-    Wired to ``User.groups.through``, so every writer keeps the invariant —
-    the manager, the user admin, scripts, the shell — and reverse writes
-    (``permission_group.user_set.add/remove/clear``) are handled too.
+    Wired to ``User.groups.through``, so every writer that goes through the m2m
+    manager — the role manager, the user admin, scripts, the shell — keeps the
+    invariant, and reverse writes
+    (``permission_group.user_set.add/remove/clear``) are handled too.  Writers
+    that bypass the m2m manager (``through.objects.bulk_create``, raw SQL,
+    ``loaddata``, ``queryset.update()``) are the documented exception.  A
+    signal is deliberately the seam here: it is the only one every real writer
+    shares, so the invariant cannot be lost by a service-level refactor (ADR
+    0001 §4 phase 2 — a sanctioned exception to the "no logic in signals"
+    styleguide rule).
 
     A cascading delete of a ``PermissionGroup`` (teardown retiring a legacy
     row) does **not** emit ``m2m_changed`` — Django fast-deletes the through

--- a/apps/betterangels-backend/accounts/tests/test_role_manager_grants.py
+++ b/apps/betterangels-backend/accounts/tests/test_role_manager_grants.py
@@ -9,8 +9,9 @@ not just ``OrgRoleManager``.
 
 from typing import Any
 
-from accounts.models import Grant, PermissionGroup, Role, User
+from accounts.models import Grant, OrganizationProfile, PermissionGroup, Role, User
 from accounts.role_manager import OrgRoleManager
+from accounts.services import reconcile_org_groups
 from common.permissions.config import TemplateConfig
 from common.tests.utils import make_permission_group
 from django.test import TestCase
@@ -181,3 +182,34 @@ class MembershipEdgeMirrorTestCase(TestCase):
         PermissionGroup.objects.filter(pk=self.group.pk).delete()
 
         self.assertTrue(self._mirrors().exists())
+
+    def test_reconcile_of_a_stale_group_unmirrors_the_grant(self) -> None:
+        """Config cleanup REVOKES the mirrored authority (finding F1 on #2443).
+
+        A type change that drops a role must lose its Grant — reconcile knows
+        the row is stale, so it unmirrors before the delete.  That is the
+        counterpart to the teardown delete above, which deliberately does not.
+        """
+        self.user.groups.add(self.group)
+        self.assertTrue(self._mirrors().exists())
+
+        OrganizationProfile.objects.filter(organization=self.org).update(org_types=["shelter"])
+        reconcile_org_groups(self.org)
+
+        self.assertFalse(PermissionGroup.objects.filter(pk=self.group.pk).exists())
+        self.assertFalse(self._mirrors().exists())
+
+    def test_removing_a_membership_revokes_a_same_row_direct_grant(self) -> None:
+        """A direct Grant of the same role/org IS the mirrored row (finding F3).
+
+        The unique constraint makes them indistinguishable, so removing the
+        membership deletes the directly-created row too — pinned here, and
+        flagged in the ``GrantAdmin`` form description.
+        """
+        Grant.objects.create(principal_user=self.user, role=self.role, scope_org=self.org)
+        self.user.groups.add(self.group)
+        self.assertEqual(self._mirrors().count(), 1)  # add found the same row
+
+        self.user.groups.remove(self.group)
+
+        self.assertFalse(self._mirrors().exists())

--- a/apps/betterangels-backend/teams/tests/test_authz_registry.py
+++ b/apps/betterangels-backend/teams/tests/test_authz_registry.py
@@ -1,0 +1,52 @@
+"""Registry canary — every teams Query/Mutation field is protected (ADR 0001 §5.3).
+
+The teams cutover made authorization behavioral: each resolver authorizes
+through ``require_can`` (``_org_or_deny`` at the payload org for creates, the
+row's org for update/delete) and no transport permission extension guards the
+fields, so a future author could add an unguarded field and nothing would
+statically complain.
+
+These tests close that gap the same way the shelter cutover did (finding F8 on
+#2443): every field on the teams ``Query`` / ``Mutation`` types must appear
+below with its authorization route — adding a field means consciously
+registering it here.
+
+The registry documents the route; ``test_grant_authorization.py`` and the
+mutation suites prove the route actually enforces the permission.
+"""
+
+from typing import Any
+
+from teams.schema import Mutation, Query
+
+# field -> where authorization happens for that read.
+QUERY_AUTHZ_ROUTES: dict[str, str] = {
+    "teams": "resolver -> _org_or_deny(organizationId) + require_can(VIEW, org)",
+}
+
+# mutation -> where authorization happens for that write.
+MUTATION_AUTHZ_ROUTES: dict[str, str] = {
+    "create_team": "resolver -> _org_or_deny(organizationId) + require_can(ADD, org)",
+    "update_team": "resolver -> team_get + require_can(CHANGE, row org)",
+    "delete_team": "resolver -> team_get + require_can(DELETE, row org)",
+}
+
+
+def _field_names(cls: Any) -> set[str]:
+    return {f.python_name for f in cls.__strawberry_definition__.fields}
+
+
+def test_every_teams_query_field_is_registered() -> None:
+    actual = _field_names(Query)
+    assert actual == set(QUERY_AUTHZ_ROUTES), (
+        "Teams Query field(s) are not registered with an authorization route: "
+        f"{sorted(actual ^ set(QUERY_AUTHZ_ROUTES))}"
+    )
+
+
+def test_every_teams_mutation_field_is_registered() -> None:
+    actual = _field_names(Mutation)
+    assert actual == set(MUTATION_AUTHZ_ROUTES), (
+        "Teams Mutation field(s) are not registered with an authorization route: "
+        f"{sorted(actual ^ set(MUTATION_AUTHZ_ROUTES))}"
+    )


### PR DESCRIPTION
## What

Follow-up to #2443's adversarial review (Mike's "Previous review items — status" comment): the code fixes for the outstanding findings, stacked on the clients cutover (#2455) so the chain keeps merging bottom-up. #2443 itself is untouched — merge it (and the chain) first.

## Findings

| Finding | Status |
|---|---|
| **F1 (medium)** — reconcile-driven group deletion no longer revoked the mirrored authority | **Fixed (option a).** `reconcile_org_groups` unmirrors each stale derived row's members before deleting it (`unmirror_membership_grants`), so dropping an org type now fully revokes both arms; teardown deletes keep leaving Grants standing. Pinned by `test_reconcile_of_a_stale_group_unmirrors_the_grant`. |
| **F2 (low-med)** — signal-hosted invariant docs / overclaim / helper duplication | **Addressed.** Receiver docstring now states the sanctioned exception precisely (“every writer that goes through the m2m manager”; `bulk_create`/raw SQL/`loaddata`/`queryset.update` bypass — ADR 0001 §4 phase 2). Helper duplication was already consolidated in #2451 (`common/tests/utils.py`). |
| **F3 (low)** — same-role direct Grant destroyed with the membership | **Pinned + documented.** New `test_removing_a_membership_revokes_a_same_row_direct_grant`; `GrantAdmin` now carries a fieldset description warning that the unique constraint makes a direct grant and a membership mirror the same row. |
| **F4 (low)** — triple-literal `PERMISSION_DENIED_MESSAGE` | **Moot.** `accounts/extensions.py` was deleted by `590dc503` (dead org-admin machinery); no non-test hardcoded literal remains. |
| **F5 (nit)** — `set(scoped_roles_for_groups(objs))` | **Fixed** — `.keys()`. |
| **F6 (nit)** — stale `accounts.signals.delete_orphaned_group` refs | **Fixed** in `services.py` (×2) and the `admin.py` `change_view` docstring found alongside; tear-down now described as the structural MTI cascade (migration 0007). |
| **F7 (nit)** — `LoadedRowRawIdWidget` drops `using` | **Fixed** — preserved via `getattr(widget, "using", None)`. |
| **F8** — teams authz registry canary | **Fixed** — `teams/tests/test_authz_registry.py` mirrors the shelters pattern: every `Query`/`Mutation` field must be registered with its authorization route (4 fields: `teams`, `create_team`, `update_team`, `delete_team`). |
| Previous review item 4 (mobile header hook) | **Resolved upstream** — the `X-Organization-ID` header is fully retired (#2450 / #2452). |

## Validation

- Full backend suite: **1890 passed, 31 skipped** (baseline 1886 + the 4 new tests)
- `ruff check` + `ruff format --check` clean on changed files

Landing order unchanged: #2415 + #2443 → #2444 → … → #2455 → **this**, bottom-up.

## Summary by Sourcery

Harden organization-group permission reconciliation and teams authorization coverage.

Bug Fixes:
- Revoke mirrored grants when reconciliation removes stale organization groups while preserving teardown behavior.
- Clarify and document the membership/grant lifecycle, including the same-row direct-grant deletion behavior.
- Preserve the database alias when loading related admin widgets.

Enhancements:
- Correct role-backed group lookup handling and update admin and service documentation for structural group deletion.
- Add an authorization registry canary requiring every teams query and mutation field to declare its authorization route.

Tests:
- Add coverage for stale-group reconciliation revocation and same-row direct grant removal.
- Add teams query and mutation authorization registry tests.