### PR TITLE
feat(fe): teams pickers send the active organizationId (DEV-2566 step 1)

### DIFF
--- a/libs/expo/betterangels/src/lib/hooks/useOrgTeams/useOrgTeams.test.tsx
+++ b/libs/expo/betterangels/src/lib/hooks/useOrgTeams/useOrgTeams.test.tsx
@@ -18,13 +18,13 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { useOrgTeams } from './useOrgTeams';
 
 /**
- * Asserts what the store holds at the moment each request is issued — counted
- * at the link, rather than inferred from loading flags, which cannot
+ * Asserts which org each request names in its ``filters.organizationId``,
+ * counted at the link, rather than inferred from loading flags, which cannot
  * distinguish a request that never went out from one still in flight.
  *
- * ``useOrgTeams`` stands in for any org-scoped query; these are the
- * cross-project tests that exercise the store, the provider and the interceptor
- * together.
+ * ``useOrgTeams`` stands in for any org-scoped query: the org now travels in
+ * the operation's variables, read from the same active-org store the (retired)
+ * header interceptor used to read.
  */
 
 const ORG = { id: 'org-1', name: 'Test Org', permissions: [] as const };
@@ -58,19 +58,30 @@ function createSyncStorage(
   };
 }
 
-/** Records the org id visible to the interceptor for each operation issued. */
+type RecordedOperation = {
+  organizationId: string | null | undefined;
+  storeOrgId: string | null;
+};
+
+/** Records the org each operation names and what the store held at the time. */
 function createRecordingClient() {
-  const orgIdPerOperation: (string | null)[] = [];
+  const operations: RecordedOperation[] = [];
   const link = new ApolloLink(
-    () =>
+    (operation) =>
       new Observable((observer) => {
-        orgIdPerOperation.push(getActiveOrgId());
+        const filters = operation.variables?.filters as
+          | { organizationId?: string | null }
+          | undefined;
+        operations.push({
+          organizationId: filters?.organizationId,
+          storeOrgId: getActiveOrgId(),
+        });
         observer.next(TEAMS_RESULT as never);
         observer.complete();
       }),
   );
   return {
-    orgIdPerOperation,
+    operations,
     client: new ApolloClient({ link, cache: new InMemoryCache() }),
   };
 }
@@ -80,7 +91,7 @@ describe('useOrgTeams', () => {
   beforeEach(() => configureActiveOrgStorage(createSyncStorage()));
 
   function renderWith(organizations: readonly (typeof ORG)[]) {
-    const { client, orgIdPerOperation } = createRecordingClient();
+    const { client, operations } = createRecordingClient();
     const wrapper = ({ children }: { children: ReactNode }) => (
       <ApolloProvider client={client}>
         <ActiveOrgProvider organizations={[...organizations]}>
@@ -90,39 +101,57 @@ describe('useOrgTeams', () => {
     );
     return {
       ...renderHook(() => useOrgTeams(), { wrapper }),
-      orgIdPerOperation,
+      operations,
     };
   }
 
-  it('every request it issues carries an active org', async () => {
+  it('every request it issues names the active org', async () => {
     configureActiveOrgStorage(createSyncStorage());
 
-    const { result, orgIdPerOperation } = renderWith([ORG]);
+    const { result, operations } = renderWith([ORG]);
 
     await waitFor(() => expect(result.current.teams).toHaveLength(1));
-    expect(orgIdPerOperation.length).toBeGreaterThan(0);
-    expect(orgIdPerOperation).not.toContain(null);
+    expect(operations.length).toBeGreaterThan(0);
+    expect(operations.every((op) => op.organizationId === 'org-1')).toBe(true);
+    // The request names the same org the store held when it went out.
+    expect(operations.every((op) => op.organizationId === op.storeOrgId)).toBe(
+      true,
+    );
   });
 
   it('uses the remembered organization, not the first one', async () => {
     const other = { ...ORG, id: 'org-2', name: 'Other Org' };
     configureActiveOrgStorage(createSyncStorage('org-2'));
 
-    const { result, orgIdPerOperation } = renderWith([ORG, other]);
+    const { result, operations } = renderWith([ORG, other]);
 
     await waitFor(() => expect(result.current.teams).toHaveLength(1));
-    expect(orgIdPerOperation.every((id) => id === 'org-2')).toBe(true);
+    expect(operations.length).toBeGreaterThan(0);
+    expect(operations.every((op) => op.organizationId === 'org-2')).toBe(true);
   });
 
   it('queries with the remembered org before the org list has loaded', async () => {
     // UserProvider renders children with organizations={[]} while the user
     // query resolves. The store already holds the remembered organization, so
-    // the request is correctly attributed.
+    // the request carries it anyway.
     configureActiveOrgStorage(createSyncStorage('org-1'));
 
-    const { orgIdPerOperation } = renderWith([]);
+    const { operations } = renderWith([]);
 
-    await waitFor(() => expect(orgIdPerOperation.length).toBeGreaterThan(0));
-    expect(orgIdPerOperation.every((id) => id === 'org-1')).toBe(true);
+    await waitFor(() => expect(operations.length).toBeGreaterThan(0));
+    expect(operations.every((op) => op.organizationId === 'org-1')).toBe(true);
+  });
+
+  it('does not query while no org is active', async () => {
+    configureActiveOrgStorage(createSyncStorage());
+
+    const { result, operations } = renderWith([]);
+
+    // Nothing to scope the read to — the hook stays idle instead of issuing a
+    // request the backend would deny.
+    expect(result.current.teams).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+    await waitFor(() => expect(getActiveOrgId()).toBeNull());
+    expect(operations).toHaveLength(0);
   });
 });

--- a/libs/expo/betterangels/src/lib/hooks/useOrgTeams/useOrgTeams.ts
+++ b/libs/expo/betterangels/src/lib/hooks/useOrgTeams/useOrgTeams.ts
@@ -1,6 +1,12 @@
 import { useQuery } from '@apollo/client/react';
+import { getActiveOrgId, subscribeActiveOrgId } from '@monorepo/ba-platform';
 import type { OffsetPaginationInput } from '@monorepo/ba-platform/types';
-import { TeamsDocument, TeamsQuery } from './__generated__/teams.generated';
+import { useSyncExternalStore } from 'react';
+import {
+  TeamsDocument,
+  TeamsQuery,
+  TeamsQueryVariables,
+} from './__generated__/teams.generated';
 
 type UseOrgTeamsOptions = {
   limit?: number;
@@ -11,6 +17,10 @@ type UseOrgTeamsOptions = {
 /**
  * Fetch teams for the active organization.
  *
+ * The org travels in the ``organizationId`` filter — the request header is
+ * retired (DEV-2566) — read from the active-org store: the same value the UI
+ * shows, so the query can never run against a stale organization.
+ *
  * Passes a high default limit (10000) to ensure all teams are available
  * in dropdowns and selects. Handles loading and error states internally.
  *
@@ -18,11 +28,23 @@ type UseOrgTeamsOptions = {
  */
 export function useOrgTeams(options: UseOrgTeamsOptions = {}) {
   const { limit = 10000, offset = 0, isActive } = options;
+  const activeOrgId = useSyncExternalStore(
+    subscribeActiveOrgId,
+    getActiveOrgId,
+    getActiveOrgId,
+  );
 
   const pagination: OffsetPaginationInput = { limit, offset };
+  const variables: TeamsQueryVariables = {
+    pagination,
+    filters: { isActive, organizationId: activeOrgId },
+  };
 
   const { data, loading, error } = useQuery<TeamsQuery>(TeamsDocument, {
-    variables: { pagination, filters: { isActive } },
+    variables,
+    // No org to scope to yet (none remembered, or the user has none): stay
+    // idle rather than issue a request the backend would deny.
+    skip: !activeOrgId,
     fetchPolicy: 'cache-and-network',
   });
 


### PR DESCRIPTION
**Mobile-first split of #2450** (`feat/perm/teams-header-strip`) — see the rollout audit on #2457. Jira: DEV-2566.

## Why this lands first

The backend half of #2450 retires the `X-Organization-ID` header — any released app build that still reads as header-only would get `You do not have access to this organization.` on the teams query the moment that deploys (and teams power the TaskForm picker). The app can't be redeployed instantly, so the client change ships **first**:

## What changes

`useOrgTeams` reads the active-org store reactively (`useSyncExternalStore` over `getActiveOrgId` / `subscribeActiveOrgId` — the same store the header interceptor read) and sends it as `TeamFilter.organizationId`. The query is **skipped while no org is active** (none remembered, or the user has none) instead of issuing a request the backend would deny.

## Why it's safe against today's backend

- `TeamFilter.organizationId` already exists on main (merged in #2443), and the teams read **prefers the filter, falling back to the header** — so:
  - old binaries (header only) → still work;
  - updated binaries (filter) → work against both today's backend and the post-retirement backend.
- The header interceptor **keeps sending** the header; its removal is #2452, which must land **after** the backend retirement.

## Rollout

1. **This PR** → publish via **EAS Update targeting the current `runtimeVersion`** (or the next store build if the runtime moved).
2. Once the build is live and adopted: land #2450's backend retirement (header + middleware deleted) and then #2452 (interceptor removal). Neither should deploy before step 1 is in users' hands.

## Notes

- #2450's rebase: drop its FE hunks (these files) — they're this PR.
- Tests pin the operation variables at the link (org named on every request, remembered org wins, idle with no org); `vitest` runs in CI (the dev container ships only the darwin rolldown binding).
- Verified locally: `tsc --noEmit` (lib + spec), `eslint`, `prettier`.

## Summary by Sourcery

Scope team picker queries to the active organization and avoid unauthorized requests when no organization is selected.

New Features:
- Send the active organization ID in team query filters so teams are scoped to the organization shown in the UI.
- Keep team queries idle when no organization is active.

Enhancements:
- Reactively synchronize team queries with the active-organization store, including remembered organizations before the organization list loads.

Tests:
- Update team hook coverage to verify organization IDs in request variables, remembered-organization behavior, and no-request behavior without an active organization.