### PR TITLE
sketch(perm): access classes — declared on the model, enforced by the selectors (ADR 0004)

### DIFF
--- a/apps/betterangels-backend/common/models.py
+++ b/apps/betterangels-backend/common/models.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Iterator, Optional, cast
 
 from common.enums import AttachmentType
@@ -27,6 +28,24 @@ class BaseModel(models.Model):
         abstract = True
 
 
+# ``Access.read`` / ``Access.write`` value: only the global tier passes — org scopes never widen it.
+ACCESS_GLOBAL = "global"
+
+
+@dataclass(frozen=True)
+class Access:
+    """Authority classes for a model's rows, per direction (sketch, ADR 0004).
+
+    ``None`` leaves the org rules in charge (reach-driven reads; the model's
+    write tier for writes).  ``ACCESS_GLOBAL`` means only the global tier ever
+    passes.  The write-tier values (SHARED, OBJECT) and PARENT fold in from
+    the write-tiers work — one declaration slot, no new attributes.
+    """
+
+    read: str | None = None
+    write: str | None = None
+
+
 class OrgScoped(models.Model):
     """Declares how a model reaches the organizations that scope it (ADR 0001).
 
@@ -40,9 +59,15 @@ class OrgScoped(models.Model):
 
     Object-grant ancestors are derived from the same graph, so this one
     declaration drives both the org filter and the object-grant cascade.
+
+    ``access`` (sketch, ADR 0004) optionally names the authority classes that
+    take precedence over org reach — per direction (``read`` / ``write``).
+    ``ACCESS_GLOBAL`` means only the global tier ever passes; the default
+    (``None``) leaves the org rules in charge.
     """
 
     org_via: ClassVar[tuple[str, ...] | None] = ()
+    access: ClassVar[Access] = Access()
     _org_paths: ClassVar[tuple[str, ...] | None] = None
 
     class Meta:

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -285,12 +285,17 @@ def can_anywhere(user: "User", perm: str) -> bool:
     return s is ALL or s.exists()
 
 
-def holds_globally(user: "User", perm: str) -> bool:
+def can_globally(user: "User", perm: str) -> bool:
     """Whether *user* holds *perm* at the global tier — never through a Grant.
 
     The global arm of :func:`scopes`: superuser, a global Role carrying *perm*
     in ``user.groups``, or a direct ``user_permissions`` row.  Scoped Grant
     reach never satisfies this, so it is the check for gates that must stay
     global (e.g. BA-only fields only the GSO role may exercise).
+
+    Sibling of :func:`can_anywhere`, which admits scoped Grant reach
+    (``ALL or s.exists()``) — use this predicate only when scoped authority
+    must never satisfy the gate.  The two diverge the moment a scoped Role
+    carries *perm* and is granted.
     """
     return scopes(user, perm) is ALL

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -224,6 +224,8 @@ def invalidate_scope_cache(user: "User") -> None:
 def visible(qs: "QuerySet", user: "User", perm: str, *, in_org: str | None = None) -> "QuerySet":
     """The rows of *qs* on which *user* may exercise *perm*.
 
+    * ``access.read = ACCESS_GLOBAL`` — all rows for the global tier, none for
+      anyone else (org scopes never widen it).
     * ``ALL`` (global tier) — the queryset, unconfined.
     * platform-shared model (``org_via = None``) — all rows when *user* holds
       *perm* anywhere, none otherwise.
@@ -233,13 +235,19 @@ def visible(qs: "QuerySet", user: "User", perm: str, *, in_org: str | None = Non
     *in_org* confines the view to one organization, and only for finite scopes —
     a global holder is never org-confined by a stale header (ADR 0001 §2.4).
     """
-    from common.models import OrgScoped
+    from common.models import ACCESS_GLOBAL, OrgScoped
 
     if not issubclass(qs.model, OrgScoped):
         return qs.none()
 
-    paths = qs.model.org_paths()
     s = scopes(user, perm)
+
+    if qs.model.access.read == ACCESS_GLOBAL:
+        # GLOBAL read class: only the global tier passes; org reach
+        # (including a scoped holder of the perm) never widens the rows.
+        return qs if s is ALL else qs.none()
+
+    paths = qs.model.org_paths()
 
     if s is ALL:
         qs = qs
@@ -282,6 +290,36 @@ def can_obj(user: "User", perm: str, obj: "Model") -> bool:
 def can_anywhere(user: "User", perm: str) -> bool:
     """Authority anywhere — the check for creates on platform-shared models."""
     s = scopes(user, perm)
+    return s is ALL or s.exists()
+
+
+def _access_class(model: "type[Model]", perm: str) -> str | None:
+    """The declared authority class for *perm* on *model* (sketch, ADR 0004).
+
+    Reads resolve through ``Access.read``; everything else through
+    ``Access.write`` — the split follows Django's codename convention.
+    """
+    access = getattr(model, "access", None)
+    if access is None:
+        return None
+    codename = perm.rsplit(".", 1)[-1]
+    return access.read if codename.startswith("view_") else access.write
+
+
+def can_model(user: "User", perm: str, model: "type[Model]") -> bool:
+    """Rowless authority on a *model's* declared access class.
+
+    The gate for payload fields whose rows do not exist yet (nested creates,
+    fields on a parent mutation), where :func:`visible` cannot be applied.
+    A GLOBAL-class model answers at the global tier only — a scoped Grant
+    holding the perm anywhere still fails; other models keep today's
+    :func:`can_anywhere` semantics until ADR 0004 defines the full matrix.
+    """
+    from common.models import ACCESS_GLOBAL
+
+    s = scopes(user, perm)
+    if _access_class(model, perm) == ACCESS_GLOBAL:
+        return s is ALL
     return s is ALL or s.exists()
 
 

--- a/apps/betterangels-backend/common/permissions/selectors.py
+++ b/apps/betterangels-backend/common/permissions/selectors.py
@@ -283,3 +283,14 @@ def can_anywhere(user: "User", perm: str) -> bool:
     """Authority anywhere — the check for creates on platform-shared models."""
     s = scopes(user, perm)
     return s is ALL or s.exists()
+
+
+def holds_globally(user: "User", perm: str) -> bool:
+    """Whether *user* holds *perm* at the global tier — never through a Grant.
+
+    The global arm of :func:`scopes`: superuser, a global Role carrying *perm*
+    in ``user.groups``, or a direct ``user_permissions`` row.  Scoped Grant
+    reach never satisfies this, so it is the check for gates that must stay
+    global (e.g. BA-only fields only the GSO role may exercise).
+    """
+    return scopes(user, perm) is ALL

--- a/apps/betterangels-backend/common/tests/test_permissions_selectors.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_selectors.py
@@ -12,7 +12,7 @@ from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
 from shelters.models import ContactInfo, Shelter
 from shelters.tests.baker_recipes import shelter_recipe
 
-from common.permissions.selectors import ALL, can, can_anywhere, can_obj, holds_globally, scopes, visible
+from common.permissions.selectors import ALL, can, can_anywhere, can_globally, can_obj, scopes, visible
 
 
 class GrantSelectorsTestCase(TestCase):
@@ -151,33 +151,36 @@ class GrantSelectorsTestCase(TestCase):
         self.assertFalse(can_anywhere(stranger, ClientProfile.perms.VIEW))
 
 
-class HoldsGloballyTestCase(TestCase):
-    """holds_globally is the global arm of scopes — Grant reach never satisfies it."""
+class CanGloballyTestCase(TestCase):
+    """can_globally is the global arm of scopes — Grant reach never satisfies it."""
 
     def setUp(self) -> None:
         sync_roles()
-        self.org = organization_recipe.make(name="Holds Globally Org")
+        self.org = organization_recipe.make(name="Can Globally Org")
         self.shelter_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
         self.gso_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
 
-    def test_global_role_carrying_the_perm_holds_it_globally(self) -> None:
+    def test_global_role_holder_can_act_globally(self) -> None:
         gso = baker.make(User)
         role_assign(user=gso, role=self.gso_role)
 
-        self.assertTrue(holds_globally(gso, ContactInfo.perms.CHANGE))
+        self.assertTrue(can_globally(gso, ContactInfo.perms.CHANGE))
 
-    def test_scoped_grant_reach_never_holds_globally(self) -> None:
+    def test_scoped_grant_holder_cannot_act_globally(self) -> None:
         alice = baker.make(User)
         grant_create(user=alice, role=self.shelter_role, scope_org=self.org)
 
-        self.assertFalse(holds_globally(alice, Shelter.perms.VIEW))
+        # The near-miss pinned: ``can_anywhere`` admits this scoped holder, so
+        # it can never substitute for a global-only gate.
+        self.assertTrue(can_anywhere(alice, Shelter.perms.VIEW))
+        self.assertFalse(can_globally(alice, Shelter.perms.VIEW))
 
-    def test_user_without_authority_does_not_hold_globally(self) -> None:
+    def test_user_without_authority_cannot_act_globally(self) -> None:
         stranger = baker.make(User)
 
-        self.assertFalse(holds_globally(stranger, ContactInfo.perms.VIEW))
+        self.assertFalse(can_globally(stranger, ContactInfo.perms.VIEW))
 
-    def test_superuser_holds_globally(self) -> None:
+    def test_superuser_can_act_globally(self) -> None:
         admin = baker.make(User, is_superuser=True)
 
-        self.assertTrue(holds_globally(admin, ContactInfo.perms.VIEW))
+        self.assertTrue(can_globally(admin, ContactInfo.perms.VIEW))

--- a/apps/betterangels-backend/common/tests/test_permissions_selectors.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_selectors.py
@@ -12,7 +12,8 @@ from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
 from shelters.models import ContactInfo, Shelter
 from shelters.tests.baker_recipes import shelter_recipe
 
-from common.permissions.selectors import ALL, can, can_anywhere, can_globally, can_obj, scopes, visible
+from common.models import ACCESS_GLOBAL
+from common.permissions.selectors import ALL, can, can_anywhere, can_globally, can_model, can_obj, scopes, visible
 
 
 class GrantSelectorsTestCase(TestCase):
@@ -149,6 +150,74 @@ class GrantSelectorsTestCase(TestCase):
 
         self.assertTrue(can_anywhere(alice, ClientProfile.perms.VIEW))
         self.assertFalse(can_anywhere(stranger, ClientProfile.perms.VIEW))
+
+
+class AccessClassTestCase(TestCase):
+    """A model's declared ``access`` slot outranks org reach (ADR 0004 sketch).
+
+    ``ContactInfo`` declares the ``ACCESS_GLOBAL`` class: the global tier sees
+    every row, and a scoped holder of the very same permission sees none — for
+    the row filter (:func:`visible`), the single-row check (:func:`can_obj`),
+    and the rowless gate (:func:`can_model`) alike.
+    """
+
+    def setUp(self) -> None:
+        sync_roles()
+        self.org = organization_recipe.make(name="Access Class Org")
+        self.shelter = shelter_recipe.make(organization=self.org)
+        self.contact = baker.make(ContactInfo, shelter=self.shelter, contact_number="+12135551234")
+        self.shelter_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
+        self.gso_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
+
+    def _scoped_contact_reader(self) -> User:
+        """A scoped Grant holder that DOES carry the ContactInfo perm."""
+        alice = baker.make(User)
+        role = Role.objects.create(name="Scoped Contact Reader")
+        perm, _ = Permission.objects.get_or_create(
+            content_type=ContentType.objects.get_for_model(ContactInfo),
+            codename=ContactInfo.perms.VIEW.split(".")[1],
+            defaults={"name": "Can view contact info"},
+        )
+        role.permissions.add(perm)
+        grant_create(user=alice, role=role, scope_org=self.org)
+        return alice
+
+    def test_declaration_is_on_the_model(self) -> None:
+        self.assertEqual(ContactInfo.access.read, ACCESS_GLOBAL)
+        self.assertEqual(ContactInfo.access.write, ACCESS_GLOBAL)
+        self.assertIsNone(Shelter.access.read)
+        self.assertIsNone(Shelter.access.write)
+
+    def test_global_class_visible_is_global_tier_only(self) -> None:
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+        scoped = self._scoped_contact_reader()
+
+        self.assertTrue(visible(ContactInfo.objects.all(), gso, ContactInfo.perms.VIEW).exists())
+        self.assertFalse(visible(ContactInfo.objects.all(), scoped, ContactInfo.perms.VIEW).exists())
+
+    def test_global_class_can_obj_is_global_tier_only(self) -> None:
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+        scoped = self._scoped_contact_reader()
+
+        self.assertTrue(can_obj(gso, ContactInfo.perms.VIEW, self.contact))
+        self.assertFalse(can_obj(scoped, ContactInfo.perms.VIEW, self.contact))
+
+    def test_can_model_reads_the_declaration(self) -> None:
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+        scoped = self._scoped_contact_reader()
+        stranger = baker.make(User)
+        bob = baker.make(User)
+        grant_create(user=bob, role=self.shelter_role, scope_org=self.org)
+
+        self.assertTrue(can_model(gso, ContactInfo.perms.CHANGE, ContactInfo))
+        # The scoped reader HOLDS VIEW in its scope — the class still refuses it.
+        self.assertFalse(can_model(scoped, ContactInfo.perms.VIEW, ContactInfo))
+        self.assertFalse(can_model(stranger, ContactInfo.perms.VIEW, ContactInfo))
+        # Non-GLOBAL models keep today's can_anywhere semantics.
+        self.assertTrue(can_model(bob, Shelter.perms.VIEW, Shelter))
 
 
 class CanGloballyTestCase(TestCase):

--- a/apps/betterangels-backend/common/tests/test_permissions_selectors.py
+++ b/apps/betterangels-backend/common/tests/test_permissions_selectors.py
@@ -3,15 +3,16 @@
 from accounts.models import Role, User
 from accounts.services import grant_create, role_assign, sync_roles
 from accounts.tests.baker_recipes import organization_recipe
-from common.permissions.selectors import ALL, can, can_anywhere, can_obj, scopes, visible
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from model_bakery import baker
 from notes.models import Note
 from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR_ROLE
-from shelters.models import Shelter
+from shelters.models import ContactInfo, Shelter
 from shelters.tests.baker_recipes import shelter_recipe
+
+from common.permissions.selectors import ALL, can, can_anywhere, can_obj, holds_globally, scopes, visible
 
 
 class GrantSelectorsTestCase(TestCase):
@@ -148,3 +149,35 @@ class GrantSelectorsTestCase(TestCase):
 
         self.assertTrue(can_anywhere(alice, ClientProfile.perms.VIEW))
         self.assertFalse(can_anywhere(stranger, ClientProfile.perms.VIEW))
+
+
+class HoldsGloballyTestCase(TestCase):
+    """holds_globally is the global arm of scopes — Grant reach never satisfies it."""
+
+    def setUp(self) -> None:
+        sync_roles()
+        self.org = organization_recipe.make(name="Holds Globally Org")
+        self.shelter_role = Role.objects.get(name=SHELTER_OPERATOR_ROLE.name)
+        self.gso_role = Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name)
+
+    def test_global_role_carrying_the_perm_holds_it_globally(self) -> None:
+        gso = baker.make(User)
+        role_assign(user=gso, role=self.gso_role)
+
+        self.assertTrue(holds_globally(gso, ContactInfo.perms.CHANGE))
+
+    def test_scoped_grant_reach_never_holds_globally(self) -> None:
+        alice = baker.make(User)
+        grant_create(user=alice, role=self.shelter_role, scope_org=self.org)
+
+        self.assertFalse(holds_globally(alice, Shelter.perms.VIEW))
+
+    def test_user_without_authority_does_not_hold_globally(self) -> None:
+        stranger = baker.make(User)
+
+        self.assertFalse(holds_globally(stranger, ContactInfo.perms.VIEW))
+
+    def test_superuser_holds_globally(self) -> None:
+        admin = baker.make(User, is_superuser=True)
+
+        self.assertTrue(holds_globally(admin, ContactInfo.perms.VIEW))

--- a/apps/betterangels-backend/shelters/constants.py
+++ b/apps/betterangels-backend/shelters/constants.py
@@ -2,6 +2,3 @@
 
 DAILY_MINUTES = 24 * 60  # 1440
 WEEK_MINUTES = 7 * DAILY_MINUTES  # 10080
-
-# django-waffle flag gating BA-internal shelter fields.
-BA_ADMIN_ONLY_FIELDS_FLAG = "ffShelterOperatorBaOnlyFields"

--- a/apps/betterangels-backend/shelters/groups.py
+++ b/apps/betterangels-backend/shelters/groups.py
@@ -6,6 +6,7 @@ from common.permissions.config import RoleDef, TemplateConfig
 
 from shelters.models.availability import ShelterAvailability
 from shelters.models.lookups import (
+    SPA,
     Accessibility,
     City,
     Demographic,
@@ -18,18 +19,11 @@ from shelters.models.lookups import (
     RoomStyle,
     ShelterProgram,
     ShelterType,
-    SPA,
     SpecialSituationRestriction,
     Storage,
     VaccinationRequirement,
 )
-from shelters.models.media import (
-    ExteriorShelterPhoto,
-    InteriorShelterPhoto,
-    MediaLink,
-    ShelterPhoto,
-    Video,
-)
+from shelters.models.media import ExteriorShelterPhoto, InteriorShelterPhoto, MediaLink, ShelterPhoto, Video
 from shelters.models.reservation import Reservation
 from shelters.models.schedule import Schedule
 from shelters.models.service import Service, ServiceCategory
@@ -191,6 +185,9 @@ GLOBAL_SHELTER_OPERATOR = TemplateConfig(
         Video.perms.DELETE,
         Video.perms.VIEW,
         # ── shelters misc ──
+        # ContactInfo perms are the global-tier gate for the BA-only
+        # additional-contacts field (``update_shelter`` / ``additionalContacts``);
+        # the scoped SHELTER_OPERATOR role deliberately carries none (ADR 0001 §2.4).
         ContactInfo.perms.ADD,
         ContactInfo.perms.CHANGE,
         ContactInfo.perms.DELETE,

--- a/apps/betterangels-backend/shelters/groups.py
+++ b/apps/betterangels-backend/shelters/groups.py
@@ -54,6 +54,8 @@ SHELTER_OPERATOR = TemplateConfig(
         # sees their org's private shelters through the org-scoped visible()
         # path instead (ADR 0001 §2.4).
         ClientProfile.perms.VIEW,
+        # ContactInfo deliberately NOT on the scoped role as it is
+        # currenty used for internal BA users only.
     ],
     invite_html="account/email/shelter_operator_invite.html",
     invite_txt="account/messages/shelter_operator_invite.txt",

--- a/apps/betterangels-backend/shelters/models/shelter.py
+++ b/apps/betterangels-backend/shelters/models/shelter.py
@@ -5,7 +5,7 @@ from functools import cache
 from typing import Any
 
 import pghistory
-from common.models import BaseModel, OrgScoped
+from common.models import ACCESS_GLOBAL, Access, BaseModel, OrgScoped
 from common.permissions.utils import PermissionSet, perm
 from django.contrib.gis.db.models import PointField
 from django.contrib.gis.geos import Point
@@ -373,6 +373,10 @@ class Room(CloneMixin, OrgScoped, BaseModel):
 )
 class ContactInfo(OrgScoped):
     org_via = ("shelter",)
+    # BA-only: platform staff (global tier) manage these — the org reach above
+    # exists for the object graph, never for authority.  Surfaces gate through
+    # the selectors, which read this declaration (ADR 0004 sketch).
+    access = Access(read=ACCESS_GLOBAL, write=ACCESS_GLOBAL)
 
     class perms(PermissionSet):
         pass

--- a/apps/betterangels-backend/shelters/schema.py
+++ b/apps/betterangels-backend/shelters/schema.py
@@ -6,7 +6,7 @@ import strawberry_django
 from accounts.models import Organization, User
 from accounts.types import OrganizationType
 from common.graphql.types import AuthorizedPresignedS3UploadsType, BulkDeleteInput, BulkDeleteResult, DeletedObjectType
-from common.permissions.selectors import holds_globally
+from common.permissions.selectors import can_globally
 from common.permissions.utils import IsAuthenticated
 from django.core.exceptions import PermissionDenied
 from django.db.models import Max, QuerySet
@@ -142,7 +142,7 @@ class Mutation:
         # BA-only field: gate on the global tier only — a scoped Grant must
         # never pass (ADR 0001 §2.4).  Only global Roles carrying the
         # ContactInfo perms (the Global Shelter Operator) satisfy this.
-        if data.additional_contacts is not UNSET and not holds_globally(user, ContactInfo.perms.CHANGE):
+        if data.additional_contacts is not UNSET and not can_globally(user, ContactInfo.perms.CHANGE):
             raise PermissionDenied("Editing additional contacts requires the Global Shelter Operator role.")
 
         clean = strawberry.asdict(data)

--- a/apps/betterangels-backend/shelters/schema.py
+++ b/apps/betterangels-backend/shelters/schema.py
@@ -6,17 +6,15 @@ import strawberry_django
 from accounts.models import Organization, User
 from accounts.types import OrganizationType
 from common.graphql.types import AuthorizedPresignedS3UploadsType, BulkDeleteInput, BulkDeleteResult, DeletedObjectType
-from common.permissions.selectors import can_globally
 from common.permissions.utils import IsAuthenticated
-from django.core.exceptions import PermissionDenied
 from django.db.models import Max, QuerySet
-from strawberry import ID, UNSET
+from strawberry import ID
 from strawberry.types import Info
 from strawberry_django.auth.utils import get_current_user
 from strawberry_django.pagination import OffsetPaginated
 
 from shelters.enums import StatusChoices
-from shelters.models import ContactInfo, Shelter
+from shelters.models import Shelter
 from shelters.selectors import shelter_get, shelter_metrics_window, shelter_organization_list
 from shelters.selectors import shelter_occupancy_metrics as shelter_occupancy_metrics_selector
 from shelters.services import shelter_photo
@@ -138,13 +136,8 @@ class Mutation:
 
     @strawberry_django.mutation(permission_classes=[IsAuthenticated])
     def update_shelter(self, info: Info, data: UpdateShelterInput) -> ShelterType:
+        """Update a shelter — authorization lives in :func:`shelter_update` (ADR 0001 §2.6)."""
         user = cast(User, get_current_user(info))
-        # BA-only field: gate on the global tier only — a scoped Grant must
-        # never pass (ADR 0001 §2.4).  Only global Roles carrying the
-        # ContactInfo perms (the Global Shelter Operator) satisfy this.
-        if data.additional_contacts is not UNSET and not can_globally(user, ContactInfo.perms.CHANGE):
-            raise PermissionDenied("Editing additional contacts requires the Global Shelter Operator role.")
-
         clean = strawberry.asdict(data)
         return cast(ShelterType, shelter_update(user=user, data=clean))
 

--- a/apps/betterangels-backend/shelters/schema.py
+++ b/apps/betterangels-backend/shelters/schema.py
@@ -5,14 +5,9 @@ import strawberry
 import strawberry_django
 from accounts.models import Organization, User
 from accounts.types import OrganizationType
-from common.graphql.types import (
-    AuthorizedPresignedS3UploadsType,
-    BulkDeleteInput,
-    BulkDeleteResult,
-    DeletedObjectType,
-)
+from common.graphql.types import AuthorizedPresignedS3UploadsType, BulkDeleteInput, BulkDeleteResult, DeletedObjectType
+from common.permissions.selectors import holds_globally
 from common.permissions.utils import IsAuthenticated
-from common.services.feature_flags import flag_is_active
 from django.core.exceptions import PermissionDenied
 from django.db.models import Max, QuerySet
 from strawberry import ID, UNSET
@@ -20,14 +15,9 @@ from strawberry.types import Info
 from strawberry_django.auth.utils import get_current_user
 from strawberry_django.pagination import OffsetPaginated
 
-from shelters.constants import BA_ADMIN_ONLY_FIELDS_FLAG
 from shelters.enums import StatusChoices
-from shelters.models import Shelter
-from shelters.selectors import (
-    shelter_get,
-    shelter_metrics_window,
-    shelter_organization_list,
-)
+from shelters.models import ContactInfo, Shelter
+from shelters.selectors import shelter_get, shelter_metrics_window, shelter_organization_list
 from shelters.selectors import shelter_occupancy_metrics as shelter_occupancy_metrics_selector
 from shelters.services import shelter_photo
 from shelters.services.bed import bed_clone, bed_create, bed_delete, bed_update
@@ -148,10 +138,13 @@ class Mutation:
 
     @strawberry_django.mutation(permission_classes=[IsAuthenticated])
     def update_shelter(self, info: Info, data: UpdateShelterInput) -> ShelterType:
-        if data.additional_contacts is not UNSET and not flag_is_active(info, BA_ADMIN_ONLY_FIELDS_FLAG):
-            raise PermissionDenied("Editing additional contacts is not enabled.")
-
         user = cast(User, get_current_user(info))
+        # BA-only field: gate on the global tier only — a scoped Grant must
+        # never pass (ADR 0001 §2.4).  Only global Roles carrying the
+        # ContactInfo perms (the Global Shelter Operator) satisfy this.
+        if data.additional_contacts is not UNSET and not holds_globally(user, ContactInfo.perms.CHANGE):
+            raise PermissionDenied("Editing additional contacts requires the Global Shelter Operator role.")
+
         clean = strawberry.asdict(data)
         return cast(ShelterType, shelter_update(user=user, data=clean))
 

--- a/apps/betterangels-backend/shelters/services/shelter.py
+++ b/apps/betterangels-backend/shelters/services/shelter.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Any, Dict, List
 
+from common.permissions.selectors import can_globally
 from common.permissions.utils import require_can
-from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, PermissionDenied, ValidationError
 from django.db import transaction
 from django.utils.text import slugify
 from organizations.models import Organization
@@ -273,11 +274,16 @@ def shelter_update(*, user: "User", data: Dict[str, Any]) -> Shelter:
 
     Only fields present in *data* (i.e. not ``UNSET``) are modified.
     Schedules, services, and additional contacts use full-replacement semantics
-    when provided.
+    when provided.  ``additional_contacts`` is a BA-only field: gated on the
+    global tier (``can_globally``) so a scoped Grant can never write it
+    (ADR 0001 §2.4).
 
     Raises:
         ``django.core.exceptions.ObjectDoesNotExist`` when no shelter matches the given ID
         or the user lacks permission.
+        ``django.core.exceptions.PermissionDenied`` when *data* carries
+        ``additional_contacts`` and the user lacks the global ContactInfo
+        ``change`` permission.
         ``django.core.exceptions.ValidationError`` on invalid data.
     """
     data = {k: v for k, v in data.items() if v is not UNSET}
@@ -286,6 +292,14 @@ def shelter_update(*, user: "User", data: Dict[str, Any]) -> Shelter:
 
     cities_served_ids = data.pop("cities_served_ids", None)
     spas_served_ids = data.pop("spas_served_ids", None)
+
+    # BA-only field: gate on the global tier only — a scoped Grant must never
+    # pass (ADR 0001 §2.4).  Only global Roles carrying the ContactInfo perms
+    # (the Global Shelter Operator) satisfy this.  Checked before the shelter
+    # lookup so an unauthorized caller gets the same refusal whether or not
+    # the shelter exists or is visible.
+    if "additional_contacts" in data and not can_globally(user, ContactInfo.perms.CHANGE):
+        raise PermissionDenied("Editing additional contacts is not allowed with this role.")
 
     shelter = shelter_get(
         user=user,

--- a/apps/betterangels-backend/shelters/services/shelter.py
+++ b/apps/betterangels-backend/shelters/services/shelter.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, List
 
-from common.permissions.selectors import can_globally
+from common.permissions.selectors import can_model
 from common.permissions.utils import require_can
 from django.core.exceptions import NON_FIELD_ERRORS, PermissionDenied, ValidationError
 from django.db import transaction
@@ -274,9 +274,9 @@ def shelter_update(*, user: "User", data: Dict[str, Any]) -> Shelter:
 
     Only fields present in *data* (i.e. not ``UNSET``) are modified.
     Schedules, services, and additional contacts use full-replacement semantics
-    when provided.  ``additional_contacts`` is a BA-only field: gated on the
-    global tier (``can_globally``) so a scoped Grant can never write it
-    (ADR 0001 §2.4).
+    when provided.  ``additional_contacts`` is a BA-only field: gated by
+    ContactInfo's declared access class (``ACCESS_GLOBAL``) so a scoped Grant
+    can never write it (ADR 0001 §2.4).
 
     Raises:
         ``django.core.exceptions.ObjectDoesNotExist`` when no shelter matches the given ID
@@ -293,12 +293,13 @@ def shelter_update(*, user: "User", data: Dict[str, Any]) -> Shelter:
     cities_served_ids = data.pop("cities_served_ids", None)
     spas_served_ids = data.pop("spas_served_ids", None)
 
-    # BA-only field: gate on the global tier only — a scoped Grant must never
-    # pass (ADR 0001 §2.4).  Only global Roles carrying the ContactInfo perms
+    # BA-only field: gated by ContactInfo's declared access class
+    # (``ACCESS_GLOBAL`` — only the global tier passes; a scoped Grant never
+    # can, ADR 0001 §2.4).  Only global Roles carrying the ContactInfo perms
     # (the Global Shelter Operator) satisfy this.  Checked before the shelter
     # lookup so an unauthorized caller gets the same refusal whether or not
     # the shelter exists or is visible.
-    if "additional_contacts" in data and not can_globally(user, ContactInfo.perms.CHANGE):
+    if "additional_contacts" in data and not can_model(user, ContactInfo.perms.CHANGE, ContactInfo):
         raise PermissionDenied("Editing additional contacts is not allowed with this role.")
 
     shelter = shelter_get(

--- a/apps/betterangels-backend/shelters/tests/test_mutations.py
+++ b/apps/betterangels-backend/shelters/tests/test_mutations.py
@@ -1,12 +1,12 @@
 from typing import Any
 
-from accounts.models import User
+from accounts.models import Role, User
+from accounts.services import role_assign
 from django.test import TestCase, ignore_warnings
 from model_bakery import baker
 from unittest_parametrize import ParametrizedTestCase
-from waffle.testutils import override_flag
 
-from shelters.constants import BA_ADMIN_ONLY_FIELDS_FLAG
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE
 from shelters.models import SPA, City, Service, ServiceCategory, Shelter
 from shelters.tests.utils import ShelterTestCase
 
@@ -1027,6 +1027,51 @@ class ShelterMutationPermissionTestCase(ShelterTestCase, TestCase):
         self.shelter.refresh_from_db()
         self.assertEqual(self.shelter.name, "Permission Target")
 
+    def test_update_shelter_additional_contacts_allowed_for_global_shelter_operator(self) -> None:
+        """The BA-only contacts field is a global-tier gate: the GSO may submit it."""
+        role_assign(
+            user=self.operator,
+            role=Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name),
+        )
+        self.graphql_client.force_login(self.operator)
+
+        response = self.execute_graphql(
+            self.UPDATE_MUTATION,
+            {
+                "data": {
+                    "id": str(self.shelter.pk),
+                    "additionalContacts": [{"contactName": "Ada", "contactNumber": "2125550100"}],
+                }
+            },
+        )
+
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(self.shelter.additional_contacts.count(), 1)
+        self.assertEqual(self.shelter.additional_contacts.get().contact_name, "Ada")
+
+    def test_update_shelter_additional_contacts_denied_for_scoped_operator(self) -> None:
+        """A scoped operator (no global ContactInfo perms) may not submit the field."""
+        self.graphql_client.force_login(self.operator)
+
+        response = self.execute_graphql(
+            self.UPDATE_MUTATION,
+            {
+                "data": {
+                    "id": str(self.shelter.pk),
+                    "additionalContacts": [{"contactName": "Ada", "contactNumber": "2125550100"}],
+                }
+            },
+        )
+
+        self.assertIsNone(response.get("errors"))
+        self.assertGraphQLOperationInfo(
+            response,
+            "updateShelter",
+            "Global Shelter Operator",
+            kind="PERMISSION",
+        )
+        self.assertEqual(self.shelter.additional_contacts.count(), 0)
+
     # ── deleteShelter ────────────────────────────────────────────────────────
 
     def test_delete_shelter_succeeds_for_user_with_delete_permission(self) -> None:
@@ -1075,10 +1120,15 @@ class UpdateShelterAdditionalContactsErrorShapeTestCase(ShelterTestCase, TestCas
 
     def setUp(self) -> None:
         super().setUp()
+        # The contacts field is a global-tier gate — log in as a GSO holder so
+        # these cases exercise the per-contact validation shape, not the gate.
+        role_assign(
+            user=self.operator,
+            role=Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name),
+        )
         self.graphql_client.force_login(self.operator)
         self.shelter = Shelter.objects.create(name="Contacts Error Shelter", organization=self.org)
 
-    @override_flag(BA_ADMIN_ONLY_FIELDS_FLAG, active=True)
     def test_two_new_contacts_each_with_error(self) -> None:
         response = self.execute_graphql(
             self.MUTATION,

--- a/apps/betterangels-backend/shelters/tests/test_mutations.py
+++ b/apps/betterangels-backend/shelters/tests/test_mutations.py
@@ -7,7 +7,7 @@ from model_bakery import baker
 from unittest_parametrize import ParametrizedTestCase
 
 from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE
-from shelters.models import SPA, City, Service, ServiceCategory, Shelter
+from shelters.models import SPA, City, ContactInfo, Service, ServiceCategory, Shelter
 from shelters.tests.utils import ShelterTestCase
 
 
@@ -1051,6 +1051,39 @@ class ShelterMutationPermissionTestCase(ShelterTestCase, TestCase):
 
     def test_update_shelter_additional_contacts_denied_for_scoped_operator(self) -> None:
         """A scoped operator (no global ContactInfo perms) may not submit the field."""
+        self.graphql_client.force_login(self.operator)
+
+        response = self.execute_graphql(
+            self.UPDATE_MUTATION,
+            {
+                "data": {
+                    "id": str(self.shelter.pk),
+                    "additionalContacts": [{"contactName": "Ada", "contactNumber": "2125550100"}],
+                }
+            },
+        )
+
+        self.assertIsNone(response.get("errors"))
+        self.assertGraphQLOperationInfo(
+            response,
+            "updateShelter",
+            "Global Shelter Operator",
+            kind="PERMISSION",
+        )
+        self.assertEqual(self.shelter.additional_contacts.count(), 0)
+
+    def test_update_shelter_additional_contacts_denied_for_granted_scoped_contactinfo_role(self) -> None:
+        """A scoped role carrying the ContactInfo perms plus a Grant still fails.
+
+        Adversarial on purpose: ``can_anywhere`` would admit this user, so only
+        a global-tier check keeps the gate closed (SDB-277).
+        """
+        self._grant_permission(
+            self.operator,
+            ContactInfo.perms.CHANGE,
+            self.org,
+            role_name="Scoped Contact Editor",
+        )
         self.graphql_client.force_login(self.operator)
 
         response = self.execute_graphql(

--- a/apps/betterangels-backend/shelters/tests/test_mutations.py
+++ b/apps/betterangels-backend/shelters/tests/test_mutations.py
@@ -1067,7 +1067,7 @@ class ShelterMutationPermissionTestCase(ShelterTestCase, TestCase):
         self.assertGraphQLOperationInfo(
             response,
             "updateShelter",
-            "Global Shelter Operator",
+            "Editing additional contacts is not allowed with this role.",
             kind="PERMISSION",
         )
         self.assertEqual(self.shelter.additional_contacts.count(), 0)
@@ -1100,7 +1100,7 @@ class ShelterMutationPermissionTestCase(ShelterTestCase, TestCase):
         self.assertGraphQLOperationInfo(
             response,
             "updateShelter",
-            "Global Shelter Operator",
+            "Editing additional contacts is not allowed with this role.",
             kind="PERMISSION",
         )
         self.assertEqual(self.shelter.additional_contacts.count(), 0)

--- a/apps/betterangels-backend/shelters/tests/test_operator_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_operator_queries.py
@@ -817,7 +817,7 @@ class OperatorShelterPermissionTestCase(GraphQLBaseTestCase):
 class OperatorShelterAdditionalContactsTestCase(GraphQLBaseTestCase):
     """additionalContacts on operatorShelter is a global-tier (GSO-only) field.
 
-    The field reads the global tier only (``can_globally``): a scoped shelter
+    The field reads the declared ``ACCESS_GLOBAL`` class: a scoped shelter
     operator — even with a VIEW grant — gets an empty list, while a Global
     Shelter Operator (whose global Role carries the ContactInfo perms) sees it.
     """

--- a/apps/betterangels-backend/shelters/tests/test_operator_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_operator_queries.py
@@ -817,7 +817,7 @@ class OperatorShelterPermissionTestCase(GraphQLBaseTestCase):
 class OperatorShelterAdditionalContactsTestCase(GraphQLBaseTestCase):
     """additionalContacts on operatorShelter is a global-tier (GSO-only) field.
 
-    The field reads the global tier only (``holds_globally``): a scoped shelter
+    The field reads the global tier only (``can_globally``): a scoped shelter
     operator — even with a VIEW grant — gets an empty list, while a Global
     Shelter Operator (whose global Role carries the ContactInfo perms) sees it.
     """
@@ -857,6 +857,24 @@ class OperatorShelterAdditionalContactsTestCase(GraphQLBaseTestCase):
 
     def test_additional_contacts_hidden_for_scoped_operator(self) -> None:
         response = self._query()
+        self.assertIsNone(response.get("errors"))
+        self.assertEqual(response["data"]["operatorShelter"]["additionalContacts"], [])
+
+    def test_additional_contacts_hidden_for_granted_scoped_contactinfo_role(self) -> None:
+        """A scoped role carrying the ContactInfo perms plus a Grant still fails.
+
+        Adversarial on purpose: ``can_anywhere`` would admit this user, so only
+        a global-tier check keeps the gate closed (SDB-277).
+        """
+        self._grant_permission(
+            self.org_1_case_manager_1,
+            ContactInfo.perms.VIEW,
+            self.org_1,
+            role_name="Scoped Contact Viewer",
+        )
+
+        response = self._query()
+
         self.assertIsNone(response.get("errors"))
         self.assertEqual(response["data"]["operatorShelter"]["additionalContacts"], [])
 

--- a/apps/betterangels-backend/shelters/tests/test_operator_queries.py
+++ b/apps/betterangels-backend/shelters/tests/test_operator_queries.py
@@ -1,13 +1,13 @@
 import datetime
 from typing import Any, Optional, cast
 
+from accounts.models import Role
+from accounts.services import role_assign
 from accounts.tests.baker_recipes import organization_recipe
 from common.tests.utils import GraphQLBaseTestCase
 from model_bakery import baker
 from unittest_parametrize import ParametrizedTestCase, parametrize
-from waffle.testutils import override_flag
 
-from shelters.constants import BA_ADMIN_ONLY_FIELDS_FLAG
 from shelters.enums import (
     DemographicChoices,
     PetChoices,
@@ -16,7 +16,7 @@ from shelters.enums import (
     StatusChoices,
 )
 from shelters.enums import ShelterChoices as ShelterTypeChoices
-from shelters.groups import SHELTER_OPERATOR
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR
 from shelters.models import (
     Bed,
     ContactInfo,
@@ -815,7 +815,12 @@ class OperatorShelterPermissionTestCase(GraphQLBaseTestCase):
 
 
 class OperatorShelterAdditionalContactsTestCase(GraphQLBaseTestCase):
-    """additionalContacts on operatorShelter is gated by ffShelterOperatorBaOnlyFields."""
+    """additionalContacts on operatorShelter is a global-tier (GSO-only) field.
+
+    The field reads the global tier only (``holds_globally``): a scoped shelter
+    operator — even with a VIEW grant — gets an empty list, while a Global
+    Shelter Operator (whose global Role carries the ContactInfo perms) sees it.
+    """
 
     ADDITIONAL_CONTACTS_QUERY = """
         query OperatorShelter($pk: ID!) {
@@ -850,14 +855,17 @@ class OperatorShelterAdditionalContactsTestCase(GraphQLBaseTestCase):
     def _query(self) -> dict:
         return self.execute_graphql(self.ADDITIONAL_CONTACTS_QUERY, {"pk": str(self.shelter.pk)})
 
-    @override_flag(BA_ADMIN_ONLY_FIELDS_FLAG, active=False)
-    def test_additional_contacts_hidden_when_flag_off(self) -> None:
+    def test_additional_contacts_hidden_for_scoped_operator(self) -> None:
         response = self._query()
         self.assertIsNone(response.get("errors"))
         self.assertEqual(response["data"]["operatorShelter"]["additionalContacts"], [])
 
-    @override_flag(BA_ADMIN_ONLY_FIELDS_FLAG, active=True)
-    def test_additional_contacts_visible_when_flag_on(self) -> None:
+    def test_additional_contacts_visible_for_global_shelter_operator(self) -> None:
+        role_assign(
+            user=self.org_1_case_manager_1,
+            role=Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name),
+        )
+
         response = self._query()
 
         self.assertIsNone(response.get("errors"))

--- a/apps/betterangels-backend/shelters/tests/test_service_shelter.py
+++ b/apps/betterangels-backend/shelters/tests/test_service_shelter.py
@@ -151,9 +151,9 @@ class ShelterUpdateOrganizationImmutableTestCase(TestCase):
 class ShelterUpdateAdditionalContactsTestCase(ShelterServiceTestCase):
     """shelter_update applies full-replacement semantics to additional contacts.
 
-    Contacts are a BA-only field gated on the global tier (``can_globally``),
-    so the shared scoped operator is promoted to a Global Shelter Operator —
-    the service-level counterpart of the GraphQL gate tests.
+    Contacts are a BA-only field declared ``ACCESS_GLOBAL`` (checked with
+    ``can_model``), so the shared scoped operator is promoted to a Global
+    Shelter Operator — the service-level counterpart of the GraphQL gate tests.
     """
 
     def setUp(self) -> None:

--- a/apps/betterangels-backend/shelters/tests/test_service_shelter.py
+++ b/apps/betterangels-backend/shelters/tests/test_service_shelter.py
@@ -1,13 +1,13 @@
 from accounts.models import Role, User
 from accounts.role_manager import OrgRoleManager
-from accounts.services import grant_create
+from accounts.services import grant_create, role_assign
 from accounts.tests.baker_recipes import organization_recipe
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
 from django.test import TestCase
 from model_bakery import baker
 
-from shelters.groups import SHELTER_OPERATOR
+from shelters.groups import GLOBAL_SHELTER_OPERATOR_ROLE, SHELTER_OPERATOR
 from shelters.models import ContactInfo, Shelter
 from shelters.services.shelter import shelter_create, shelter_delete, shelter_update
 
@@ -149,11 +149,34 @@ class ShelterUpdateOrganizationImmutableTestCase(TestCase):
 
 
 class ShelterUpdateAdditionalContactsTestCase(ShelterServiceTestCase):
-    """shelter_update applies full-replacement semantics to additional contacts."""
+    """shelter_update applies full-replacement semantics to additional contacts.
+
+    Contacts are a BA-only field gated on the global tier (``can_globally``),
+    so the shared scoped operator is promoted to a Global Shelter Operator —
+    the service-level counterpart of the GraphQL gate tests.
+    """
 
     def setUp(self) -> None:
         super().setUp()
+        role_assign(user=self.user, role=Role.objects.get(name=GLOBAL_SHELTER_OPERATOR_ROLE.name))
         self.shelter = Shelter.objects.create(name="Contacts Shelter", organization=self.org)
+
+    def test_contacts_update_denied_without_global_perm(self) -> None:
+        """A scoped operator (CHANGE on the shelter, no global ContactInfo perms) is refused."""
+        scoped = baker.make(User)
+        self.org.users.add(scoped)
+        OrgRoleManager(self.org).add_roles(scoped, SHELTER_OPERATOR)
+
+        with self.assertRaises(PermissionDenied):
+            shelter_update(
+                user=scoped,
+                data={
+                    "id": self.shelter.pk,
+                    "additional_contacts": [{"contact_name": "Ada", "contact_number": "2125550100"}],
+                },
+            )
+
+        self.assertEqual(self.shelter.additional_contacts.count(), 0)
 
     def _update(self, contacts: list[dict]) -> Shelter:
         return shelter_update(

--- a/apps/betterangels-backend/shelters/types/outputs.py
+++ b/apps/betterangels-backend/shelters/types/outputs.py
@@ -11,13 +11,12 @@ from clients.types import ClientProfileType
 from common.enums import ImagePresetEnum
 from common.graphql.types import PhoneNumberScalar, TransformableImageType
 from common.images import build_img_url
-from common.services.feature_flags import flag_is_active
+from common.permissions.selectors import holds_globally
 from django.db.models import Prefetch, QuerySet
 from strawberry import ID, Info, auto
 from strawberry_django.auth.utils import get_current_user
 
 from shelters import models
-from shelters.constants import BA_ADMIN_ONLY_FIELDS_FLAG
 from shelters.enums import (
     BedStatusChoices,
     BedTypeChoices,
@@ -285,7 +284,9 @@ class ShelterType(ShelterTypeMixin):
 class OperatorShelterType(ShelterTypeMixin):
     @strawberry_django.field(prefetch_related=["additional_contacts"])
     def additional_contacts(self, root: models.Shelter, info: Info) -> List[ShelterContactInfoType]:
-        if not flag_is_active(info, BA_ADMIN_ONLY_FIELDS_FLAG):
+        """BA-only contacts — global-tier gate: only the Global Shelter Operator sees them (ADR 0001 §2.4)."""
+        user = cast(User, get_current_user(info))
+        if not user or not user.is_authenticated or not holds_globally(user, models.ContactInfo.perms.VIEW):
             return []
         return cast(List[ShelterContactInfoType], list(root.additional_contacts.all()))
 

--- a/apps/betterangels-backend/shelters/types/outputs.py
+++ b/apps/betterangels-backend/shelters/types/outputs.py
@@ -11,7 +11,7 @@ from clients.types import ClientProfileType
 from common.enums import ImagePresetEnum
 from common.graphql.types import PhoneNumberScalar, TransformableImageType
 from common.images import build_img_url
-from common.permissions.selectors import can_globally
+from common.permissions.selectors import visible
 from django.db.models import Prefetch, QuerySet
 from strawberry import ID, Info, auto
 from strawberry_django.auth.utils import get_current_user
@@ -284,10 +284,18 @@ class ShelterType(ShelterTypeMixin):
 class OperatorShelterType(ShelterTypeMixin):
     @strawberry_django.field(prefetch_related=["additional_contacts"])
     def additional_contacts(self, root: models.Shelter, info: Info) -> List[ShelterContactInfoType]:
-        """BA-only contacts — global-tier gate: only the Global Shelter Operator sees them (ADR 0001 §2.4)."""
+        """BA-only contacts — declared ``ACCESS_GLOBAL`` class: the rows themselves answer.
+
+        :func:`visible` reads ContactInfo's access class, so the Global Shelter
+        Operator sees the rows and every org-scoped holder sees none — no
+        call-site tier check (ADR 0001 §2.4 / ADR 0004 sketch).
+        """
         user = cast(User, get_current_user(info))
-        if user and user.is_authenticated and can_globally(user, models.ContactInfo.perms.VIEW):
-            return cast(List[ShelterContactInfoType], list(root.additional_contacts.all()))
+        if user and user.is_authenticated:
+            return cast(
+                List[ShelterContactInfoType],
+                list(visible(root.additional_contacts.all(), user, models.ContactInfo.perms.VIEW)),
+            )
         return []
 
     @classmethod

--- a/apps/betterangels-backend/shelters/types/outputs.py
+++ b/apps/betterangels-backend/shelters/types/outputs.py
@@ -286,9 +286,9 @@ class OperatorShelterType(ShelterTypeMixin):
     def additional_contacts(self, root: models.Shelter, info: Info) -> List[ShelterContactInfoType]:
         """BA-only contacts — global-tier gate: only the Global Shelter Operator sees them (ADR 0001 §2.4)."""
         user = cast(User, get_current_user(info))
-        if not user or not user.is_authenticated or not holds_globally(user, models.ContactInfo.perms.VIEW):
-            return []
-        return cast(List[ShelterContactInfoType], list(root.additional_contacts.all()))
+        if user and user.is_authenticated and holds_globally(user, models.ContactInfo.perms.VIEW):
+            return cast(List[ShelterContactInfoType], list(root.additional_contacts.all()))
+        return []
 
     @classmethod
     def get_queryset(cls, queryset: QuerySet, info: Info) -> QuerySet[models.Shelter]:

--- a/apps/betterangels-backend/shelters/types/outputs.py
+++ b/apps/betterangels-backend/shelters/types/outputs.py
@@ -11,7 +11,7 @@ from clients.types import ClientProfileType
 from common.enums import ImagePresetEnum
 from common.graphql.types import PhoneNumberScalar, TransformableImageType
 from common.images import build_img_url
-from common.permissions.selectors import holds_globally
+from common.permissions.selectors import can_globally
 from django.db.models import Prefetch, QuerySet
 from strawberry import ID, Info, auto
 from strawberry_django.auth.utils import get_current_user
@@ -286,7 +286,7 @@ class OperatorShelterType(ShelterTypeMixin):
     def additional_contacts(self, root: models.Shelter, info: Info) -> List[ShelterContactInfoType]:
         """BA-only contacts — global-tier gate: only the Global Shelter Operator sees them (ADR 0001 §2.4)."""
         user = cast(User, get_current_user(info))
-        if user and user.is_authenticated and holds_globally(user, models.ContactInfo.perms.VIEW):
+        if user and user.is_authenticated and can_globally(user, models.ContactInfo.perms.VIEW):
             return cast(List[ShelterContactInfoType], list(root.additional_contacts.all()))
         return []
 

--- a/docs/adr/0004-access-classes.md
+++ b/docs/adr/0004-access-classes.md
@@ -1,0 +1,134 @@
+# ADR 0004 — Access classes for scoped models
+
+**Status:** Proposed — sketch. Reference implementation: draft PR #2463
+(stacked on #2461, which it converts end-to-end). Vocabulary folds RFC 0002's
+write tiers (#2447) when the stacks meet.
+**Date:** 2026-09-11
+**Scope:** How authority is declared on org-scoped models and enforced; the
+single-slot replacement for `write_tier` / `access_class`; enforcement across
+definition, binding, and evaluation time.
+**Related:** ADR 0001 (grant model), RFC 0002 (read/write tiers, #2447),
+RFC 0003 (#2462 notes cutover), [PR #2461] (ContactInfo gates),
+[PR #2463] (this sketch).
+
+## Problem
+
+Model authority is currently described by three overlapping, ad-hoc mechanisms,
+plus call-site predicates that re-state rules wherever they are used:
+
+- `org_via` — **reach**: which organization(s) a row lives in (ADR 0001).
+- `write_tier` — RFC 0002 / #2447: `WRITE_SHARED` / `WRITE_OBJECT` — which
+  *arm* computes the write filter.
+- `holds_globally` → `can_globally` (#2461) — a **call-site predicate**: "does
+  the user hold this perm at the global tier?" Because it is re-stated per
+  surface, a missed call site **fails open**; #2461 needed a manual exposure
+  audit to catch the risk.
+
+Every new shape (BA-only fields, shared writes, object-arm writes,
+parent-gated children) has been adding a new attribute or a new call-site
+check. That is an open-ended keyword surface, and its failure mode is silent.
+
+## Decision
+
+One **authority slot** per model, next to reach:
+
+```python
+class ContactInfo(OrgScoped):
+    org_via = ("shelter",)                     # reach (unchanged)
+    access = Access(read=ACCESS_GLOBAL,        # authority classes
+                    write=ACCESS_GLOBAL)
+```
+
+- **Reach stays separate** (`org_via`): where rows attach (object graph, grant
+  scope, org filters). Reach alone never grants authority.
+- **`Access(read, write)`** is a single declaration; values are a closed set:
+  - `None` — derive today's behavior: reads by reach (org-scoped rows;
+    platform-shared all-or-none), writes by the org arm.
+  - `ACCESS_GLOBAL` — only the global tier passes; org scopes never widen it.
+  - Folding #2447: `write` additionally takes `WRITE_SHARED` and
+    `WRITE_OBJECT`; `PARENT` (authority delegated to an ancestor row — e.g.
+    note-gated uploads) is reserved for the slice that needs it.
+- **Selectors are the single enforcement surface**: `visible`, `writable`,
+  `can_obj`, and the rowless `can_model`. Surfaces and services ask selectors;
+  no call-site tier predicates in product code.
+- **Direction** resolves by codename convention today (`view_*` → `read`;
+  everything else → `write`), in one helper. If custom codenames appear, the
+  direction moves onto `PermissionSet` — never into callers.
+- **Delete the interim names** when folding (`write_tier`, `access_class`);
+  no aliases.
+
+## Enforcement layers (why one is not enough)
+
+The class is enforced at **three** times; each catches what the others cannot:
+
+1. **Definition time — E-codes.** "Scoped `RoleDef`s may not carry abilities
+   on `ACCESS_GLOBAL` models" and "`access` values must be legal" (a typo is an
+   error, not a silent fall back to org rules). This mechanizes the audit
+   #2461 performed by hand.
+2. **Binding time — admittance.** Role seeding (`sync_roles`) and
+   `grant_create` validate the same rule: *a scoped binding can never acquire a
+   GLOBAL-class ability.* Grants are the only way authority enters the system;
+   constraining admittance means the grant table itself can never hold an
+   ability the model forbids. (This is the "seed the grant table with access
+   ability" reading — with the model's declaration filtering what can be
+   seeded.)
+3. **Evaluation time — selectors branch on the declaration.** Kept even when
+   (1) and (2) hold: checks are dev-time and drift happens (manual rows,
+   migrations, future code paths); evaluation is the only layer that fails
+   closed regardless. It is also the only layer that can express **shape
+   classes** — `SHARED`/`OBJECT`/`PARENT` change *how* the filter computes,
+   not just who may pass.
+
+**Rejected alternatives.**
+
+- *Binding-time only* (validate at seeding / DB constraint, class-free
+  evaluator): fails open on drift, and cannot express shape classes.
+- *Materialized per-grant ability rows* (denormalize each grant's effective
+  abilities at creation): reintroduces the guardian era's sync disease that
+  ADR 0001 §2.1 removed — derived rows re-seeded on every template or class
+  change, with staleness windows. Evaluation already caches computed scopes
+  per request (`_scope_cache`, `_global_permissions`); persistent copies buy
+  little and rot.
+
+## Consequences
+
+- One fact, one place: "who may touch these rows" is declared once, enforced
+  everywhere via selectors, and validated at role-definition and
+  grant-creation time.
+- New model shapes compose as *enum values + declaration slots*; no new
+  keywords, and `explain` can render the declared chain.
+- Costs: indirection (reading authority means reading the declaration), and
+  the validation layers must be extended whenever a class value is added.
+- `can_model`'s fallback for non-GLOBAL models keeps today's `can_anywhere`
+  semantics until the matrix defines per-class rowless rules; consumers of
+  non-GLOBAL classes must wait for that decision (see Open questions).
+
+## Rollout
+
+1. **This PR (#2463)** — read-side seed: `Access` slot, `ACCESS_GLOBAL`,
+   `can_model`, the `visible` branch; converts #2461's ContactInfo gates
+   (`shelter_update` service + the `additional_contacts` resolver) to the
+   declaration. Behavior-preserving: same refusal, same message as #2461's
+   service; two GraphQL assertions stranded by `c418bffb3`'s message change
+   are realigned in this PR.
+2. **Fold #2447** — `WRITE_SHARED` / `WRITE_OBJECT` become `Access.write`
+   values; `writable()` branches read the slot; `write_tier` is deleted.
+3. **Validation** — add the layer-1 E-codes; extend the gating tripwire so
+   authority attributes cannot sprawl; one styleguide rule: new authority
+   rules land as enum values, not attributes.
+4. **Mixin rename** — `OrgScoped` → `ScopedResource` (mechanical, separate
+   PR; `org_via` keeps its name as the reach attribute).
+
+## Open questions
+
+- **Totality**: should every model elect its classes explicitly (auditable
+  election), or keep derive-from-reach defaults (current)? Recommend defaults
+  plus E-code-derived constraints; revisit as the class set grows.
+- **Per-permission classes**: `Access` is per-direction. If a real case needs
+  per-perm granularity (VIEW org-wide / CHANGE global), grow the slot — do not
+  add a second attribute.
+- **Explicit direction**: move the `view_*`-prefix inference onto
+  `PermissionSet` when custom codenames first appear.
+- **`can_model` fallback**: define per-class rowless semantics before any
+  non-GLOBAL class gains consumers; today's fallback is deliberately permissive
+  and footgun-shaped.


### PR DESCRIPTION
**Sketch / discussion — stacked on #2461 (`SDB-277/flag-to-perms`); not for merge as-is.**

Proposes **access classes**: authority declared once on the model, enforced by the selectors, instead of tier checks at each call site. This branch is the read-side reference implementation for ADR 0004 (draft to follow).

## Why
#2461 gates `ContactInfo` correctly — but via call-site checks (`can_globally`). Correct semantics, wrong long-term home: every new resolver/filter must re-state the rule, and a missed call site fails open. The resource should declare its authority class once; the selectors answer everywhere.

## What this sketch does
- `OrgScoped.access = Access(read=..., write=...)` — one declaration slot, per direction (the write side folds #2447's write tiers into this same slot when the stacks meet).
- `ACCESS_GLOBAL` — only the global tier passes; org scopes never widen it.
- `visible()` reads `access.read`: the row filter itself carries the class.
- `can_model()` — new rowless gate for payload fields (nested creates / parent mutations); resolves `access.read` for `view_*` perms, `access.write` otherwise.
- `ContactInfo` declares `access = Access(read=ACCESS_GLOBAL, write=ACCESS_GLOBAL)`; the two #2461 surfaces route through the selectors — no call-site tier checks left.
- `AccessClassTestCase`: a global-tier user passes; a scoped holder of the *same* permission is refused for the row filter, the single-row check, and the rowless gate.

## Semantics
Behavior-preserving vs #2461: this branch is rebased onto your latest (`can_globally` rename) and keeps it — function, docstring, and tests intact; the diff is additive only. `can_globally` remains available for ad-hoc checks.

## Next (ADR 0004)
- Fold #2447's write tiers into the same slot: `Access.write` ∈ {None = org-arm, SHARED, OBJECT, GLOBAL, PARENT}.
- Derived E-code: scoped roles may not carry perms on GLOBAL-class models (mechanizes #2461's audit finding).
- Guardrails: styleguide rule + tripwire so authority attributes can't sprawl again.

Stacked on #2461; when it merges this retargets to main. If you'd rather fold the two call-site conversions into #2461 directly, this diff is the preview — same behavior, tests unchanged.

## Summary by Sourcery

Centralize ContactInfo authority in model-declared access classes and enforce its global-only policy consistently through permission selectors.

New Features:
- Add model-level read and write access classes with a global-only authority option.
- Add selector support for model-aware rowless authorization and global-tier checks.

Bug Fixes:
- Ensure scoped grants cannot access or modify ContactInfo data reserved for global-tier users.
- Replace feature-flag-based additional-contact authorization with selector-enforced permissions.

Enhancements:
- Declare ContactInfo authority on the model and route its query, object, and mutation checks through permission selectors.

Documentation:
- Document the proposed access-class model and its planned enforcement and rollout in ADR 0004.

Tests:
- Add coverage for global-only access across queryset, object, rowless, GraphQL, and service authorization paths.

Chores:
- Remove the obsolete additional-contact feature flag and related call-site handling.