### PR TITLE
docs: API compatibility — staged rollouts for mobile-visible schema changes

### DIFF
--- a/apps/betterangels-backend/docs/api-compatibility.md
+++ b/apps/betterangels-backend/docs/api-compatibility.md
@@ -1,0 +1,44 @@
+# API Compatibility — Mobile Clients vs Instant Backend Deploys
+
+How to change the GraphQL API without breaking the **released mobile app** (`libs/expo/betterangels`, shipped through EAS).
+
+## The asymmetry
+
+- The backend deploys in minutes; the app in users' hands does not.
+- Web apps (`betterangels-admin`, `shelter-web`, `react/*`) deploy with the backend — they do not constrain schema changes. **Mobile clients do.**
+- **EAS Update** can ship JS-only changes without a store review, but the update still applies on a user's **next app open** and only within the same `runtimeVersion`. It is a fast window, not an instant one — and a native-dependency change needs a full store build.
+
+## The rules
+
+1. **Never add a required input field (or required argument) in one step.**
+   - New client → old backend: `Field 'organizationId' is not defined by type 'CreateTaskInput'`.
+   - Old client → new backend: `Field 'organizationId' of required type 'ID!' was not provided`.
+   - So neither side can ship first alone — a **tolerant middle phase is mandatory** (below).
+2. **Never remove a field, mutation, or fallback** until clients using it are gone. Check usage first: `git grep <symbol> origin/main -- libs/expo`.
+3. **Additive changes are deploy-safe**: new fields, new *optional* inputs/arguments, new queries/mutations, and server-side directive swaps (`@hasPerm` etc. — clients never send directives). No staging needed.
+4. **Semantic tightening needs its data story**: if enforcement starts denying callers who previously succeeded, the conversion (grant/role backfills — e.g. the `post_migrate` grant backfills in `accounts/apps.py`) must be live **before** the enforcement ships.
+
+## The recipe: tolerant → release → strict
+
+For any change that moves the contract (new required field, fallback removal, enforcement flip), split it across **three deployments**:
+
+| Step | What ships | Why it's safe |
+| ---- | ---------- | ------------- |
+| **1. Tolerant backend** | Backend accepts both behaviors: implement the new path when the new input/argument is present; keep the **old behavior verbatim** when it is absent. Pin both paths in tests. | Old binaries keep working; new binaries exercise the new path early. Deploy immediately. |
+| **2. Client release** | The app change that sends the new input. Prefer EAS Update on the current `runtimeVersion`; store build otherwise. | Backend already accepts it; un-updated binaries still ride the tolerant path. |
+| **3. Strict flip** | Make the field required / delete the fallback. A **separate, small PR**. | Only after adoption. Old binaries now fail — by design, and only when we chose the moment. |
+
+Rules of thumb:
+
+- **Do not bundle step 3 into step 1 "to save a deploy."** Review/merge timing is not release timing; the gate is *adoption*, and a bundled flip removes the option to wait.
+- Ship each step as its own PR (steps 1 and 3 may be stacked, with the step-3 PR carrying a **DO NOT LAND** checklist: tolerant backend live → build released → adoption window elapsed).
+- Put the ordering requirement in the PR bodies and link the related PRs (see examples below).
+
+## Examples
+
+- **Teams — header retirement (DEV-2566).** `TeamFilter.organizationId` already existed and the backend already prefers the filter, falling back to the `X-Organization-ID` header — so the FE change alone was safe to ship **first** (#2458). The header/middleware retirement (#2450) and the interceptor removal (#2452) wait for the FE build's adoption.
+- **Tasks — payload org (RFC 0003 slice 1, DEV-2561).** `createTask` grew `organizationId`. Tolerant backend + mobile wiring (#2457, with `task_create_legacy` preserving the pre-cutover path), strict flip (#2459) gated on the app build being live.
+
+## What non-holders see
+
+Staging controls *when* the contract moves; what a caller *without* authority gets (OperationInfo vs top-level error vs empty list) is pinned per mechanism in [`graphql_errors.md` §1.4.1](./graphql_errors.md) — denial-shape tests belong in the domain's parity suite (`tasks/tests/test_grant_authorization.py`, `clients/tests/test_clients_grant_authorization.py`, …).

--- a/apps/betterangels-backend/docs/graphql_errors.md
+++ b/apps/betterangels-backend/docs/graphql_errors.md
@@ -349,3 +349,4 @@ The `_handle_error_response` method maps upstream HTTP status codes to exception
 | `apps/betterangels-backend/clients/enums.py`             | `ErrorCodeEnum` — machine-readable error codes for custom validation                              |
 | `apps/betterangels-backend/hmis/api_bridge.py`           | HMIS proxy — raises `GraphQLError` for upstream 422 responses                                     |
 | `apps/betterangels-backend/schema.graphql`               | Generated schema showing all payload unions with `OperationInfo`                                  |
+| `apps/betterangels-backend/docs/api-compatibility.md`    | Staged rollouts for mobile-visible schema changes (tolerant → release → strict)                   |


### PR DESCRIPTION
**Docs-only.** Codifies the rollout discipline the mobile compat audit produced (teams #2450/#2458, tasks #2457/#2459): released mobile binaries + instant backend deploys mean contract moves must be staged **tolerant → release → strict**, never in one step.

- New `apps/betterangels-backend/docs/api-compatibility.md`: the asymmetry, the four rules (no one-step required fields, no fallback removal before adoption, additive changes are safe, semantic tightening needs its backfills), the three-deployment recipe with the DO-NOT-LAND checklist convention, and worked examples from the two live cutovers.
- Pointer row added to `graphql_errors.md`'s Related files (denial *shapes* stay there; this doc is about *when* contracts move).

## Summary by Sourcery

Document the tolerant → release → strict rollout process for safely evolving API contracts used by released mobile clients.

New Features:
- Document staged API rollout guidance for mobile-visible GraphQL schema changes, including compatibility rules, deployment sequencing, and real-world cutover examples.

Enhancements:
- Clarify how released mobile clients constrain backend contract changes and distinguish rollout timing from authorization error-shape behavior.

Documentation:
- Link the new API compatibility guidance from the GraphQL errors documentation.