### PR TITLE
fix(perm): make Role provisioning resilient to auth.Group name collisions

### DIFF
--- a/apps/betterangels-backend/accounts/services.py
+++ b/apps/betterangels-backend/accounts/services.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from common.org_types import REGISTRY
 from common.permissions.config import RoleDef, TemplateConfig
+from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from organizations.backends import invitation_backend
@@ -569,16 +570,117 @@ def _all_role_defs() -> tuple[RoleDef, ...]:
     return (*ROLES, *ORG_ADMIN_ROLES, CASEWORKER_ROLE)
 
 
+def _rename_legacy_group(group: Group) -> str:
+    """Rename a staffed legacy ``auth.Group`` out of a ``RoleDef``'s name.
+
+    ``auth.Group.name`` is unique and at most 150 characters, so the candidate
+    is ``"<name> (legacy group <pk>)"`` — pk-suffixed, hence stable across
+    runs — with a ``-<n>`` counter for the pathological case in which even that
+    candidate is taken.  The renamed row keeps its pk, members and permissions;
+    only the name moves.  Returns the new name.
+    """
+    max_length: int = Group._meta.get_field("name").max_length or 150
+    suffix = f" (legacy group {group.pk})"
+    candidate = f"{group.name[: max(max_length - len(suffix), 0)]}{suffix}"
+    n = 1
+    while Group.objects.filter(name=candidate).exclude(pk=group.pk).exists():
+        marker = f"-{n}"
+        candidate = f"{group.name[: max(max_length - len(suffix) - len(marker), 0)]}{suffix}{marker}"
+        n += 1
+    group.name = candidate
+    group.save(update_fields=["name"])
+    return candidate
+
+
+def _adopt_bare_group_as_role(group: Group, role_def: RoleDef) -> Role:
+    """Write the MTI ``accounts_role`` child row for an existing bare ``Group``.
+
+    ``Role(group_ptr=group, ...)`` keeps the group's primary key: the pk is set,
+    so Django updates the existing ``auth_group`` row (the name is written
+    unchanged) and inserts only the child — the group *becomes* the role,
+    keeping its pk, name and any references (admin log rows, guardian object
+    permissions) instead of being orphaned or duplicated.  ``name`` is passed
+    explicitly: it is a concrete ``Group`` field, and the parent update would
+    otherwise blank it.
+    """
+    role = Role(group_ptr=group, name=group.name, is_global=role_def.is_global)
+    role.save()
+    return role
+
+
+def _provision_role(role_def: RoleDef) -> tuple[Role, bool]:
+    """Return ``(role, created)`` for *role_def*, resolving name collisions.
+
+    ``Role`` and ``PermissionGroup`` are MTI subclasses of ``auth.Group``, so
+    all three share the ``auth_group`` name namespace.  A plain
+    ``get_or_create`` inserts the parent row first, which means a legacy *bare*
+    ``Group`` holding a ``RoleDef``'s name — no ``Role``/``PermissionGroup``
+    child, so it grants no org-scoped authority — aborts the whole
+    ``sync_roles`` transaction on ``auth_group_name_key`` (2026-09-11 incident:
+    a bare ``Caseworker`` group rolled back Role provisioning, every grant
+    backfill and the phantom retire, denying reports/teams to legacy holders).
+
+    The row actually holding the name decides the policy:
+
+    * an existing ``Role`` is returned as-is (no behavior change);
+    * a **memberless** bare ``Group`` is adopted — see
+      :func:`_adopt_bare_group_as_role`;
+    * a bare ``Group`` **with members** cannot be adopted: a scoped ``Role`` in
+      ``user.groups`` is a ``permissions.E001`` error, so it is renamed (see
+      :func:`_rename_legacy_group`) and a fresh ``Role`` created.  The members
+      stay on the renamed group, untouched;
+    * a ``PermissionGroup`` is never touched — its names are generated
+      (``"<organization> [<pk>] · <template>"``), so an exact match is a
+      hand-made row a human must resolve; the error names it.
+
+    Idempotent: after the first run the name is held by a ``Role``, so later
+    runs take the first branch and touch nothing.
+    """
+    role = Role.objects.filter(name=role_def.name).first()
+    if role is not None:
+        return role, False
+
+    group = Group.objects.filter(name=role_def.name).first()
+    if group is None:
+        return Role.objects.create(name=role_def.name), True
+
+    if PermissionGroup.objects.filter(pk=group.pk).exists():
+        raise RuntimeError(
+            f"auth.Group name {role_def.name!r} is held by a PermissionGroup.  Roles are "
+            "code-owned and never adopt or rename one; PermissionGroup names are generated "
+            '("<organization> [<pk>] · <template>"), so this is a hand-made row — rename it '
+            "before roles can be provisioned."
+        )
+
+    if group.user_set.exists():
+        renamed = _rename_legacy_group(group)
+        logger.warning(
+            "Renamed legacy group %r to %r before provisioning Role %r (a group with "
+            "members cannot be adopted as a scoped Role — permissions.E001)",
+            role_def.name,
+            renamed,
+            role_def.name,
+        )
+        return Role.objects.create(name=role_def.name), True
+
+    adopted = _adopt_bare_group_as_role(group, role_def)
+    logger.info("Adopted legacy group %r as Role %s", role_def.name, role_def.name)
+    return adopted, True
+
+
 def sync_roles() -> None:
     """Create or refresh the code-owned ``Role`` rows (ADR 0001 §2.2).
 
     One row per :class:`~common.permissions.config.RoleDef` — global roles are
-    provisioned once, never per organization.  Idempotent: get_or_create each
-    ``Role``, then reconcile ``permissions`` and ``is_global`` from the RoleDef.
+    provisioned once, never per organization.  Idempotent: provision each
+    ``Role`` (a pre-existing ``auth.Group`` holding the name is resolved by
+    :func:`_provision_role` — ``Role`` is an MTI subclass of ``Group``, so the
+    unique name is shared with every ``auth.Group`` row), then reconcile
+    ``permissions`` and ``is_global`` from the RoleDef.
     """
     with transaction.atomic():
         for role_def in _all_role_defs():
-            role, created = Role.objects.get_or_create(name=role_def.name)
+            role, created = _provision_role(role_def)
             wanted = set(_resolve_permissions(role_def.permissions))
             _raise_on_phantom_role_permissions(role_def, wanted)
             perms_changed = {p.pk for p in role.permissions.all()} != wanted

--- a/apps/betterangels-backend/accounts/tests/test_roles.py
+++ b/apps/betterangels-backend/accounts/tests/test_roles.py
@@ -1,6 +1,7 @@
 """Tests for Role provisioning and grant backfill (ADR 0001 §2.2, §4 phase 1)."""
 
 from accounts.models import Grant, PermissionGroup, PermissionGroupTemplate, Role, User
+from accounts.seed import _resolve_permissions
 from accounts.services import (
     _raise_on_phantom_role_permissions,
     backfill_caseworker_grants,
@@ -10,10 +11,14 @@ from accounts.services import (
     sync_roles,
 )
 from accounts.tests.baker_recipes import organization_recipe
-from common.permissions.checks import check_role_permissions_models_declare_org_scoping
+from common.permissions.checks import (
+    check_role_permissions_models_declare_org_scoping,
+    check_scoped_role_never_in_user_groups,
+)
 from common.permissions.config import RoleDef
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
 from django.test import TestCase
 from model_bakery import baker
 from notes.groups import CASEWORKER_ROLE
@@ -119,6 +124,112 @@ class SyncRolesTestCase(TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "no model class"):
             _raise_on_phantom_role_permissions(role_def, {phantom_perm.pk})
+
+
+class RoleNameCollisionTestCase(TestCase):
+    """A legacy bare ``auth.Group`` holding a ``RoleDef``'s name must not abort provisioning.
+
+    Regression for the 2026-09-11 production incident: ``Role`` and
+    ``PermissionGroup`` are MTI subclasses of ``auth.Group``, so they share the
+    unique ``auth_group.name``.  A pre-cutover leftover
+    ``Group(name="Caseworker")`` (no ``Role``/``PermissionGroup`` child, 0
+    members, 0 permissions) made ``Role.objects.get_or_create`` collide on
+    ``auth_group_name_key``; ``sync_roles`` is one transaction, so the rollback
+    skipped every Role, every grant backfill and the phantom retire for that
+    deploy — denying reports/teams to legacy ``PermissionGroup`` holders.
+    """
+
+    ROLE_NAME = CASEWORKER_ROLE.name
+
+    def setUp(self) -> None:
+        self.org = organization_recipe.make(preset_names=["outreach"], owner_roles=())
+        # Model the pre-provisioning DB: no Role for the name yet — a bare group
+        # holds it (any Role the test DB's post_migrate created is withdrawn).
+        Role.objects.filter(name=self.ROLE_NAME).delete()
+        self.bare_group = Group.objects.create(name=self.ROLE_NAME)
+
+    def _role(self) -> Role:
+        return Role.objects.get(name=self.ROLE_NAME)
+
+    def test_adopts_a_memberless_bare_group_as_the_role(self) -> None:
+        sync_roles()
+
+        role = self._role()
+        self.assertEqual(role.pk, self.bare_group.pk)  # the group itself became the role
+        self.assertEqual(Group.objects.filter(name=self.ROLE_NAME).count(), 1)
+        self.assertFalse(role.is_global)
+        self.assertEqual(
+            {p.pk for p in role.permissions.all()},
+            set(_resolve_permissions(CASEWORKER_ROLE.permissions)),
+        )
+
+    def test_adoption_is_idempotent(self) -> None:
+        sync_roles()
+        sync_roles()
+
+        self.assertEqual(Role.objects.filter(name=self.ROLE_NAME).count(), 1)
+        self.assertEqual(self._role().pk, self.bare_group.pk)
+
+    def test_adopted_role_backfills_grants(self) -> None:
+        permission_group = PermissionGroup.objects.get(organization=self.org, template__name=self.ROLE_NAME)
+        member = baker.make(User)
+        _add_legacy_membership(permission_group, member)
+
+        sync_roles()
+        backfill_caseworker_grants()
+
+        self.assertTrue(Grant.objects.filter(principal_user=member, role=self._role(), scope_org=self.org).exists())
+
+    def test_staffed_bare_group_is_renamed_instead_of_adopted(self) -> None:
+        member = baker.make(User)
+        member.groups.add(self.bare_group)
+
+        sync_roles()
+
+        role = self._role()
+        self.assertNotEqual(role.pk, self.bare_group.pk)
+        self.bare_group.refresh_from_db()
+        self.assertEqual(self.bare_group.name, f"{self.ROLE_NAME} (legacy group {self.bare_group.pk})")
+        # The membership moved nowhere: it stays on the renamed group…
+        self.assertTrue(member.groups.filter(pk=self.bare_group.pk).exists())
+        # …so no scoped Role sits in user.groups (permissions.E001).
+        self.assertEqual(check_scoped_role_never_in_user_groups(None), [])
+
+    def test_rename_candidate_that_is_also_taken_still_converges(self) -> None:
+        taken = Group.objects.create(name=f"{self.ROLE_NAME} (legacy group {self.bare_group.pk})")
+        member = baker.make(User)
+        member.groups.add(self.bare_group)
+
+        sync_roles()
+
+        self.bare_group.refresh_from_db()
+        self.assertEqual(self.bare_group.name, f"{self.ROLE_NAME} (legacy group {self.bare_group.pk})-1")
+        self.assertTrue(Group.objects.filter(pk=taken.pk).exists())
+        self.assertTrue(Role.objects.filter(name=self.ROLE_NAME).exists())
+
+    def test_permission_group_holding_the_name_raises_an_actionable_error(self) -> None:
+        self.bare_group.delete()  # free the name for the hand-made PermissionGroup
+        PermissionGroup.objects.filter(organization=self.org, template__name=self.ROLE_NAME).update(name=self.ROLE_NAME)
+
+        with self.assertRaisesMessage(RuntimeError, "held by a PermissionGroup"):
+            sync_roles()
+
+        # Never touched: the row survives, under the colliding name.
+        self.assertTrue(PermissionGroup.objects.filter(organization=self.org, name=self.ROLE_NAME).exists())
+
+    def test_migrate_completes_with_a_legacy_bare_group_present(self) -> None:
+        """The deploy path — ``manage.py migrate`` (post_migrate) runs the whole chain."""
+        permission_group = PermissionGroup.objects.get(organization=self.org, template__name=self.ROLE_NAME)
+        member = baker.make(User)
+        _add_legacy_membership(permission_group, member)
+
+        call_command("migrate", verbosity=0)
+
+        role = self._role()
+        self.assertEqual(role.pk, self.bare_group.pk)  # adopted, not orphaned
+        self.assertTrue(Grant.objects.filter(principal_user=member, role=role, scope_org=self.org).exists())
+        # Provisioning ran to completion, not only for the colliding RoleDef.
+        self.assertTrue(Role.objects.filter(name=ORG_ADMIN_ROLE.name).exists())
 
 
 class BackfillTestCase(TestCase):

--- a/docs/adr/0001-grant-based-authorization.md
+++ b/docs/adr/0001-grant-based-authorization.md
@@ -202,11 +202,28 @@ GLOBAL_SHELTER_OPERATOR = RoleDef(
 )
 ```
 
-A `sync_roles` command `get_or_create`s the `Role` rows and sets their permissions from
+A `sync_roles` command provisions the `Role` rows and sets their permissions from
 the `RoleDef`s (replacing `sync_group_permissions` for role-backed domains; legacy
 templates keep their own sync during transition). `is_global` is **code-owned** — the
 admin may not flip it (see E002). Invite/welcome email metadata lives on the `RoleDef`,
 not on a per-org row.
+
+**A role name is an `auth.Group` name, and that namespace is shared.** `Role` and
+`PermissionGroup` are MTI subclasses of `auth.Group`, so all three draw from the same
+unique `auth_group.name`. A plain `get_or_create` therefore inserts the parent row
+first, and a *bare* `Group` carrying a RoleDef's name (no `Role`/`PermissionGroup`
+child — a pre-cutover leftover) aborts the whole provisioning transaction on
+`auth_group_name_key`, rolling back every Role, every grant backfill and the phantom
+retire for that deploy (2026-09-11 incident: a bare `Caseworker` group cost one
+deploy's entire conversion). Provisioning resolves the name-holder deterministically:
+an existing `Role` is reused; a **memberless** bare `Group` is adopted as the Role's
+group row (the `accounts_role` child is written with the same pk, keeping the row's
+identity); a bare `Group` **with members** is renamed to `"<name> (legacy group <pk>)"`
+and a fresh `Role` created — a scoped `Role` must never sit in `user.groups` (E001), so
+those memberships stay on the renamed group; a `PermissionGroup` is never adopted or
+renamed — an exact match there is a hand-made row and fails with an actionable error.
+Idempotent: once the name is held by the `Role`, later runs take the reuse branch and
+touch nothing.
 
 **Global roles compose and may be narrower than full CRUD.** Authority at the global
 tier is the per-permission union of every global `Role` a user holds in `user.groups`
@@ -717,7 +734,7 @@ authorization, which is the service→selector pattern the guide prescribes.
 | Phase | Ships |
 |---|---|
 | **0** | This ADR; §7 decision log (items resolved; §7.2 open) |
-| **1** | `Role` + `Grant` models, constraints, checks, provisioning + backfill. **The backfill converts only shelter roles** — every other domain's `PermissionGroups` are untouched until their cutover. **Nothing reads it.** Provisioning (`sync_roles`) and backfill (`backfill_shelter_grants` / `backfill_global_role_members`) are idempotent `post_migrate` syncs + a `manage.py sync_roles` command, per the repo's "replaces RunPython data migrations" convention — not RunPython migrations. **Transition caveat: the phase-1 backfill is add-only and runs only at `migrate`** — a membership removed after the last backfill leaves a stale `Grant`, and a brand-new org gets none until the next migrate. Phase 2's dual-write must therefore treat backfilled rows as a bootstrapping snapshot: write `Grant`s synchronously on membership change (assign/invite/remove, org creation) and make the `reconcile` command *revoke* stale rows, not just backfill. |
+| **1** | `Role` + `Grant` models, constraints, checks, provisioning + backfill. **The backfill converts only shelter roles** — every other domain's `PermissionGroups` are untouched until their cutover. **Nothing reads it.** Provisioning (`sync_roles`) and backfill (`backfill_shelter_grants` / `backfill_global_role_members`) are idempotent `post_migrate` syncs + a `manage.py sync_roles` command, per the repo's "replaces RunPython data migrations" convention — not RunPython migrations. (`sync_roles` is one transaction: any failure inside it — e.g. an `auth_group.name` collision — skips the whole conversion chain that follows; name-holders are resolved per §2.2, so leftover `Group` rows cannot abort it.) **Transition caveat: the phase-1 backfill is add-only and runs only at `migrate`** — a membership removed after the last backfill leaves a stale `Grant`, and a brand-new org gets none until the next migrate. Phase 2's dual-write must therefore treat backfilled rows as a bootstrapping snapshot: write `Grant`s synchronously on membership change (assign/invite/remove, org creation) and make the `reconcile` command *revoke* stale rows, not just backfill. |
 | **2** | `scopes()`/`visible()`/`can()` wired to **shelter** selectors/mutations (global + user + delegation arms); mutation-surface convention; org→org delegation admin inline; assign/invite service dual-writes `Grant` (authoritative for shelters) + legacy `PermissionGroup` (authoritative for everything else) with a `reconcile` command + test. **Covers org creation and owner-role seeding** (finding F22) — new orgs born during transition get `Grant`s for shelter roles, not legacy groups. |
 | **3** | Frontend (both apps): grants-based FINITE org list (never every org — no "All" mode), header optional, effective per-org permission entries, `currentUser.permissions` global list as the shared contract (finding F24). |
 | **4** | Clients/notes cutover: wire the object arm + whitelist + cleanup signals; client-sharing data edge; **notes/guardian migration per §5 / clients per §5.1**; guardian teardown per domain. |


### PR DESCRIPTION
## Incident

The 2026-09-11 deploy's `post_migrate` conversion aborted:

```
IntegrityError: duplicate key value violates unique constraint "auth_group_name_key"
DETAIL: Key (name)=(Caseworker) already exists.
```

`Role` and `PermissionGroup` are MTI subclasses of `auth.Group`, so all three share the unique `auth_group.name`. `sync_roles()` used `Role.objects.get_or_create(name=...)`, which inserts the shared parent row first — a legacy **bare** `Group(name="Caseworker")` (no `Role`/`PermissionGroup` child, 0 members, 0 permissions) collided there. Because `sync_roles()` runs in one transaction, the rollback skipped every Role, every grant backfill (org-admin/caseworker/shelter) and the phantom retire — zero Grants, reports/teams denied to legacy `PermissionGroup` holders. Prod was remediated by hand (rename + re-run migrate; 152 Grants backfilled).

This is not a one-off row: the shared dev DB (`db:5432`) still holds a bare `Group(pk=1, name="Caseworker")`, so its next `manage.py migrate` fails exactly the same way, and any environment carrying such a leftover hits it too.

## Fix

`accounts/services.py` — `_provision_role()` resolves the row holding a `RoleDef`'s name **before** creating anything:

| name holder | policy |
| --- | --- |
| existing `Role` | reused (unchanged behavior) |
| **memberless** bare `Group` | **adopted** — `accounts_role` child written with the same pk (`Role(group_ptr=group, ...)`): the group becomes the role and keeps its pk/name/references (admin log, guardian perms) instead of being orphaned or duplicated |
| bare `Group` with members | **renamed** to `"<name> (legacy group <pk>)"` (deterministic; `-n` counter if taken) then a fresh `Role` — memberships stay on the renamed group, since a scoped `Role` in `user.groups` is a `permissions.E001` error and adoption is not an option |
| `PermissionGroup` | **never touched** — names are generated (`"<org> [<pk>] · <role>"`), so an exact match is hand-made data; raises an actionable error instead of a raw `IntegrityError` |

Idempotent: once a `Role` holds the name, later runs reuse it and touch nothing. No behavior change for already-converted DBs; the phantom-permission guard, atomic sync and reconcile behavior are untouched.

## Tests — `accounts/tests/test_roles.py::RoleNameCollisionTestCase`

- memberless bare group → adopted in place; Role carries the RoleDef's permissions; exactly one group owns the name
- re-run → idempotent
- adopted Role → caseworker grant backfills (org + member fixture)
- staffed bare group → renamed, membership intact, `permissions.E001` clean
- rename candidate already taken → `-1` variant converges
- `PermissionGroup` name collision → actionable `RuntimeError`, row untouched
- **acceptance**: `call_command("migrate")` (post_migrate) with the legacy bare group present completes, adopts it and backfills the grant

Validation: new suite 7/7; `accounts/tests` + teams/reports grant-authorization suites **369 passed**. Full backend suite running locally / CI.

## Docs

ADR 0001 §2.2 documents the shared `auth.Group` name namespace and the resolution policy; §4 phase 1 notes `sync_roles` is a single transaction (a failure there skips the whole conversion chain) and that name-holders are now resolved.

Fixes the root cause of the 2026-09-11 reports/teams outage (the data-side remediation is already live).

## Summary by Sourcery

Make Role provisioning safely resolve legacy auth.Group name collisions so migrations and authorization backfills complete successfully.

Bug Fixes:
- Make role provisioning resilient to collisions with legacy bare auth groups, preventing migration failures and allowing subsequent grant backfills to complete.

Enhancements:
- Adopt memberless legacy groups in place, rename staffed legacy groups while preserving memberships, and report actionable errors for PermissionGroup collisions.
- Document the shared auth.Group name namespace and deterministic collision-resolution policy.

Documentation:
- Document the role name collision policy and its transactional provisioning implications in ADR 0001.

Tests:
- Add regression and migration acceptance coverage for adoption, idempotency, staffed-group renaming, conflicting rename candidates, PermissionGroup collisions, and grant backfills.